### PR TITLE
feat: provision remote observability environments

### DIFF
--- a/.agents/skills/technical-writing/SKILL.md
+++ b/.agents/skills/technical-writing/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: technical-writing
+description: "Layered technical-writing standard: Diátaxis structure, Google developer style sentences, STE instruction rules, Global English syntax. Use for /technical-writing or when writing or reviewing docs, RFCs, readmes, PR descriptions, or commit messages."
+---
+
+# Technical writing
+
+The goal is writing a tired engineer understands on the first read. Four layers get you there, one question each: what kind of document is this, how do sentences address the reader, how much does each sentence carry, and can any sentence be read two ways. Apply all four.
+
+Three rules sit above the layers:
+
+- **Cut every word that does no work.** If the sentence survives without a word, the word goes. "In order to" is "to". "It is important to note that" is nothing.
+- **Use the short, everyday word.** "Use", not "utilize". "Help", not "facilitate". "Do", not "perform". A long word has to buy its length with precision.
+- **When a rule makes a sentence worse, fix the sentence another way or leave it alone.** The rules serve the reader. A sentence that follows every rule and sounds like a machine wrote it has failed.
+
+The codebase is the word list. Write the real symbol, file, flag, or command name, not a synonym or a description of it.
+
+Don't invent jargon. Use the words a developer would say out loud: "move", "delete", "a budget that only decreases", not "evacuate", "ratchet", or "endgame". A named pattern is fine when the doc says what it means the first time. Add new offenders to `unslop`'s abstract-metaphor rule with their replacement.
+
+## Vary the rhythm
+
+The layers decide what a document says and how much each sentence carries. A doc can obey all of them and still read machine-written: every sentence clipped short, no view anywhere, nothing specific.
+
+- Mix sentence lengths on purpose. Short sentences land a point. Longer ones that take their time carry a fact with its condition or consequence.
+- One thought per sentence does not mean one length per sentence. Split the sentence that carries two thoughts. Keep the long sentence that carries one.
+- Have a view where the mode allows it. Explanation weighs trade-offs, so say what you make of them instead of listing pros and cons. Reference stays dry.
+- Be specific over sterile. Not "schema changes can cause issues" but "a column rename fails the build".
+
+## Pick the mode first (Diátaxis)
+
+One document, one mode. Two questions pick it: does the content inform action (doing) or understanding (thinking), and does it serve learning or work?
+
+- Action + learning: **tutorial**.
+- Action + work: **how-to**.
+- Understanding + work: **reference**.
+- Understanding + learning: **explanation**.
+
+Use the compass on a whole document or on one sentence. Reach for it whenever you feel unsure what you are writing. Gut feel is often wrong here.
+
+**Tutorial: learning by doing.** You are the teacher. The learner's success is your job, not theirs. Open by saying what the learner will build, not what they will "learn". Every step produces a visible result, early and often. Tell them what they should see: the expected output, the prompt change, the log line. Cut explanation to one clause and a link. Teaching pauses break the lesson. Stay concrete. Write as "we", in commands: "First, do x. Now, do y."
+
+**How-to: steps to a goal.** Solve a problem a person has, not an operation the machine can perform. Assume competence. Skip teaching. Action only: no digressions, no background, no completeness for its own sake. Link those instead. Allow forks and judgment: "If you want x, do y." Name the guide by the task: "How to calibrate the radar array", not "Radar array calibration".
+
+**Reference: facts for lookup.** Describe. Only describe. No instruction, no persuasion, no opinion. Be dry, complete, and sure: state facts, options, limits, and errors with no hedging. Mirror the structure of the thing described, so code and docs can be navigated together. Put material where readers expect it. Generate from code where possible, so it stays true.
+
+**Explanation: understanding and why.** One bounded topic, readable away from the product. Each title should tolerate an implicit "About..." in front. Anchor on a real why question. Give context: design decisions, history, constraints, alternatives. Opinion is allowed here and nowhere else.
+
+Don't mix modes: no reference tables inside a tutorial, no tutorial hand-holding inside reference, no arguing inside a how-to. Split and link instead.
+
+Source: diataxis.fr, fetched 2026-07-18.
+
+## Write sentences to the reader (Google developer style)
+
+- Talk to the reader as "you", in the present tense. "Will" only for things that genuinely happen later.
+- Say who does what: "the compiler checks", not "is checked". Passive is fine only when the actor is unknown or beside the point.
+- Write instructions as commands: "Click Submit." State facts plainly. Never "should be done".
+- Put the condition before the instruction: "To delete the document, click Delete." The reader skips what does not apply.
+- Put the common case first. Exceptions after.
+- Sound like a knowledgeable friend. No buzzwords, no figurative language, no "please" in instructions, and never "simply", "easy", or "quickly" in a procedure. If it were simple, the reader would not be here.
+- Don't pre-announce ("we will soon support...") and don't start consecutive sentences with the same phrase.
+- Read the awkward sentence aloud. If it stays awkward, rewrite it.
+- Link with words that say where the link goes: the page title or a short description. Never "click here". Prefer a sentence of context on the page over a link off it.
+- Headings carry the point, not just the topic ("Pick the mode first", not "Modes"). Sentence case. A task heading is a bare verb phrase ("Create an instance"). A concept heading is a noun phrase. One h1 per page, no skipped levels.
+- Numbered lists for sequences, bullets for everything else. Introduce a list with a complete sentence. Keep items parallel.
+- Code goes in code font. UI elements go in bold. Use serial commas. Drop "etc." and say up front that a list is partial.
+
+Source: developers.google.com/style, fetched 2026-07-18.
+
+## Make statements load one at a time (STE rules)
+
+- One instruction per sentence. One thought per sentence everywhere else.
+- Split instructions longer than about 20 words and other sentences longer than about 25.
+- Put the warning or condition before the step it guards: "If hot oil touches your skin, injuries can occur."
+- Keep "the" and "a": "Remove backup file" reads two ways. "Remove the backup file" reads one.
+- Give each word one meaning and one job, then keep it. If "check" means inspect, don't also use it for restrain.
+- Pick one word per action and stick to it: "start", not "start" here and "initiate" there.
+- Write procedures as direct commands, never as narration and never in the passive: "Install the component", not "the component must be installed".
+- Avoid "-ing" words where you can. They take too many grammatical jobs and breed misreadings.
+
+Source: asd-ste100.org (Issue 9, 2025), fetched 2026-07-18. The numbered rules and dictionary live in the spec PDF. The principles above are the transferable core.
+
+## Leave no sentence open to two readings (Global English)
+
+- Keep words like "only" and "not" next to the word they change: "only fails on growth" and "fails only on growth" say different things.
+- Break up long noun strings: "the proto import budget check script" becomes "the script that checks the proto-import budget".
+- Make every "it", "they", and "this" point at one obvious thing. Repeat the noun when in doubt. Never use "this" or "which" to point at a whole clause.
+- Don't drop verbs: "Phase 1 moves the converters and Phase 2 the runtime" leaves Phase 2 without one. Give it one.
+- Keep the small words that show structure. "Ensure that the switch is off" keeps "that" because it makes the sentence parse one way. Never trade clarity for word count.
+- Repeat the article in a series when it prevents a misread: "the client and the host", not "the client and host", when they are two things.
+- Say which parts "and" or "or" joins when a sentence can group two ways. "Both...and", "either...or", and "if...then" are free disambiguators.
+- Use periods, not semicolons. Replace an em dash with a new sentence.
+- Make text in parentheses a full grammatical unit or its own sentence. Never form plurals with "(s)".
+- No slashes: write "a, b, or both" instead of "a/b" or "and/or".
+- Call each thing by one name, everywhere. A doc that says "the gate", "the ratchet", and "the budget check" for one thing teaches three things. Rewording an unchanged sentence between edits costs the same way: don't churn what didn't change.
+- Skip idioms, colloquialisms, Latin abbreviations, and metaphors. A non-native reader, a translator, and an agent all parse plain constructions best.
+
+Source: Kohl, The Global English Style Guide (SAS Press). Guideline text fetched from the Internet Archive and the SAS sample chapter, 2026-07-18.
+
+## Voice and repo specifics
+
+- Apply the **unslop** skill to every doc this skill touches. That skill owns the slop-pattern catalog: AI vocabulary, filler, hedging, formatting tells.
+- PR descriptions and commit messages are writing too. Every layer except Diátaxis applies to them.
+- Product UI strings are not documentation. Use your product's copy guidelines for those.
+- Indent code snippets with tabs. Write real paths and real symbols. Make every count or tree claim true at the commit that lands it, and include the command that regenerates it.
+
+## Worked example
+
+Before:
+
+> Configuration of the proto import ratchet budget script parameters is performed via budget.json. Note that it's important to remember that running with --write, which updates the committed budget to reflect the current count, should only be done when lowering it. If exceeded, CI fails.
+
+After:
+
+> `budget.mjs` reads the committed budget from `budget.json` and counts the files that import protos. If the count exceeds the budget, CI fails. Run `budget.mjs --write` only to lower the budget.
+
+The fixes, by layer: "configuration is performed" becomes "`budget.mjs` reads", so someone does something (Google). "Ratchet" goes away. The script's real filename does the naming (jargon rule). The five-noun string breaks up into plain clauses (Global English). The hedge "note that it's important to remember" is deleted (cut every word that does no work). The failure condition moves ahead of the step it explains (STE). The buried "should only be done when lowering" becomes a command with "only" next to its verb (STE). "If exceeded" gets a subject: the count (Global English).
+
+## Review checklist
+
+Apply to any prose this skill covers. Item 1 applies only to document sets:
+
+1. Is each file one Diátaxis mode, with links where modes meet?
+2. Is every instruction written as a command, with its condition in front?
+3. Does any sentence carry two instructions or two thoughts? Split it.
+4. Can any word be cut without losing meaning? Cut it.
+5. Is "only" next to the word it changes? Does every "it" point at one thing? Does every clause keep its verb?
+6. Does each thing have exactly one name across the docs?
+7. Would a developer say these words out loud? Replace invented metaphors and fancy synonyms with the plain word or the real symbol name.
+8. Are all symbols, paths, and counts real at this commit, with the commands that regenerate the counts?

--- a/.agents/skills/unslop/SKILL.md
+++ b/.agents/skills/unslop/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: unslop
+description: Cut AI tells from any writing. Must always apply.
+---
+
+# Unslop
+
+Edit text to remove AI patterns and add human voice.
+
+## Process
+
+1. Scan for the patterns below.
+2. Rewrite. Preserve meaning, match intended tone.
+3. Add soul (see next section).
+4. Self-audit: "What makes this obviously AI generated?" Fix remaining tells.
+
+## Adding soul
+
+Removing patterns is half the job. Sterile, voiceless writing is just as obvious.
+
+- **Have opinions.** React to facts instead of neutrally listing pros and cons.
+- **Vary rhythm.** Short sentences. Then longer ones that take their time. Mix it up.
+- **Acknowledge complexity.** "Impressive but also kind of unsettling" beats "impressive."
+- **Use "I" when it fits.** First person isn't unprofessional.
+- **Let some mess in.** Perfect structure looks machine-made.
+- **Be specific.** Not "this is concerning" but "there's something unsettling about agents churning away at 3am."
+
+## Patterns to detect and fix
+
+### Content
+
+1. **Puffery.** "pivotal moment", "testament to", "evolving landscape", "setting the stage for", "indelible mark", "deeply rooted". Cut puffery, state what happened.
+2. **Name-dropping.** Listing media outlets without context. Pick one, say what was said.
+3. **Superficial -ing phrases.** "highlighting...", "ensuring...", "reflecting...", "showcasing...", "fostering...". Delete or expand with real sources.
+4. **Promotional language.** "nestled", "vibrant", "breathtaking", "groundbreaking", "renowned", "stunning", "must-visit". Use neutral descriptions.
+5. **Vague attributions.** "Experts believe", "Industry reports suggest", "Some critics argue". Name the source or delete.
+6. **Formulaic challenges.** "Despite challenges... continues to thrive." Replace with specific facts.
+
+### Language
+
+7. **AI vocabulary.** Additionally, crucial, delve, enduring, enhance, fostering, garner, interplay, intricate, landscape (abstract), pivotal, showcase, tapestry (abstract), testament, underscore, vibrant. Replace with plain words.
+8. **Fancy ways to say "is".** "serves as", "stands as", "boasts", "features". Just say "is" or "has".
+9. **"Not just X, but Y."** State the point directly instead.
+10. **Rule of three.** Forcing ideas into groups of three. Use the natural number.
+11. **Synonym cycling.** Protagonist, main character, central figure, hero all in one paragraph. Pick one, repeat it.
+12. **False ranges.** "from X to Y" where X and Y aren't on a meaningful scale. List topics directly.
+
+### Style
+
+13. **Em dash overuse.** Avoid em dashes entirely. Use periods or commas only (no parentheses, no en dashes, no hyphen-as-dash substitutes). Em dashes are an AI tell, and reaching for parentheses instead just trades one tell for another. If a thought needs separation, end the sentence or use a comma.
+14. **Colon overuse.** Colons are fine before a list or example. Not as mid-sentence connectors. "If you're coming from traditional automation: instead of registering event handlers, you describe conditions" adds nothing with the colon. Rewrite to let the point stand on its own without comparison framing. "Describing when the scheduler should fire works best as plain English." Same meaning, no crutch punctuation.
+15. **Boldface overuse.** Don't bold every proper noun or acronym.
+16. **Inline-header lists.** The tell is a bold label and colon that restates the line: "**Performance:** Performance improved...". Convert those to prose. A bold lead-in that ends in a period, names the item, and is followed by genuinely new detail ("**Schema in TypeScript.** Tables live in one file.") is fine, not a tell.
+17. **Title case headings.** Use sentence case.
+18. **Decorative emojis.** Remove from headings and bullets.
+19. **Curly quotes.** Replace with straight quotes.
+
+### Communication artifacts
+
+20. **Chatbot phrases.** "I hope this helps!", "Let me know if...", "Of course!", "Certainly!", "Found the smoking gun!" Remove.
+21. **Cutoff disclaimers.** "While specific details are limited..." Find sources or remove.
+22. **Sycophantic tone.** "Great question! You're absolutely right!" Respond directly.
+
+### Filler
+
+23. **Filler phrases.** "In order to" becomes "To". "Due to the fact that" becomes "Because". "It is important to note that" gets deleted.
+24. **Excessive hedging.** "could potentially possibly be argued that it might" becomes "may".
+25. **Generic conclusions.** "The future looks bright." State specific plans or facts.
+
+### Jargon
+
+26. **Abstract metaphor nouns.** Substrate, wedge, vector, locus, vantage, nexus, primitive (as noun), harness (as metaphor), surface (as in "API surface"), bedrock, scaffolding (as metaphor), modality, paradigm, gold-plating, ratchet (as metaphor), evacuate (for moving code), endgame, north star, flywheel. These read as technical but usually have a plainer concrete word. "Substrate" becomes "base". "Wedge in" becomes "add". "Vector" becomes "way" or "method". "Gold-plating" becomes "more than the job needs". "Ratchet" becomes the mechanism's real name or "a limit that only tightens". "Evacuate" becomes "move out". "Endgame" becomes "the last phase". Pick the concrete word.
+
+### Plain speech
+
+27. **Say what it does, not how it feels.** "the database stays close at hand", "SQL you can read", "types that follow your schema" name a feeling. The fix names the mechanism or a number: "`.toSQL()` returns the exact string sent to the database", "a column rename fails the build". Ask what the sentence tells the reader to do or know, then write that. If you can't restate it as a concrete instruction, fact, or number, cut it. One more check: if the sentence could appear unchanged in another project's docs, it says nothing about this one. Cut it.
+28. **Shorten or split dense sentences.** If the reader has to backtrack to parse a sentence, break it in two or drop clauses. One idea per sentence.
+29. **Active voice.** Prefer it. Catch "is/are/was/were + past participle" and name the actor: "queries are validated" becomes "the compiler validates queries", "the file is parsed by the loader" becomes "the loader parses the file". Passive is fine only when the actor is unknown or genuinely doesn't matter.
+30. **Cut adverbs, or use a stronger verb.** "runs quickly" becomes "is fast" or the number. "significantly improves" becomes the measured delta. An adverb propping up a weak verb means the verb is wrong.
+31. **Prefer the plain word.** "utilize" becomes "use", "leverage" becomes "use", "facilitate" becomes "help", "numerous" becomes "many", "in the event that" becomes "if". The fancier synonym is rarely clearer.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Plataforma de observabilidade da Equipe Tech. Um contrato OpenTelemetry, um Collector por stack e adapters para cada runtime. O mesmo pipeline roda no desenvolvimento local e na produção.
 
-> Status: pipeline local, adapters por runtime e provisionamento implementados. Pacote de telemetria, adapters (node, nestjs, browser, testing), CLI, stack local e provisionamento dos assets de produção funcionam de ponta a ponta.
+> Status: pipeline local, adapters por runtime e provisionamento implementados. A CLI também cria datasets, tokens Axiom e projetos Sentry por ambiente.
 
 ## Princípios
 
@@ -116,6 +116,16 @@ O comando escreve no projeto alvo:
 - `observability/kamal.accessory.yml`: trecho de accessory para mesclar em `config/deploy.yml`, com os datasets `<name>-traces|logs|metrics`
 
 O comando é idempotente. Um arquivo provisionado que foi modificado localmente gera o erro `OBS_CLI_PROVISION_CONFLICT`; use `--force` para sobrescrever. Depois do merge do accessory, defina o secret `AXIOM_TOKEN` no Kamal.
+
+### Ambientes remotos
+
+A CLI autentica com Axiom e Sentry, cria recursos isolados por ambiente e salva as credenciais com modo `0600`.
+
+Consulte estes documentos:
+
+- [Ambientes isolam dados sem acoplar a aplicação](docs/environment-management.md)
+- [Configurar um projeto com ambientes remotos](docs/setup-project-environments.md)
+- [Referência da CLI](docs/cli-reference.md)
 
 Com a stack no ar, o canário valida traces, logs e métricas no pipeline completo:
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,122 @@
+# Referência da CLI
+
+`observability` gerencia a stack local, os assets do Collector, e os recursos remotos de observabilidade.
+
+## `auth login axiom`
+
+```text
+observability auth login axiom --organization-id <id>
+```
+
+O comando solicita um personal access token em um prompt protegido. A CLI valida o token com `GET /v2/user`.
+
+A CLI salva o token e o identificador da organização no arquivo local de credenciais.
+
+## `auth login sentry`
+
+```text
+observability auth login sentry \
+  --organization <slug> \
+  --team <slug> \
+  [--url https://sentry.io]
+```
+
+O comando solicita um organization auth token em um prompt protegido. A CLI valida o acesso à organização informada.
+
+`--url` permite um servidor Sentry próprio. O valor padrão é `https://sentry.io`.
+
+## `auth status`
+
+```text
+observability auth status
+```
+
+O comando valida cada credencial salva contra o provider. A saída também contém o caminho do arquivo de credenciais.
+
+## `provision`
+
+```text
+observability provision \
+  [--dir <path>] \
+  [--name <project>] \
+  [--force] \
+  [--environment <name>]... \
+  [--sentry-platform <platform>] \
+  [--rotate-token]
+```
+
+Sem `--environment`, o comando gera somente os assets locais. Esse comportamento mantém compatibilidade com versões anteriores.
+
+Cada `--environment` cria três datasets Axiom e um token de ingestão. Todos os ambientes usam o mesmo projeto Sentry.
+
+`--rotate-token` regenera um token Axiom existente. A CLI salva o novo valor no arquivo local de credenciais.
+
+`--force` afeta somente os assets locais. A flag não sobrescreve recursos remotos.
+
+## `env list`
+
+```text
+observability env list [--name <project>]
+```
+
+O comando lista os ambientes salvos no arquivo local de credenciais. A lista não confirma que os destinos receberam telemetria.
+
+## `env export`
+
+```text
+observability env export \
+  --name <project> \
+  --environment <name>
+```
+
+O comando imprime estas variáveis no formato dotenv:
+
+- `OTEL_SERVICE_NAME`
+- `OTEL_DEPLOYMENT_ENVIRONMENT`
+- `OTEL_EXPORTER_OTLP_ENDPOINT`
+- `AXIOM_TOKEN`
+- `AXIOM_DATASET_TRACES`
+- `AXIOM_DATASET_LOGS`
+- `AXIOM_DATASET_METRICS`
+- `SENTRY_DSN`
+
+A saída contém segredos. A CLI não mascara a saída desse comando.
+
+## Arquivo de credenciais
+
+O caminho padrão é `~/.local/state/observability/credentials.json`. `OBSERVABILITY_HOME` altera o diretório pai.
+
+A CLI cria o diretório com modo `0700`. A CLI cria o arquivo com modo `0600`.
+
+O arquivo contém tokens administrativos, tokens de ingestão, DSNs, e o estado dos ambientes. A CLI recusa um arquivo acessível por grupo ou outros usuários.
+
+## Convenção de nomes
+
+O nome de um dataset segue este formato:
+
+```text
+<project>-<environment>-<signal>
+```
+
+`<signal>` aceita `traces`, `logs`, ou `metrics`.
+
+O nome do token Axiom segue este formato:
+
+```text
+<project>-<environment>-collector
+```
+
+## Erros remotos
+
+| Código                                 | Significado                                                            |
+| -------------------------------------- | ---------------------------------------------------------------------- |
+| `OBS_CLI_CREDENTIALS_INVALID`          | O arquivo ou a configuração de credenciais não passa no parse.         |
+| `OBS_CLI_CREDENTIALS_INSECURE`         | O arquivo de credenciais permite acesso para grupo ou outros usuários. |
+| `OBS_CLI_CREDENTIALS_FAILED`           | A CLI não consegue acessar o arquivo de credenciais.                   |
+| `OBS_CLI_REMOTE_CREDENTIALS_MISSING`   | O provisionamento remoto não encontra as duas credenciais.             |
+| `OBS_CLI_REMOTE_UNAUTHORIZED`          | O provider recusa a credencial ou o acesso à organização.              |
+| `OBS_CLI_REMOTE_FAILED`                | A requisição falha ou o provider retorna um status inesperado.         |
+| `OBS_CLI_REMOTE_INVALID_RESPONSE`      | A resposta do provider não passa no parse.                             |
+| `OBS_CLI_REMOTE_INVALID_ENVIRONMENT`   | O ambiente ou o nome derivado de um dataset é inválido.                |
+| `OBS_CLI_REMOTE_TOKEN_UNAVAILABLE`     | O token existe no Axiom, mas a CLI não possui o valor secreto.         |
+| `OBS_CLI_REMOTE_ENVIRONMENT_NOT_FOUND` | O arquivo local não contém o projeto e o ambiente solicitados.         |

--- a/docs/environment-management.md
+++ b/docs/environment-management.md
@@ -1,0 +1,51 @@
+# Ambientes isolam dados sem acoplar a aplicação
+
+O pacote trata o ambiente como um atributo OpenTelemetry. `OTEL_DEPLOYMENT_ENVIRONMENT` identifica `development`, `staging`, `production`, ou outro ambiente.
+
+A aplicação envia os três sinais para um Collector. Ela não contém credenciais do Axiom e não conhece os nomes dos datasets.
+
+## O ambiente local não usa contas externas
+
+O ambiente local usa `http://localhost:4318` como endpoint padrão. O Collector local envia os sinais para o `otel-desktop-viewer`.
+
+Esse fluxo mantém o Collector entre a aplicação e o destino. O mesmo contrato OTLP existe no ambiente local e nos ambientes remotos.
+
+## Cada ambiente remoto tem recursos isolados no Axiom
+
+A CLI cria três datasets para cada ambiente:
+
+- `<project>-<environment>-traces`
+- `<project>-<environment>-logs`
+- `<project>-<environment>-metrics`
+
+A CLI também cria um token de ingestão para cada ambiente. O token concede acesso somente aos três datasets daquele ambiente.
+
+Esse isolamento permite retenções e permissões diferentes. Uma credencial de `staging` não concede acesso aos dados de `production`.
+
+## Um projeto Sentry atende todos os ambientes
+
+A CLI cria um projeto Sentry por aplicação. O SDK Sentry envia o nome do ambiente em cada evento.
+
+O Sentry cria a lista de ambientes observados após receber eventos. A CLI não cria ambientes Sentry separados.
+
+## A CLI separa credenciais administrativas de credenciais de runtime
+
+`observability auth login` salva os tokens administrativos no arquivo local de credenciais. O arquivo usa o modo `0600`.
+
+O provisionamento usa esses tokens para criar recursos remotos. A CLI cria um token Axiom com acesso somente para ingestão.
+
+A CLI não grava segredos nos assets em `observability/`. `observability env export` imprime as variáveis para integração com Kamal ou outro gerenciador de segredos.
+
+## O estado local preserva segredos que o provider não retorna
+
+O Axiom retorna o valor do token somente na criação ou na regeneração. A CLI salva esse valor no arquivo local de credenciais.
+
+Se esse estado local for perdido, a CLI encontra o token remoto sem acesso ao valor. Nesse caso, `--rotate-token` regenera o token e salva o novo valor.
+
+## Ambientes configurados e ambientes observados têm significados diferentes
+
+`observability env list` mostra os ambientes configurados por esta CLI. A lista vem do arquivo local de credenciais.
+
+Um ambiente observado contém telemetria no destino. Ele passa a existir após o primeiro evento chegar ao Axiom ou ao Sentry.
+
+Consulte [Configurar um projeto com ambientes remotos](setup-project-environments.md) para executar o fluxo. Consulte [Referência da CLI](cli-reference.md) para ver os comandos e os erros.

--- a/docs/setup-project-environments.md
+++ b/docs/setup-project-environments.md
@@ -1,0 +1,129 @@
+# Configurar um projeto com ambientes remotos
+
+Use este guia para configurar Axiom e Sentry para `development`, `staging`, e `production`.
+
+## Preparar os tokens administrativos
+
+1. Crie um personal access token no Axiom.
+2. Conceda ao token acesso para gerenciar datasets e API tokens.
+3. Copie o identificador da organização Axiom.
+4. Crie um organization auth token no Sentry.
+5. Conceda ao token os escopos `org:read`, `project:read`, e `project:write`.
+6. Copie os slugs da organização e do time Sentry.
+
+Não use tokens administrativos no runtime da aplicação. Esses tokens podem alterar recursos da organização.
+
+## Autenticar a CLI
+
+Execute o login do Axiom:
+
+```sh
+observability auth login axiom --organization-id <axiom-organization-id>
+```
+
+Cole o personal access token no prompt protegido.
+
+Execute o login do Sentry:
+
+```sh
+observability auth login sentry \
+  --organization maxxi-cash \
+  --team backend
+```
+
+Cole o organization auth token no prompt protegido.
+
+Valide as duas conexões:
+
+```sh
+observability auth status
+```
+
+A saída mostra a identidade Axiom, a organização Sentry, e o caminho do arquivo de credenciais.
+
+## Iniciar a observabilidade local
+
+Inicie o Collector e o viewer:
+
+```sh
+observability dev up
+```
+
+Configure o serviço local:
+
+```sh
+export OTEL_SERVICE_NAME=livro-caixa
+export OTEL_DEPLOYMENT_ENVIRONMENT=development
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+```
+
+Abra `http://localhost:8000` para ver os sinais recebidos.
+
+## Provisionar staging e production
+
+Execute o comando no projeto `maxxi-cash/livro-caixa`:
+
+```sh
+observability provision \
+  --dir . \
+  --name livro-caixa \
+  --environment staging \
+  --environment production \
+  --sentry-platform node
+```
+
+O comando cria estes recursos:
+
+- seis datasets Axiom;
+- dois tokens Axiom com acesso somente para ingestão;
+- um projeto Sentry chamado `livro-caixa`;
+- os assets do Collector e do accessory Kamal.
+
+O comando não imprime os tokens de runtime.
+
+## Adicionar as variáveis ao deploy
+
+Exporte as variáveis de `staging`:
+
+```sh
+observability env export \
+  --name livro-caixa \
+  --environment staging
+```
+
+A saída contém `AXIOM_TOKEN` e `SENTRY_DSN`. Não salve essa saída em um arquivo versionado.
+
+Adicione os valores ao gerenciador de segredos do ambiente. Adicione as variáveis `OTEL_*` e `AXIOM_DATASET_*` ao destino Kamal.
+
+Repita o processo para `production`:
+
+```sh
+observability env export \
+  --name livro-caixa \
+  --environment production
+```
+
+Mescle `observability/kamal.accessory.yml` em `config/deploy.yml`. O accessory lê os nomes dos datasets das variáveis exportadas.
+
+## Inspecionar a configuração
+
+Liste todos os ambientes configurados:
+
+```sh
+observability env list --name livro-caixa
+```
+
+A lista mostra os datasets Axiom e o projeto Sentry de cada ambiente.
+
+## Recuperar um token Axiom perdido
+
+Se o arquivo local de credenciais foi perdido, regenere o token do ambiente:
+
+```sh
+observability provision \
+  --name livro-caixa \
+  --environment staging \
+  --rotate-token
+```
+
+Atualize o segredo `AXIOM_TOKEN` antes do próximo deploy. O token anterior deixa de funcionar imediatamente.

--- a/packages/cli/src/Cli.ts
+++ b/packages/cli/src/Cli.ts
@@ -1,7 +1,8 @@
-import { Console, Effect, Option, Path } from "effect";
-import { Command, Flag } from "effect/unstable/cli";
+import { Console, Effect, Option, Path, Redacted } from "effect";
+import { Command, Flag, Prompt } from "effect/unstable/cli";
 import { DockerCompose } from "./DockerCompose.ts";
 import { ProvisionAssets } from "./ProvisionAssets.ts";
+import { Authentication, RemoteEnvironment } from "./RemoteEnvironment.ts";
 import { StackAssets } from "./StackAssets.ts";
 
 const composeFile = Flag.string("file").pipe(
@@ -54,6 +55,72 @@ const dev = Command.make("dev").pipe(
   Command.withDescription("Ciclo de vida da stack local de observabilidade"),
 );
 
+const axiomOrganization = Flag.string("organization-id").pipe(
+  Flag.withDescription("Identificador da organização Axiom"),
+);
+
+const authLoginAxiom = Command.make(
+  "axiom",
+  { organizationId: axiomOrganization },
+  Effect.fn(function* ({ organizationId }) {
+    const token = yield* Prompt.run(Prompt.password({ message: "Axiom personal access token" }));
+    const authentication = yield* Authentication;
+    const identity = yield* authentication.loginAxiom(Redacted.value(token), organizationId);
+    yield* Console.log(`Authenticated with Axiom as ${identity}.`);
+  }),
+).pipe(Command.withDescription("Autentica com Axiom e salva as credenciais locais"));
+
+const sentryOrganization = Flag.string("organization").pipe(
+  Flag.withDescription("Slug da organização Sentry"),
+);
+const sentryTeam = Flag.string("team").pipe(Flag.withDescription("Slug do time Sentry"));
+const sentryUrl = Flag.string("url").pipe(
+  Flag.withDescription("URL base do Sentry"),
+  Flag.withDefault("https://sentry.io"),
+  Flag.mapTryCatch(
+    (value) => new URL(value),
+    () => "Expected an absolute Sentry URL",
+  ),
+);
+
+const authLoginSentry = Command.make(
+  "sentry",
+  { organization: sentryOrganization, team: sentryTeam, url: sentryUrl },
+  Effect.fn(function* ({ organization, team, url }) {
+    const token = yield* Prompt.run(Prompt.password({ message: "Sentry organization auth token" }));
+    const authentication = yield* Authentication;
+    const identity = yield* authentication.loginSentry(
+      Redacted.value(token),
+      organization,
+      team,
+      url,
+    );
+    yield* Console.log(`Authenticated with Sentry organization ${identity}.`);
+  }),
+).pipe(Command.withDescription("Autentica com Sentry e salva as credenciais locais"));
+
+const authLogin = Command.make("login").pipe(
+  Command.withSubcommands([authLoginAxiom, authLoginSentry]),
+  Command.withDescription("Salva credenciais após validar o acesso ao provider"),
+);
+
+const authStatus = Command.make(
+  "status",
+  {},
+  Effect.fn(function* () {
+    const authentication = yield* Authentication;
+    const result = yield* authentication.status();
+    yield* Console.log(`Axiom: ${result.axiom}`);
+    yield* Console.log(`Sentry: ${result.sentry}`);
+    yield* Console.log(`Credentials: ${result.credentialsPath}`);
+  }),
+).pipe(Command.withDescription("Valida as credenciais salvas"));
+
+const auth = Command.make("auth").pipe(
+  Command.withSubcommands([authLogin, authStatus]),
+  Command.withDescription("Gerencia autenticação com os providers"),
+);
+
 const provisionDirectory = Flag.string("dir").pipe(
   Flag.withAlias("d"),
   Flag.withDescription("Diretório do projeto alvo (padrão: diretório atual)"),
@@ -71,26 +138,116 @@ const provisionForce = Flag.boolean("force").pipe(
   Flag.withDefault(false),
 );
 
+const provisionEnvironments = Flag.string("environment").pipe(
+  Flag.withAlias("e"),
+  Flag.withDescription("Ambiente remoto. Repita a flag para configurar vários ambientes"),
+  Flag.atMost(10),
+);
+
+const provisionPlatform = Flag.string("sentry-platform").pipe(
+  Flag.withDescription("Plataforma do projeto Sentry"),
+  Flag.withDefault("node"),
+);
+
+const provisionRotateToken = Flag.boolean("rotate-token").pipe(
+  Flag.withDescription("Regenera o token de ingestão Axiom de cada ambiente"),
+  Flag.withDefault(false),
+);
+
 const provision = Command.make(
   "provision",
-  { dir: provisionDirectory, name: provisionName, force: provisionForce },
-  Effect.fn(function* ({ dir, force, name }) {
+  {
+    dir: provisionDirectory,
+    name: provisionName,
+    force: provisionForce,
+    environments: provisionEnvironments,
+    platform: provisionPlatform,
+    rotateToken: provisionRotateToken,
+  },
+  Effect.fn(function* ({ dir, environments, force, name, platform, rotateToken }) {
     const assets = yield* ProvisionAssets;
-    const files = yield* assets.provision(dir, name, force);
+    const projectName = yield* assets.resolveName(dir, name);
+    const files = yield* assets.provision(dir, Option.some(projectName), force);
     for (const file of files) {
       yield* Console.log(`${file.action}  ${file.relativePath}`);
     }
     yield* Console.log(
       "Merge observability/kamal.accessory.yml into config/deploy.yml and set the AXIOM_TOKEN secret.",
     );
+
+    const uniqueEnvironments = [...new Set(environments)];
+    if (uniqueEnvironments.length > 0) {
+      const remote = yield* RemoteEnvironment;
+      const configured = yield* remote.provision(
+        projectName,
+        uniqueEnvironments,
+        platform,
+        rotateToken,
+      );
+      for (const environment of configured) {
+        yield* Console.log(
+          `configured  ${environment.project}/${environment.environment} (${environment.tracesDataset}, ${environment.logsDataset}, ${environment.metricsDataset})`,
+        );
+      }
+      yield* Console.log(
+        `Run observability env export --name ${projectName} --environment <environment> to print deploy variables.`,
+      );
+    }
   }),
 ).pipe(
   Command.withDescription(
-    "Provisiona os assets do Collector de produção (config + accessory Kamal) no projeto",
+    "Provisiona os assets locais e, com --environment, os recursos Axiom e Sentry",
   ),
 );
 
+const environmentProject = Flag.string("name").pipe(
+  Flag.withAlias("n"),
+  Flag.withDescription("Nome do projeto"),
+  Flag.optional,
+);
+
+const environmentList = Command.make(
+  "list",
+  { name: environmentProject },
+  Effect.fn(function* ({ name }) {
+    const remote = yield* RemoteEnvironment;
+    const environments = yield* remote.list(name);
+    if (environments.length === 0) {
+      yield* Console.log("No configured environments.");
+      return;
+    }
+    for (const environment of environments) {
+      yield* Console.log(
+        `${environment.project}/${environment.environment}  axiom=${environment.tracesDataset},${environment.logsDataset},${environment.metricsDataset}  sentry=${environment.sentryProject}`,
+      );
+    }
+  }),
+).pipe(Command.withDescription("Lista os ambientes configurados por esta CLI"));
+
+const environmentExportName = Flag.string("name").pipe(
+  Flag.withAlias("n"),
+  Flag.withDescription("Nome do projeto"),
+);
+const environmentExportEnvironment = Flag.string("environment").pipe(
+  Flag.withAlias("e"),
+  Flag.withDescription("Nome do ambiente"),
+);
+
+const environmentExport = Command.make(
+  "export",
+  { name: environmentExportName, environment: environmentExportEnvironment },
+  Effect.fn(function* ({ environment, name }) {
+    const remote = yield* RemoteEnvironment;
+    yield* Console.log(yield* remote.export(name, environment));
+  }),
+).pipe(Command.withDescription("Imprime variáveis de deploy no formato dotenv"));
+
+const environment = Command.make("env").pipe(
+  Command.withSubcommands([environmentList, environmentExport]),
+  Command.withDescription("Inspeciona e exporta ambientes configurados"),
+);
+
 export const observability = Command.make("observability").pipe(
-  Command.withSubcommands([dev, provision]),
+  Command.withSubcommands([dev, auth, provision, environment]),
   Command.withDescription("Plataforma de observabilidade da Equipe Tech"),
 );

--- a/packages/cli/src/CredentialsStore.ts
+++ b/packages/cli/src/CredentialsStore.ts
@@ -1,0 +1,160 @@
+import { Context, Effect, FileSystem, Layer, Option, Path, Schema } from "effect";
+import { homedir } from "node:os";
+
+const CredentialsEnvironment = Schema.Struct({
+  OBSERVABILITY_HOME: Schema.NonEmptyString.pipe(Schema.optionalKey),
+});
+
+const decodeCredentialsEnvironment = Schema.decodeUnknownEffect(CredentialsEnvironment);
+
+export class AxiomCredentials extends Schema.Class<AxiomCredentials>(
+  "@equipe-tech/observability-cli/AxiomCredentials",
+)({
+  token: Schema.NonEmptyString,
+  organizationId: Schema.NonEmptyString,
+}) {}
+
+export class SentryCredentials extends Schema.Class<SentryCredentials>(
+  "@equipe-tech/observability-cli/SentryCredentials",
+)({
+  token: Schema.NonEmptyString,
+  organization: Schema.NonEmptyString,
+  team: Schema.NonEmptyString,
+  baseUrl: Schema.URLFromString,
+}) {}
+
+export class ManagedEnvironment extends Schema.Class<ManagedEnvironment>(
+  "@equipe-tech/observability-cli/ManagedEnvironment",
+)({
+  project: Schema.NonEmptyString,
+  environment: Schema.NonEmptyString,
+  axiomTokenId: Schema.NonEmptyString,
+  axiomToken: Schema.NonEmptyString,
+  tracesDataset: Schema.NonEmptyString,
+  logsDataset: Schema.NonEmptyString,
+  metricsDataset: Schema.NonEmptyString,
+  sentryProject: Schema.NonEmptyString,
+  sentryDsn: Schema.NonEmptyString,
+}) {}
+
+export class CredentialsFile extends Schema.Class<CredentialsFile>(
+  "@equipe-tech/observability-cli/CredentialsFile",
+)({
+  version: Schema.Literal(1),
+  axiom: AxiomCredentials.pipe(Schema.optionalKey),
+  sentry: SentryCredentials.pipe(Schema.optionalKey),
+  environments: Schema.Array(ManagedEnvironment),
+}) {}
+
+const decodeCredentialsFile = Schema.decodeUnknownEffect(CredentialsFile);
+
+export class CredentialsError extends Schema.TaggedError<CredentialsError>()("CredentialsError", {
+  code: Schema.Literals([
+    "OBS_CLI_CREDENTIALS_INVALID",
+    "OBS_CLI_CREDENTIALS_INSECURE",
+    "OBS_CLI_CREDENTIALS_FAILED",
+  ]),
+  message: Schema.String,
+  cause: Schema.Defect(),
+}) {}
+
+const credentialsFailure = (cause: unknown): CredentialsError =>
+  new CredentialsError({
+    code: "OBS_CLI_CREDENTIALS_FAILED",
+    message:
+      "The credentials file could not be accessed. Check OBSERVABILITY_HOME permissions and retry.",
+    cause,
+  });
+
+const parseCredentials = Effect.fn("parseCredentials")(function* (content: string) {
+  const value = yield* Effect.try({
+    try: () => JSON.parse(content),
+    catch: (cause) =>
+      new CredentialsError({
+        code: "OBS_CLI_CREDENTIALS_INVALID",
+        message:
+          "The credentials file is invalid. Remove it and run the authentication commands again.",
+        cause,
+      }),
+  });
+  return yield* decodeCredentialsFile(value).pipe(
+    Effect.mapError(
+      (cause) =>
+        new CredentialsError({
+          code: "OBS_CLI_CREDENTIALS_INVALID",
+          message:
+            "The credentials file is invalid. Remove it and run the authentication commands again.",
+          cause,
+        }),
+    ),
+  );
+});
+
+export class CredentialsStore extends Context.Service<
+  CredentialsStore,
+  {
+    load(): Effect.Effect<Option.Option<CredentialsFile>, CredentialsError>;
+    save(credentials: CredentialsFile): Effect.Effect<void, CredentialsError>;
+    path: string;
+  }
+>()("@equipe-tech/observability-cli/CredentialsStore") {
+  static readonly layer = Layer.effect(
+    CredentialsStore,
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const environment = yield* decodeCredentialsEnvironment(process.env).pipe(
+        Effect.mapError(
+          (cause) =>
+            new CredentialsError({
+              code: "OBS_CLI_CREDENTIALS_INVALID",
+              message: "OBSERVABILITY_HOME must contain a non-empty path.",
+              cause,
+            }),
+        ),
+      );
+      const root =
+        environment.OBSERVABILITY_HOME ?? path.join(homedir(), ".local", "state", "observability");
+      const credentialsPath = path.join(root, "credentials.json");
+
+      const load = Effect.fn("CredentialsStore.load")(function* () {
+        const exists = yield* fs.exists(credentialsPath).pipe(Effect.mapError(credentialsFailure));
+        if (!exists) {
+          return Option.none();
+        }
+        const info = yield* fs.stat(credentialsPath).pipe(Effect.mapError(credentialsFailure));
+        if ((info.mode & 0o077) !== 0) {
+          return yield* new CredentialsError({
+            code: "OBS_CLI_CREDENTIALS_INSECURE",
+            message:
+              "The credentials file is accessible by other users. Run chmod 600 on the file and retry.",
+            cause: info.mode,
+          });
+        }
+        const content = yield* fs
+          .readFileString(credentialsPath)
+          .pipe(Effect.mapError(credentialsFailure));
+        return Option.some(yield* parseCredentials(content));
+      });
+
+      const save = Effect.fn("CredentialsStore.save")(function* (credentials: CredentialsFile) {
+        yield* fs
+          .makeDirectory(root, { recursive: true })
+          .pipe(Effect.mapError(credentialsFailure));
+        yield* fs.chmod(root, 0o700).pipe(Effect.mapError(credentialsFailure));
+        const temporaryPath = `${credentialsPath}.tmp`;
+        const content = `${JSON.stringify(credentials, undefined, 2)}\n`;
+        yield* fs
+          .writeFileString(temporaryPath, content, { mode: 0o600 })
+          .pipe(Effect.mapError(credentialsFailure));
+        yield* fs.chmod(temporaryPath, 0o600).pipe(Effect.mapError(credentialsFailure));
+        yield* fs.rename(temporaryPath, credentialsPath).pipe(Effect.mapError(credentialsFailure));
+      });
+
+      return CredentialsStore.of({ load, save, path: credentialsPath });
+    }),
+  );
+}
+
+export const emptyCredentials = (): CredentialsFile =>
+  new CredentialsFile({ version: 1, environments: [] });

--- a/packages/cli/src/ErrorReporter.ts
+++ b/packages/cli/src/ErrorReporter.ts
@@ -13,7 +13,10 @@ export const publicErrorFromCause = (cause: Cause.Cause<unknown>): Option.Option
       (Predicate.hasProperty(value, "_tag") &&
         (value._tag === "DockerComposeError" ||
           value._tag === "StackAssetsError" ||
-          value._tag === "ProvisionError"))
+          value._tag === "ProvisionError" ||
+          value._tag === "CredentialsError" ||
+          value._tag === "RemoteApiError" ||
+          value._tag === "RemoteEnvironmentError"))
     ) {
       return Option.none();
     }

--- a/packages/cli/src/ProviderApis.ts
+++ b/packages/cli/src/ProviderApis.ts
@@ -1,0 +1,334 @@
+import { Context, Effect, Layer, Schema } from "effect";
+import { AxiomCredentials, SentryCredentials } from "./CredentialsStore.ts";
+
+const AxiomUser = Schema.Struct({
+  id: Schema.NonEmptyString,
+  email: Schema.NonEmptyString,
+});
+
+const AxiomDataset = Schema.Struct({ name: Schema.NonEmptyString });
+const AxiomDatasets = Schema.Array(AxiomDataset);
+const AxiomToken = Schema.Struct({ id: Schema.NonEmptyString, name: Schema.NonEmptyString });
+const AxiomTokens = Schema.Array(AxiomToken);
+const AxiomTokenSecret = Schema.Struct({
+  id: Schema.NonEmptyString,
+  token: Schema.NonEmptyString,
+});
+
+const SentryOrganization = Schema.Struct({
+  slug: Schema.NonEmptyString,
+  name: Schema.NonEmptyString,
+});
+const SentryProject = Schema.Struct({
+  slug: Schema.NonEmptyString,
+  name: Schema.NonEmptyString,
+});
+const SentryClientKey = Schema.Struct({
+  dsn: Schema.Struct({ public: Schema.NonEmptyString }),
+});
+const SentryClientKeys = Schema.Array(SentryClientKey);
+
+const decodeAxiomUser = Schema.decodeUnknownEffect(AxiomUser);
+const decodeAxiomDatasets = Schema.decodeUnknownEffect(AxiomDatasets);
+const decodeAxiomTokens = Schema.decodeUnknownEffect(AxiomTokens);
+const decodeAxiomTokenSecret = Schema.decodeUnknownEffect(AxiomTokenSecret);
+const decodeSentryOrganization = Schema.decodeUnknownEffect(SentryOrganization);
+const decodeSentryProject = Schema.decodeUnknownEffect(SentryProject);
+const decodeSentryClientKeys = Schema.decodeUnknownEffect(SentryClientKeys);
+
+export class RemoteApiError extends Schema.TaggedError<RemoteApiError>()("RemoteApiError", {
+  code: Schema.Literals([
+    "OBS_CLI_REMOTE_UNAUTHORIZED",
+    "OBS_CLI_REMOTE_FAILED",
+    "OBS_CLI_REMOTE_INVALID_RESPONSE",
+  ]),
+  message: Schema.String,
+  provider: Schema.Literals(["Axiom", "Sentry"]),
+  status: Schema.Int,
+  cause: Schema.Defect(),
+}) {}
+
+type Provider = "Axiom" | "Sentry";
+
+type RemoteResponse = {
+  readonly status: number;
+  readonly content: string;
+};
+
+const remoteRequest = Effect.fn("remoteRequest")(function* (
+  provider: Provider,
+  url: string,
+  init: RequestInit,
+): Effect.fn.Return<RemoteResponse, RemoteApiError> {
+  const response = yield* Effect.tryPromise({
+    try: () => fetch(url, init),
+    catch: (cause) =>
+      new RemoteApiError({
+        code: "OBS_CLI_REMOTE_FAILED",
+        message: `${provider} could not be reached. Check the network connection and retry.`,
+        provider,
+        status: 0,
+        cause,
+      }),
+  });
+  const content = yield* Effect.tryPromise({
+    try: () => response.text(),
+    catch: (cause) =>
+      new RemoteApiError({
+        code: "OBS_CLI_REMOTE_FAILED",
+        message: `${provider} returned an unreadable response. Retry the command.`,
+        provider,
+        status: response.status,
+        cause,
+      }),
+  });
+  if (response.status === 401 || response.status === 403) {
+    return yield* new RemoteApiError({
+      code: "OBS_CLI_REMOTE_UNAUTHORIZED",
+      message: `${provider} rejected the stored credentials. Run observability auth login again.`,
+      provider,
+      status: response.status,
+      cause: response.status,
+    });
+  }
+  return { status: response.status, content };
+});
+
+const parseRemoteJson = Effect.fn("parseRemoteJson")(function* (
+  provider: Provider,
+  response: RemoteResponse,
+) {
+  return yield* Effect.try({
+    try: () => JSON.parse(response.content),
+    catch: (cause) =>
+      new RemoteApiError({
+        code: "OBS_CLI_REMOTE_INVALID_RESPONSE",
+        message: `${provider} returned an invalid response. Retry the command.`,
+        provider,
+        status: response.status,
+        cause,
+      }),
+  });
+});
+
+const expectStatus = Effect.fn("expectStatus")(function* (
+  provider: Provider,
+  response: RemoteResponse,
+  accepted: ReadonlyArray<number>,
+): Effect.fn.Return<RemoteResponse, RemoteApiError> {
+  if (!accepted.includes(response.status)) {
+    return yield* new RemoteApiError({
+      code: "OBS_CLI_REMOTE_FAILED",
+      message: `${provider} returned HTTP ${response.status}. Retry the command or verify the provider configuration.`,
+      provider,
+      status: response.status,
+      cause: response.status,
+    });
+  }
+  return response;
+});
+
+const invalidResponse = (provider: Provider, status: number, cause: unknown): RemoteApiError =>
+  new RemoteApiError({
+    code: "OBS_CLI_REMOTE_INVALID_RESPONSE",
+    message: `${provider} returned an invalid response. Retry the command.`,
+    provider,
+    status,
+    cause,
+  });
+
+const axiomHeaders = (credentials: AxiomCredentials) => ({
+  Authorization: `Bearer ${credentials.token}`,
+  "Content-Type": "application/json",
+  "X-Axiom-Org-Id": credentials.organizationId,
+});
+
+export class AxiomApi extends Context.Service<
+  AxiomApi,
+  {
+    identity(credentials: AxiomCredentials): Effect.Effect<string, RemoteApiError>;
+    datasets(credentials: AxiomCredentials): Effect.Effect<ReadonlyArray<string>, RemoteApiError>;
+    createDataset(credentials: AxiomCredentials, name: string): Effect.Effect<void, RemoteApiError>;
+    tokens(
+      credentials: AxiomCredentials,
+    ): Effect.Effect<ReadonlyArray<{ readonly id: string; readonly name: string }>, RemoteApiError>;
+    createToken(
+      credentials: AxiomCredentials,
+      name: string,
+      datasets: ReadonlyArray<string>,
+    ): Effect.Effect<{ readonly id: string; readonly token: string }, RemoteApiError>;
+    regenerateToken(
+      credentials: AxiomCredentials,
+      id: string,
+    ): Effect.Effect<{ readonly id: string; readonly token: string }, RemoteApiError>;
+  }
+>()("@equipe-tech/observability-cli/AxiomApi") {
+  static readonly layer = Layer.succeed(
+    AxiomApi,
+    AxiomApi.of({
+      identity: Effect.fn("AxiomApi.identity")(function* (credentials) {
+        const response = yield* remoteRequest("Axiom", "https://api.axiom.co/v2/user", {
+          headers: axiomHeaders(credentials),
+        });
+        yield* expectStatus("Axiom", response, [200]);
+        const value = yield* parseRemoteJson("Axiom", response);
+        const user = yield* decodeAxiomUser(value).pipe(
+          Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
+        );
+        return user.email;
+      }),
+      datasets: Effect.fn("AxiomApi.datasets")(function* (credentials) {
+        const response = yield* remoteRequest("Axiom", "https://api.axiom.co/v2/datasets", {
+          headers: axiomHeaders(credentials),
+        });
+        yield* expectStatus("Axiom", response, [200]);
+        const value = yield* parseRemoteJson("Axiom", response);
+        const datasets = yield* decodeAxiomDatasets(value).pipe(
+          Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
+        );
+        return datasets.map((dataset) => dataset.name);
+      }),
+      createDataset: Effect.fn("AxiomApi.createDataset")(function* (credentials, name) {
+        const response = yield* remoteRequest("Axiom", "https://api.axiom.co/v2/datasets", {
+          method: "POST",
+          headers: axiomHeaders(credentials),
+          body: JSON.stringify({ name, description: `OpenTelemetry data for ${name}` }),
+        });
+        yield* expectStatus("Axiom", response, [200, 201, 409]);
+      }),
+      tokens: Effect.fn("AxiomApi.tokens")(function* (credentials) {
+        const response = yield* remoteRequest("Axiom", "https://api.axiom.co/v2/tokens", {
+          headers: axiomHeaders(credentials),
+        });
+        yield* expectStatus("Axiom", response, [200]);
+        const value = yield* parseRemoteJson("Axiom", response);
+        return yield* decodeAxiomTokens(value).pipe(
+          Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
+        );
+      }),
+      createToken: Effect.fn("AxiomApi.createToken")(function* (credentials, name, datasets) {
+        const datasetCapabilities = Object.fromEntries(
+          datasets.map((dataset) => [dataset, { ingest: ["create"] }]),
+        );
+        const response = yield* remoteRequest("Axiom", "https://api.axiom.co/v2/tokens", {
+          method: "POST",
+          headers: axiomHeaders(credentials),
+          body: JSON.stringify({
+            name,
+            description: `Collector ingest token for ${name}`,
+            datasetCapabilities,
+            orgCapabilities: {},
+            viewCapabilities: {},
+          }),
+        });
+        yield* expectStatus("Axiom", response, [200, 201]);
+        const value = yield* parseRemoteJson("Axiom", response);
+        return yield* decodeAxiomTokenSecret(value).pipe(
+          Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
+        );
+      }),
+      regenerateToken: Effect.fn("AxiomApi.regenerateToken")(function* (credentials, id) {
+        const response = yield* remoteRequest(
+          "Axiom",
+          `https://api.axiom.co/v2/tokens/${encodeURIComponent(id)}/regenerate`,
+          { method: "POST", headers: axiomHeaders(credentials) },
+        );
+        yield* expectStatus("Axiom", response, [200]);
+        const value = yield* parseRemoteJson("Axiom", response);
+        return yield* decodeAxiomTokenSecret(value).pipe(
+          Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
+        );
+      }),
+    }),
+  );
+}
+
+const sentryHeaders = (credentials: SentryCredentials) => ({
+  Authorization: `Bearer ${credentials.token}`,
+  "Content-Type": "application/json",
+});
+
+const sentryUrl = (credentials: SentryCredentials, path: string): string =>
+  new URL(path, `${credentials.baseUrl.toString().replace(/\/$/, "")}/`).toString();
+
+export class SentryApi extends Context.Service<
+  SentryApi,
+  {
+    identity(credentials: SentryCredentials): Effect.Effect<string, RemoteApiError>;
+    ensureProject(
+      credentials: SentryCredentials,
+      slug: string,
+      platform: string,
+    ): Effect.Effect<string, RemoteApiError>;
+    dsn(credentials: SentryCredentials, project: string): Effect.Effect<string, RemoteApiError>;
+  }
+>()("@equipe-tech/observability-cli/SentryApi") {
+  static readonly layer = Layer.succeed(
+    SentryApi,
+    SentryApi.of({
+      identity: Effect.fn("SentryApi.identity")(function* (credentials) {
+        const organizationPath = `/api/0/organizations/${encodeURIComponent(credentials.organization)}/`;
+        const response = yield* remoteRequest("Sentry", sentryUrl(credentials, organizationPath), {
+          headers: sentryHeaders(credentials),
+        });
+        yield* expectStatus("Sentry", response, [200]);
+        const value = yield* parseRemoteJson("Sentry", response);
+        const organization = yield* decodeSentryOrganization(value).pipe(
+          Effect.mapError((cause) => invalidResponse("Sentry", response.status, cause)),
+        );
+        return organization.name;
+      }),
+      ensureProject: Effect.fn("SentryApi.ensureProject")(function* (credentials, slug, platform) {
+        const projectPath = `/api/0/projects/${encodeURIComponent(credentials.organization)}/${encodeURIComponent(slug)}/`;
+        const existing = yield* remoteRequest("Sentry", sentryUrl(credentials, projectPath), {
+          headers: sentryHeaders(credentials),
+        });
+        if (existing.status === 200) {
+          const value = yield* parseRemoteJson("Sentry", existing);
+          const project = yield* decodeSentryProject(value).pipe(
+            Effect.mapError((cause) => invalidResponse("Sentry", existing.status, cause)),
+          );
+          return project.slug;
+        }
+        yield* expectStatus("Sentry", existing, [404]);
+        const createPath = `/api/0/teams/${encodeURIComponent(credentials.organization)}/${encodeURIComponent(credentials.team)}/projects/`;
+        const created = yield* remoteRequest("Sentry", sentryUrl(credentials, createPath), {
+          method: "POST",
+          headers: sentryHeaders(credentials),
+          body: JSON.stringify({ name: slug, slug, platform }),
+        });
+        if (created.status === 409) {
+          return slug;
+        }
+        yield* expectStatus("Sentry", created, [200, 201]);
+        const value = yield* parseRemoteJson("Sentry", created);
+        const project = yield* decodeSentryProject(value).pipe(
+          Effect.mapError((cause) => invalidResponse("Sentry", created.status, cause)),
+        );
+        return project.slug;
+      }),
+      dsn: Effect.fn("SentryApi.dsn")(function* (credentials, project) {
+        const keysPath = `/api/0/projects/${encodeURIComponent(credentials.organization)}/${encodeURIComponent(project)}/keys/`;
+        const response = yield* remoteRequest("Sentry", sentryUrl(credentials, keysPath), {
+          headers: sentryHeaders(credentials),
+        });
+        yield* expectStatus("Sentry", response, [200]);
+        const value = yield* parseRemoteJson("Sentry", response);
+        const keys = yield* decodeSentryClientKeys(value).pipe(
+          Effect.mapError((cause) => invalidResponse("Sentry", response.status, cause)),
+        );
+        const key = keys[0];
+        if (key === undefined) {
+          return yield* new RemoteApiError({
+            code: "OBS_CLI_REMOTE_FAILED",
+            message: `Sentry project ${project} has no client key. Create a client key and retry.`,
+            provider: "Sentry",
+            status: 404,
+            cause: project,
+          });
+        }
+        return key.dsn.public;
+      }),
+    }),
+  );
+}

--- a/packages/cli/src/ProvisionAssets.ts
+++ b/packages/cli/src/ProvisionAssets.ts
@@ -134,6 +134,10 @@ export const provisionAssets = Effect.fn("provisionAssets")(function* (
 export class ProvisionAssets extends Context.Service<
   ProvisionAssets,
   {
+    resolveName(
+      directory: string,
+      name: Option.Option<string>,
+    ): Effect.Effect<string, ProvisionError>;
     provision(
       directory: string,
       name: Option.Option<string>,
@@ -147,14 +151,23 @@ export class ProvisionAssets extends Context.Service<
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
 
+      const resolveName = Effect.fn("ProvisionAssets.resolveName")(function* (
+        directory: string,
+        name: Option.Option<string>,
+      ) {
+        const resolved = path.resolve(directory);
+        return yield* Option.match(name, {
+          onNone: () => projectNameFromDirectory(path.basename(resolved)),
+          onSome: parseProjectName,
+        });
+      });
+
       return ProvisionAssets.of({
+        resolveName,
         provision: (directory, name, force) =>
           Effect.gen(function* () {
             const resolved = path.resolve(directory);
-            const projectName = yield* Option.match(name, {
-              onNone: () => projectNameFromDirectory(path.basename(resolved)),
-              onSome: parseProjectName,
-            });
+            const projectName = yield* resolveName(directory, name);
             return yield* provisionAssets(packagedAssetsDirectory, resolved, projectName, force);
           }).pipe(
             Effect.provideService(FileSystem.FileSystem, fs),

--- a/packages/cli/src/RemoteEnvironment.ts
+++ b/packages/cli/src/RemoteEnvironment.ts
@@ -1,0 +1,342 @@
+import { Context, Effect, Layer, Option, Schema } from "effect";
+import {
+  AxiomCredentials,
+  CredentialsError,
+  CredentialsFile,
+  CredentialsStore,
+  emptyCredentials,
+  ManagedEnvironment,
+  SentryCredentials,
+} from "./CredentialsStore.ts";
+import { AxiomApi, RemoteApiError, SentryApi } from "./ProviderApis.ts";
+
+const EnvironmentName = Schema.NonEmptyString.check(
+  Schema.isMaxLength(32),
+  Schema.isPattern(/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/, {
+    expected: "a lowercase environment name with letters, digits and single dashes",
+  }),
+);
+const DatasetName = Schema.NonEmptyString.check(Schema.isMaxLength(128));
+const decodeEnvironmentName = Schema.decodeUnknownEffect(EnvironmentName);
+const decodeDatasetName = Schema.decodeUnknownEffect(DatasetName);
+
+export class RemoteEnvironmentError extends Schema.TaggedError<RemoteEnvironmentError>()(
+  "RemoteEnvironmentError",
+  {
+    code: Schema.Literals([
+      "OBS_CLI_REMOTE_CREDENTIALS_MISSING",
+      "OBS_CLI_REMOTE_INVALID_ENVIRONMENT",
+      "OBS_CLI_REMOTE_TOKEN_UNAVAILABLE",
+      "OBS_CLI_REMOTE_ENVIRONMENT_NOT_FOUND",
+    ]),
+    message: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {}
+
+export type EnvironmentDatasets = {
+  readonly traces: string;
+  readonly logs: string;
+  readonly metrics: string;
+};
+
+export const parseEnvironmentName = Effect.fn("parseEnvironmentName")(function* (
+  environment: string,
+): Effect.fn.Return<string, RemoteEnvironmentError> {
+  return yield* decodeEnvironmentName(environment).pipe(
+    Effect.mapError(
+      (cause) =>
+        new RemoteEnvironmentError({
+          code: "OBS_CLI_REMOTE_INVALID_ENVIRONMENT",
+          message:
+            "The environment name is invalid. Use lowercase letters, digits and single dashes, with at most 32 characters.",
+          cause,
+        }),
+    ),
+  );
+});
+
+export const environmentDatasets = Effect.fn("environmentDatasets")(function* (
+  project: string,
+  environment: string,
+): Effect.fn.Return<EnvironmentDatasets, RemoteEnvironmentError> {
+  const names = {
+    traces: `${project}-${environment}-traces`,
+    logs: `${project}-${environment}-logs`,
+    metrics: `${project}-${environment}-metrics`,
+  };
+  for (const name of [names.traces, names.logs, names.metrics]) {
+    yield* decodeDatasetName(name).pipe(
+      Effect.mapError(
+        (cause) =>
+          new RemoteEnvironmentError({
+            code: "OBS_CLI_REMOTE_INVALID_ENVIRONMENT",
+            message:
+              "The project and environment names produce a dataset name longer than 128 characters. Use shorter names.",
+            cause,
+          }),
+      ),
+    );
+  }
+  return names;
+});
+
+const requiredCredentials = (
+  credentials: CredentialsFile,
+): Effect.Effect<
+  { readonly axiom: AxiomCredentials; readonly sentry: SentryCredentials },
+  RemoteEnvironmentError
+> => {
+  if (credentials.axiom === undefined || credentials.sentry === undefined) {
+    return Effect.fail(
+      new RemoteEnvironmentError({
+        code: "OBS_CLI_REMOTE_CREDENTIALS_MISSING",
+        message:
+          "Remote provisioning requires Axiom and Sentry credentials. Run observability auth login for both providers.",
+        cause: "credentials",
+      }),
+    );
+  }
+  return Effect.succeed({ axiom: credentials.axiom, sentry: credentials.sentry });
+};
+
+const currentCredentials = Effect.fn("currentCredentials")(function* (
+  store: CredentialsStore["Service"],
+): Effect.fn.Return<CredentialsFile, CredentialsError> {
+  const current = yield* store.load();
+  return Option.getOrElse(current, emptyCredentials);
+});
+
+const makeCredentialsFile = (
+  axiom: AxiomCredentials | undefined,
+  sentry: SentryCredentials | undefined,
+  environments: ReadonlyArray<ManagedEnvironment>,
+): CredentialsFile => {
+  if (axiom !== undefined && sentry !== undefined) {
+    return new CredentialsFile({ version: 1, axiom, sentry, environments });
+  }
+  if (axiom !== undefined) {
+    return new CredentialsFile({ version: 1, axiom, environments });
+  }
+  if (sentry !== undefined) {
+    return new CredentialsFile({ version: 1, sentry, environments });
+  }
+  return new CredentialsFile({ version: 1, environments });
+};
+
+const replaceEnvironment = (
+  credentials: CredentialsFile,
+  environment: ManagedEnvironment,
+): CredentialsFile =>
+  makeCredentialsFile(credentials.axiom, credentials.sentry, [
+    ...credentials.environments.filter(
+      (candidate) =>
+        candidate.project !== environment.project ||
+        candidate.environment !== environment.environment,
+    ),
+    environment,
+  ]);
+
+export type AuthenticationStatus = {
+  readonly axiom: string;
+  readonly sentry: string;
+  readonly credentialsPath: string;
+};
+
+export class Authentication extends Context.Service<
+  Authentication,
+  {
+    loginAxiom(
+      token: string,
+      organizationId: string,
+    ): Effect.Effect<string, CredentialsError | RemoteApiError>;
+    loginSentry(
+      token: string,
+      organization: string,
+      team: string,
+      baseUrl: URL,
+    ): Effect.Effect<string, CredentialsError | RemoteApiError>;
+    status(): Effect.Effect<AuthenticationStatus, CredentialsError | RemoteApiError>;
+  }
+>()("@equipe-tech/observability-cli/Authentication") {
+  static readonly layer = Layer.effect(
+    Authentication,
+    Effect.gen(function* () {
+      const store = yield* CredentialsStore;
+      const axiomApi = yield* AxiomApi;
+      const sentryApi = yield* SentryApi;
+
+      return Authentication.of({
+        loginAxiom: Effect.fn("Authentication.loginAxiom")(function* (token, organizationId) {
+          const credentials = new AxiomCredentials({ token, organizationId });
+          const identity = yield* axiomApi.identity(credentials);
+          const current = yield* currentCredentials(store);
+          yield* store.save(makeCredentialsFile(credentials, current.sentry, current.environments));
+          return identity;
+        }),
+        loginSentry: Effect.fn("Authentication.loginSentry")(
+          function* (token, organization, team, baseUrl) {
+            const credentials = new SentryCredentials({ token, organization, team, baseUrl });
+            const identity = yield* sentryApi.identity(credentials);
+            const current = yield* currentCredentials(store);
+            yield* store.save(
+              makeCredentialsFile(current.axiom, credentials, current.environments),
+            );
+            return identity;
+          },
+        ),
+        status: Effect.fn("Authentication.status")(function* () {
+          const current = yield* currentCredentials(store);
+          const axiom =
+            current.axiom === undefined
+              ? "not authenticated"
+              : yield* axiomApi.identity(current.axiom);
+          const sentry =
+            current.sentry === undefined
+              ? "not authenticated"
+              : yield* sentryApi.identity(current.sentry);
+          return { axiom, sentry, credentialsPath: store.path };
+        }),
+      });
+    }),
+  );
+}
+
+export class RemoteEnvironment extends Context.Service<
+  RemoteEnvironment,
+  {
+    provision(
+      project: string,
+      environments: ReadonlyArray<string>,
+      platform: string,
+      rotateToken: boolean,
+    ): Effect.Effect<
+      ReadonlyArray<ManagedEnvironment>,
+      CredentialsError | RemoteApiError | RemoteEnvironmentError
+    >;
+    list(
+      project: Option.Option<string>,
+    ): Effect.Effect<ReadonlyArray<ManagedEnvironment>, CredentialsError>;
+    export(
+      project: string,
+      environment: string,
+    ): Effect.Effect<string, CredentialsError | RemoteEnvironmentError>;
+  }
+>()("@equipe-tech/observability-cli/RemoteEnvironment") {
+  static readonly layer = Layer.effect(
+    RemoteEnvironment,
+    Effect.gen(function* () {
+      const store = yield* CredentialsStore;
+      const axiomApi = yield* AxiomApi;
+      const sentryApi = yield* SentryApi;
+
+      const list = Effect.fn("RemoteEnvironment.list")(function* (project: Option.Option<string>) {
+        const credentials = yield* currentCredentials(store);
+        return Option.match(project, {
+          onNone: () => credentials.environments,
+          onSome: (name) =>
+            credentials.environments.filter((environment) => environment.project === name),
+        });
+      });
+
+      return RemoteEnvironment.of({
+        provision: Effect.fn("RemoteEnvironment.provision")(
+          function* (project, environments, platform, rotateToken) {
+            let credentials = yield* currentCredentials(store);
+            const providers = yield* requiredCredentials(credentials);
+            const existingDatasets = [...(yield* axiomApi.datasets(providers.axiom))];
+            const existingTokens = [...(yield* axiomApi.tokens(providers.axiom))];
+            const sentryProject = yield* sentryApi.ensureProject(
+              providers.sentry,
+              project,
+              platform,
+            );
+            const sentryDsn = yield* sentryApi.dsn(providers.sentry, sentryProject);
+            const provisioned: Array<ManagedEnvironment> = [];
+
+            for (const rawEnvironment of environments) {
+              const environment = yield* parseEnvironmentName(rawEnvironment);
+              const datasets = yield* environmentDatasets(project, environment);
+              const datasetNames = [datasets.traces, datasets.logs, datasets.metrics];
+              for (const dataset of datasetNames) {
+                if (!existingDatasets.includes(dataset)) {
+                  yield* axiomApi.createDataset(providers.axiom, dataset);
+                  existingDatasets.push(dataset);
+                }
+              }
+
+              const tokenName = `${project}-${environment}-collector`;
+              const remoteToken = existingTokens.find((token) => token.name === tokenName);
+              const managed = credentials.environments.find(
+                (candidate) =>
+                  candidate.project === project && candidate.environment === environment,
+              );
+              let token: { readonly id: string; readonly token: string };
+              if (rotateToken && remoteToken !== undefined) {
+                token = yield* axiomApi.regenerateToken(providers.axiom, remoteToken.id);
+              } else if (managed !== undefined && !rotateToken) {
+                if (remoteToken === undefined || remoteToken.id !== managed.axiomTokenId) {
+                  return yield* new RemoteEnvironmentError({
+                    code: "OBS_CLI_REMOTE_TOKEN_UNAVAILABLE",
+                    message: `The stored token for ${project}/${environment} does not match Axiom. Rerun with --rotate-token.`,
+                    cause: tokenName,
+                  });
+                }
+                token = { id: managed.axiomTokenId, token: managed.axiomToken };
+              } else if (remoteToken !== undefined) {
+                return yield* new RemoteEnvironmentError({
+                  code: "OBS_CLI_REMOTE_TOKEN_UNAVAILABLE",
+                  message: `Axiom already contains token ${tokenName}, but its secret is unavailable. Rerun with --rotate-token.`,
+                  cause: tokenName,
+                });
+              } else {
+                token = yield* axiomApi.createToken(providers.axiom, tokenName, datasetNames);
+                existingTokens.push({ id: token.id, name: tokenName });
+              }
+
+              const result = new ManagedEnvironment({
+                project,
+                environment,
+                axiomTokenId: token.id,
+                axiomToken: token.token,
+                tracesDataset: datasets.traces,
+                logsDataset: datasets.logs,
+                metricsDataset: datasets.metrics,
+                sentryProject,
+                sentryDsn,
+              });
+              credentials = replaceEnvironment(credentials, result);
+              yield* store.save(credentials);
+              provisioned.push(result);
+            }
+            return provisioned;
+          },
+        ),
+        list,
+        export: Effect.fn("RemoteEnvironment.export")(function* (project, rawEnvironment) {
+          const environment = yield* parseEnvironmentName(rawEnvironment);
+          const environments = yield* list(Option.some(project));
+          const managed = environments.find((candidate) => candidate.environment === environment);
+          if (managed === undefined) {
+            return yield* new RemoteEnvironmentError({
+              code: "OBS_CLI_REMOTE_ENVIRONMENT_NOT_FOUND",
+              message: `Environment ${project}/${environment} is not configured. Run observability provision with --environment ${environment}.`,
+              cause: `${project}/${environment}`,
+            });
+          }
+          const variables = [
+            ["OTEL_SERVICE_NAME", managed.project],
+            ["OTEL_DEPLOYMENT_ENVIRONMENT", managed.environment],
+            ["OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector:4318"],
+            ["AXIOM_TOKEN", managed.axiomToken],
+            ["AXIOM_DATASET_TRACES", managed.tracesDataset],
+            ["AXIOM_DATASET_LOGS", managed.logsDataset],
+            ["AXIOM_DATASET_METRICS", managed.metricsDataset],
+            ["SENTRY_DSN", managed.sentryDsn],
+          ];
+          return variables.map(([name, value]) => `${name}=${JSON.stringify(value)}`).join("\n");
+        }),
+      });
+    }),
+  );
+}

--- a/packages/cli/src/assets/kamal.accessory.yml
+++ b/packages/cli/src/assets/kamal.accessory.yml
@@ -12,6 +12,6 @@ accessories:
       secret:
         - AXIOM_TOKEN
       clear:
-        AXIOM_DATASET_TRACES: "{{name}}-traces"
-        AXIOM_DATASET_LOGS: "{{name}}-logs"
-        AXIOM_DATASET_METRICS: "{{name}}-metrics"
+        AXIOM_DATASET_TRACES: <%= ENV.fetch("AXIOM_DATASET_TRACES", "{{name}}-traces") %>
+        AXIOM_DATASET_LOGS: <%= ENV.fetch("AXIOM_DATASET_LOGS", "{{name}}-logs") %>
+        AXIOM_DATASET_METRICS: <%= ENV.fetch("AXIOM_DATASET_METRICS", "{{name}}-metrics") %>

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -3,16 +3,25 @@ import { BunRuntime, BunServices } from "@effect/platform-bun";
 import { Console, Effect, Layer, Option } from "effect";
 import { Command } from "effect/unstable/cli";
 import { observability } from "./Cli.ts";
+import { CredentialsStore } from "./CredentialsStore.ts";
 import { DockerCompose } from "./DockerCompose.ts";
 import { packageVersion } from "./PackageVersion.ts";
 import { publicErrorFromCause } from "./ErrorReporter.ts";
 import { ProvisionAssets } from "./ProvisionAssets.ts";
+import { AxiomApi, SentryApi } from "./ProviderApis.ts";
+import { Authentication, RemoteEnvironment } from "./RemoteEnvironment.ts";
 import { StackAssets } from "./StackAssets.ts";
 
+const ProviderLayer = Layer.mergeAll(CredentialsStore.layer, AxiomApi.layer, SentryApi.layer);
+const RemoteLayer = Layer.mergeAll(Authentication.layer, RemoteEnvironment.layer).pipe(
+  Layer.provide(ProviderLayer),
+);
 const MainLayer = Layer.mergeAll(
   DockerCompose.layer,
   StackAssets.layer,
   ProvisionAssets.layer,
+  ProviderLayer,
+  RemoteLayer,
 ).pipe(Layer.provideMerge(BunServices.layer));
 
 observability.pipe(
@@ -24,6 +33,12 @@ observability.pipe(
     StackAssetsError: (error) =>
       Console.error(`${error.code}: ${error.message}`).pipe(Effect.andThen(Effect.fail(error))),
     ProvisionError: (error) =>
+      Console.error(`${error.code}: ${error.message}`).pipe(Effect.andThen(Effect.fail(error))),
+    CredentialsError: (error) =>
+      Console.error(`${error.code}: ${error.message}`).pipe(Effect.andThen(Effect.fail(error))),
+    RemoteApiError: (error) =>
+      Console.error(`${error.code}: ${error.message}`).pipe(Effect.andThen(Effect.fail(error))),
+    RemoteEnvironmentError: (error) =>
       Console.error(`${error.code}: ${error.message}`).pipe(Effect.andThen(Effect.fail(error))),
   }),
   Effect.catchCause((cause) =>

--- a/packages/cli/test/CredentialsStore.bun.test.ts
+++ b/packages/cli/test/CredentialsStore.bun.test.ts
@@ -1,0 +1,97 @@
+import { BunServices } from "@effect/platform-bun";
+import { describe, expect, test } from "bun:test";
+import { Effect, FileSystem, Option } from "effect";
+import {
+  AxiomCredentials,
+  CredentialsFile,
+  CredentialsStore,
+  SentryCredentials,
+} from "../src/CredentialsStore.ts";
+
+describe("CredentialsStore", () => {
+  test.serial("writes credentials with owner-only permissions and reads them back", async () => {
+    const previousHome = process.env.OBSERVABILITY_HOME;
+    const root = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        return yield* fs.makeTempDirectory({ prefix: "observability-credentials-" });
+      }).pipe(Effect.provide(BunServices.layer)),
+    );
+    process.env.OBSERVABILITY_HOME = root;
+
+    try {
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const store = yield* CredentialsStore;
+          const fs = yield* FileSystem.FileSystem;
+          yield* store.save(
+            new CredentialsFile({
+              version: 1,
+              axiom: new AxiomCredentials({
+                token: "xapt-secret",
+                organizationId: "org-id",
+              }),
+              sentry: new SentryCredentials({
+                token: "sentry-secret",
+                organization: "maxxi-cash",
+                team: "backend",
+                baseUrl: new URL("https://sentry.io"),
+              }),
+              environments: [],
+            }),
+          );
+          const loaded = yield* store.load();
+          const info = yield* fs.stat(store.path);
+          return { loaded, mode: info.mode & 0o777 };
+        }).pipe(Effect.provide(CredentialsStore.layer), Effect.provide(BunServices.layer)),
+      );
+
+      expect(result.mode).toBe(0o600);
+      expect(Option.isSome(result.loaded)).toBeTrue();
+      if (Option.isSome(result.loaded)) {
+        expect(result.loaded.value.axiom?.organizationId).toBe("org-id");
+        expect(result.loaded.value.axiom?.token).toBe("xapt-secret");
+        expect(result.loaded.value.sentry?.organization).toBe("maxxi-cash");
+        expect(result.loaded.value.sentry?.baseUrl.toString()).toBe("https://sentry.io/");
+      }
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.OBSERVABILITY_HOME;
+      } else {
+        process.env.OBSERVABILITY_HOME = previousHome;
+      }
+    }
+  });
+
+  test.serial("rejects a credentials file that other users can read", async () => {
+    const previousHome = process.env.OBSERVABILITY_HOME;
+    const root = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        return yield* fs.makeTempDirectory({ prefix: "observability-insecure-" });
+      }).pipe(Effect.provide(BunServices.layer)),
+    );
+    process.env.OBSERVABILITY_HOME = root;
+
+    try {
+      const error = await Effect.runPromise(
+        Effect.gen(function* () {
+          const store = yield* CredentialsStore;
+          const fs = yield* FileSystem.FileSystem;
+          yield* store.save(new CredentialsFile({ version: 1, environments: [] }));
+          yield* fs.chmod(store.path, 0o644);
+          return yield* Effect.flip(store.load());
+        }).pipe(Effect.provide(CredentialsStore.layer), Effect.provide(BunServices.layer)),
+      );
+
+      expect(error.code).toBe("OBS_CLI_CREDENTIALS_INSECURE");
+      expect(error.message).toContain("chmod 600");
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.OBSERVABILITY_HOME;
+      } else {
+        process.env.OBSERVABILITY_HOME = previousHome;
+      }
+    }
+  });
+});

--- a/packages/cli/test/RemoteEnvironment.bun.test.ts
+++ b/packages/cli/test/RemoteEnvironment.bun.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Layer, Option } from "effect";
+import {
+  AxiomCredentials,
+  CredentialsFile,
+  CredentialsStore,
+  SentryCredentials,
+} from "../src/CredentialsStore.ts";
+import { AxiomApi, SentryApi } from "../src/ProviderApis.ts";
+import {
+  environmentDatasets,
+  parseEnvironmentName,
+  RemoteEnvironment,
+} from "../src/RemoteEnvironment.ts";
+
+const makeRemoteLayer = () => {
+  let credentials = new CredentialsFile({
+    version: 1,
+    axiom: new AxiomCredentials({ token: "xapt-admin", organizationId: "org-id" }),
+    sentry: new SentryCredentials({
+      token: "sentry-admin",
+      organization: "maxxi-cash",
+      team: "backend",
+      baseUrl: new URL("https://sentry.io"),
+    }),
+    environments: [],
+  });
+  const datasets: Array<string> = [];
+  const tokens: Array<{ readonly id: string; readonly name: string }> = [];
+  let tokenCreations = 0;
+  let tokenRegenerations = 0;
+
+  const store = CredentialsStore.of({
+    path: "/private/credentials.json",
+    load: () => Effect.succeed(Option.some(credentials)),
+    save: (next) => Effect.sync(() => void (credentials = next)),
+  });
+  const axiom = AxiomApi.of({
+    identity: () => Effect.succeed("owner@example.com"),
+    datasets: () => Effect.succeed(datasets),
+    createDataset: (_credentials, name) =>
+      Effect.sync(() => {
+        datasets.push(name);
+      }),
+    tokens: () => Effect.succeed(tokens),
+    createToken: (_credentials, name) =>
+      Effect.sync(() => {
+        tokenCreations += 1;
+        const token = { id: `token-${tokenCreations}`, name };
+        tokens.push(token);
+        return { id: token.id, token: `secret-${tokenCreations}` };
+      }),
+    regenerateToken: (_credentials, id) =>
+      Effect.sync(() => {
+        tokenRegenerations += 1;
+        return { id, token: `rotated-${tokenRegenerations}` };
+      }),
+  });
+  const sentry = SentryApi.of({
+    identity: () => Effect.succeed("Maxxi Cash"),
+    ensureProject: (_credentials, slug) => Effect.succeed(slug),
+    dsn: () => Effect.succeed("https://public@sentry.example/1"),
+  });
+  const dependencies = Layer.mergeAll(
+    Layer.succeed(CredentialsStore, store),
+    Layer.succeed(AxiomApi, axiom),
+    Layer.succeed(SentryApi, sentry),
+  );
+
+  return {
+    layer: RemoteEnvironment.layer.pipe(Layer.provide(dependencies)),
+    state: () => ({ credentials, datasets, tokens, tokenCreations, tokenRegenerations }),
+  };
+};
+
+describe("environment names", () => {
+  test("builds one dataset per signal and environment", async () => {
+    const result = await Effect.runPromise(environmentDatasets("livro-caixa", "staging"));
+    expect(result).toEqual({
+      traces: "livro-caixa-staging-traces",
+      logs: "livro-caixa-staging-logs",
+      metrics: "livro-caixa-staging-metrics",
+    });
+  });
+
+  test("rejects malformed environment names", async () => {
+    const error = await Effect.runPromise(Effect.flip(parseEnvironmentName("Production US")));
+    expect(error.code).toBe("OBS_CLI_REMOTE_INVALID_ENVIRONMENT");
+  });
+});
+
+describe("RemoteEnvironment", () => {
+  test("provisions isolated datasets and one reusable ingest token", async () => {
+    const remote = makeRemoteLayer();
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        const first = yield* service.provision("livro-caixa", ["staging"], "node", false);
+        const second = yield* service.provision("livro-caixa", ["staging"], "node", false);
+        const exported = yield* service.export("livro-caixa", "staging");
+        return { first, second, exported };
+      }).pipe(Effect.provide(remote.layer)),
+    );
+    const state = remote.state();
+
+    expect(result.first).toHaveLength(1);
+    expect(result.second).toHaveLength(1);
+    expect(state.datasets).toEqual([
+      "livro-caixa-staging-traces",
+      "livro-caixa-staging-logs",
+      "livro-caixa-staging-metrics",
+    ]);
+    expect(state.tokenCreations).toBe(1);
+    expect(state.credentials.environments).toHaveLength(1);
+    expect(result.exported).toContain('OTEL_DEPLOYMENT_ENVIRONMENT="staging"');
+    expect(result.exported).toContain('AXIOM_TOKEN="secret-1"');
+    expect(result.exported).toContain('SENTRY_DSN="https://public@sentry.example/1"');
+  });
+
+  test("requires rotation when the remote token has no local secret", async () => {
+    const remote = makeRemoteLayer();
+    remote.state().tokens.push({
+      id: "existing-token",
+      name: "livro-caixa-staging-collector",
+    });
+
+    const error = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        return yield* Effect.flip(service.provision("livro-caixa", ["staging"], "node", false));
+      }).pipe(Effect.provide(remote.layer)),
+    );
+
+    expect(error._tag).toBe("RemoteEnvironmentError");
+    if (error._tag === "RemoteEnvironmentError") {
+      expect(error.code).toBe("OBS_CLI_REMOTE_TOKEN_UNAVAILABLE");
+      expect(error.message).toContain("--rotate-token");
+      expect(error.message).not.toContain("xapt-admin");
+      expect(error.message).not.toContain("sentry-admin");
+    }
+  });
+
+  test("rotates an existing Axiom token only when requested", async () => {
+    const remote = makeRemoteLayer();
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        yield* service.provision("livro-caixa", ["production"], "node", false);
+        return yield* service.provision("livro-caixa", ["production"], "node", true);
+      }).pipe(Effect.provide(remote.layer)),
+    );
+    const state = remote.state();
+
+    expect(state.tokenCreations).toBe(1);
+    expect(state.tokenRegenerations).toBe(1);
+    expect(result[0]?.axiomToken).toBe("rotated-1");
+    expect(state.credentials.environments[0]?.axiomToken).toBe("rotated-1");
+  });
+});


### PR DESCRIPTION
## Summary

- add authenticated Axiom and Sentry provider clients
- provision isolated datasets and ingest tokens for each environment
- persist credentials with owner-only file permissions
- add environment inspection, dotenv export, and token rotation commands
- document the environment model, setup flow, CLI contract, and errors

## Security

- request administrative tokens through protected prompts
- keep runtime secrets out of provisioned project assets
- scope each Axiom token to one environment and its three datasets
- reject credential files that permit group or public access

## Verification

- `bun run check`
- `bun run test`
- `bun run build`
- `bun run test:package`

The deployed provider flow requires real Axiom and Sentry credentials. The local suite uses provider service fakes and covers idempotency, rotation, permissions, and secret export.
