### PR TITLE
OBS-2 Redact sensitive Collector telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,14 @@ OBSERVABILITY_E2E=1 bun test:canary
 
 ### Canário deployed (Axiom)
 
-O alvo `deployed` roda o mesmo canário contra a fronteira de aceitação real: aplicação -> Collector com a configuração de produção -> Axiom -> consulta APL. Requisitos: um Collector local com `production.yaml` apontado para datasets E2E dedicados e as variáveis `AXIOM_TOKEN`, `AXIOM_DATASET_TRACES` e `AXIOM_DATASET_LOGS`.
+O alvo `deployed` roda o canário na fronteira de aceitação real. A fronteira é aplicação -> Collector -> Axiom. O teste usa APL para traces e logs. O teste usa MPL para métricas.
+
+Use `production.yaml` com datasets E2E dedicados. Defina estas variáveis:
+
+- `AXIOM_TOKEN`.
+- `AXIOM_DATASET_TRACES`.
+- `AXIOM_DATASET_LOGS`.
+- `AXIOM_DATASET_METRICS`.
 
 ```sh
 OBSERVABILITY_E2E_DEPLOYED=1 bun test:canary:deployed

--- a/packages/cli/src/assets/local.yaml
+++ b/packages/cli/src/assets/local.yaml
@@ -11,6 +11,36 @@ processors:
     check_interval: 1s
     limit_mib: 256
     spike_limit_mib: 64
+  transform/redact:
+    error_mode: propagate
+    trace_statements:
+      - 'replace_pattern(spanevent.name, "(?i)(\"(?:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)\"[[:space:]]*:[[:space:]]*)(?:\"[^\"]*\"|[^,}[:space:]]+)", "$$1\"[REDACTED]\"")'
+      - 'replace_pattern(spanevent.name, "(?i)((?:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)[[:space:]]*[=:][[:space:]]*)(?:\"[^\"]*\"|[^,;[:space:]]+)", "$$1[REDACTED]")'
+      - 'replace_pattern(spanevent.name, "(?i)Bearer[[:space:]]+[A-Za-z0-9._~+/=-]+", "[REDACTED]")'
+      - 'replace_pattern(spanevent.name, "(?:sk|rk)[_-][A-Za-z0-9_*.-]{3,}", "[REDACTED]")'
+      - 'replace_pattern(spanevent.name, "eyJ[A-Za-z0-9_-]+[.]eyJ[A-Za-z0-9_-]+[.][A-Za-z0-9_-]+", "[REDACTED]")'
+      - 'replace_pattern(spanevent.name, "(?i)[A-Z0-9._%+-]+@[A-Z0-9.-]+[.][A-Z]{2,}", "[REDACTED]")'
+      - 'replace_pattern(spanevent.name, "(?s)-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----.*?-----END (?:RSA |EC |OPENSSH )?PRIVATE KEY-----", "[REDACTED]")'
+    log_statements:
+      - 'replace_pattern(log.body, "(?i)(\"(?:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)\"[[:space:]]*:[[:space:]]*)(?:\"[^\"]*\"|[^,}[:space:]]+)", "$$1\"[REDACTED]\"") where IsString(log.body)'
+      - 'replace_pattern(log.body, "(?i)((?:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)[[:space:]]*[=:][[:space:]]*)(?:\"[^\"]*\"|[^,;[:space:]]+)", "$$1[REDACTED]") where IsString(log.body)'
+      - 'replace_pattern(log.body, "(?i)Bearer[[:space:]]+[A-Za-z0-9._~+/=-]+", "[REDACTED]") where IsString(log.body)'
+      - 'replace_pattern(log.body, "(?:sk|rk)[_-][A-Za-z0-9_*.-]{3,}", "[REDACTED]") where IsString(log.body)'
+      - 'replace_pattern(log.body, "eyJ[A-Za-z0-9_-]+[.]eyJ[A-Za-z0-9_-]+[.][A-Za-z0-9_-]+", "[REDACTED]") where IsString(log.body)'
+      - 'replace_pattern(log.body, "(?i)[A-Z0-9._%+-]+@[A-Z0-9.-]+[.][A-Z]{2,}", "[REDACTED]") where IsString(log.body)'
+      - 'replace_pattern(log.body, "(?s)-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----.*?-----END (?:RSA |EC |OPENSSH )?PRIVATE KEY-----", "[REDACTED]") where IsString(log.body)'
+  redaction/sensitive:
+    allow_all_keys: true
+    blocked_key_patterns:
+      - "(?i)(^|[._-])(authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)([._-]|$)"
+    blocked_values:
+      - "(?i)Bearer[[:space:]]+[A-Za-z0-9._~+/=-]+"
+      - "(?:sk|rk)[_-][A-Za-z0-9_*.-]{3,}"
+      - "eyJ[A-Za-z0-9_-]+[.]eyJ[A-Za-z0-9_-]+[.][A-Za-z0-9_-]+"
+      - "(?i)[A-Z0-9._%+-]+@[A-Z0-9.-]+[.][A-Z]{2,}"
+      - "(?s)-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----.*?-----END (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"
+    redact_all_types: true
+    summary: silent
   batch:
     send_batch_size: 512
     timeout: 1s
@@ -28,13 +58,13 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [memory_limiter, batch]
+      processors: [memory_limiter, transform/redact, redaction/sensitive, batch]
       exporters: [otlp/viewer, file/telemetry]
     logs:
       receivers: [otlp]
-      processors: [memory_limiter, batch]
+      processors: [memory_limiter, transform/redact, redaction/sensitive, batch]
       exporters: [otlp/viewer, file/telemetry]
     metrics:
       receivers: [otlp]
-      processors: [memory_limiter, batch]
+      processors: [memory_limiter, redaction/sensitive, batch]
       exporters: [otlp/viewer, file/telemetry]

--- a/packages/cli/src/assets/local.yaml
+++ b/packages/cli/src/assets/local.yaml
@@ -14,16 +14,16 @@ processors:
   transform/redact:
     error_mode: propagate
     trace_statements:
-      - 'replace_pattern(spanevent.name, "(?i)(\"(?:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)\"[[:space:]]*:[[:space:]]*)(?:\"[^\"]*\"|[^,}[:space:]]+)", "$$1\"[REDACTED]\"")'
-      - 'replace_pattern(spanevent.name, "(?i)((?:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)[[:space:]]*[=:][[:space:]]*)(?:\"[^\"]*\"|[^,;[:space:]]+)", "$$1[REDACTED]")'
+      - 'replace_pattern(spanevent.name, "(\"[A-Za-z0-9_.-]*(?i:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)(?:(?:[._-]|[A-Z0-9])[A-Za-z0-9_.-]*)?\"[[:space:]]*:[[:space:]]*)(?:\"(?:[^\"\\\\]|\\\\.)*\"|[^,}[:space:]]+)", "$$1\"[REDACTED]\"")'
+      - 'replace_pattern(spanevent.name, "([A-Za-z0-9_.-]*(?i:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)(?:(?:[._-]|[A-Z0-9])[A-Za-z0-9_.-]*)?[[:space:]]*[=:][[:space:]]*)(?:\"(?:[^\"\\\\]|\\\\.)*\"|[^,;[:space:]]+)", "$$1[REDACTED]")'
       - 'replace_pattern(spanevent.name, "(?i)Bearer[[:space:]]+[A-Za-z0-9._~+/=-]+", "[REDACTED]")'
       - 'replace_pattern(spanevent.name, "(?:sk|rk)[_-][A-Za-z0-9_*.-]{3,}", "[REDACTED]")'
       - 'replace_pattern(spanevent.name, "eyJ[A-Za-z0-9_-]+[.]eyJ[A-Za-z0-9_-]+[.][A-Za-z0-9_-]+", "[REDACTED]")'
       - 'replace_pattern(spanevent.name, "(?i)[A-Z0-9._%+-]+@[A-Z0-9.-]+[.][A-Z]{2,}", "[REDACTED]")'
       - 'replace_pattern(spanevent.name, "(?s)-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----.*?-----END (?:RSA |EC |OPENSSH )?PRIVATE KEY-----", "[REDACTED]")'
     log_statements:
-      - 'replace_pattern(log.body, "(?i)(\"(?:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)\"[[:space:]]*:[[:space:]]*)(?:\"[^\"]*\"|[^,}[:space:]]+)", "$$1\"[REDACTED]\"") where IsString(log.body)'
-      - 'replace_pattern(log.body, "(?i)((?:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)[[:space:]]*[=:][[:space:]]*)(?:\"[^\"]*\"|[^,;[:space:]]+)", "$$1[REDACTED]") where IsString(log.body)'
+      - 'replace_pattern(log.body, "(\"[A-Za-z0-9_.-]*(?i:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)(?:(?:[._-]|[A-Z0-9])[A-Za-z0-9_.-]*)?\"[[:space:]]*:[[:space:]]*)(?:\"(?:[^\"\\\\]|\\\\.)*\"|[^,}[:space:]]+)", "$$1\"[REDACTED]\"") where IsString(log.body)'
+      - 'replace_pattern(log.body, "([A-Za-z0-9_.-]*(?i:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)(?:(?:[._-]|[A-Z0-9])[A-Za-z0-9_.-]*)?[[:space:]]*[=:][[:space:]]*)(?:\"(?:[^\"\\\\]|\\\\.)*\"|[^,;[:space:]]+)", "$$1[REDACTED]") where IsString(log.body)'
       - 'replace_pattern(log.body, "(?i)Bearer[[:space:]]+[A-Za-z0-9._~+/=-]+", "[REDACTED]") where IsString(log.body)'
       - 'replace_pattern(log.body, "(?:sk|rk)[_-][A-Za-z0-9_*.-]{3,}", "[REDACTED]") where IsString(log.body)'
       - 'replace_pattern(log.body, "eyJ[A-Za-z0-9_-]+[.]eyJ[A-Za-z0-9_-]+[.][A-Za-z0-9_-]+", "[REDACTED]") where IsString(log.body)'
@@ -32,7 +32,7 @@ processors:
   redaction/sensitive:
     allow_all_keys: true
     blocked_key_patterns:
-      - "(?i)(^|[._-])(authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)([._-]|$)"
+      - "(?i:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)(?:[._-]|[A-Z0-9]|$)"
     blocked_values:
       - "(?i)Bearer[[:space:]]+[A-Za-z0-9._~+/=-]+"
       - "(?:sk|rk)[_-][A-Za-z0-9_*.-]{3,}"

--- a/packages/cli/src/assets/production.yaml
+++ b/packages/cli/src/assets/production.yaml
@@ -16,6 +16,36 @@ processors:
     check_interval: 1s
     limit_mib: 512
     spike_limit_mib: 128
+  transform/redact:
+    error_mode: propagate
+    trace_statements:
+      - 'replace_pattern(spanevent.name, "(?i)(\"(?:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)\"[[:space:]]*:[[:space:]]*)(?:\"[^\"]*\"|[^,}[:space:]]+)", "$$1\"[REDACTED]\"")'
+      - 'replace_pattern(spanevent.name, "(?i)((?:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)[[:space:]]*[=:][[:space:]]*)(?:\"[^\"]*\"|[^,;[:space:]]+)", "$$1[REDACTED]")'
+      - 'replace_pattern(spanevent.name, "(?i)Bearer[[:space:]]+[A-Za-z0-9._~+/=-]+", "[REDACTED]")'
+      - 'replace_pattern(spanevent.name, "(?:sk|rk)[_-][A-Za-z0-9_*.-]{3,}", "[REDACTED]")'
+      - 'replace_pattern(spanevent.name, "eyJ[A-Za-z0-9_-]+[.]eyJ[A-Za-z0-9_-]+[.][A-Za-z0-9_-]+", "[REDACTED]")'
+      - 'replace_pattern(spanevent.name, "(?i)[A-Z0-9._%+-]+@[A-Z0-9.-]+[.][A-Z]{2,}", "[REDACTED]")'
+      - 'replace_pattern(spanevent.name, "(?s)-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----.*?-----END (?:RSA |EC |OPENSSH )?PRIVATE KEY-----", "[REDACTED]")'
+    log_statements:
+      - 'replace_pattern(log.body, "(?i)(\"(?:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)\"[[:space:]]*:[[:space:]]*)(?:\"[^\"]*\"|[^,}[:space:]]+)", "$$1\"[REDACTED]\"") where IsString(log.body)'
+      - 'replace_pattern(log.body, "(?i)((?:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)[[:space:]]*[=:][[:space:]]*)(?:\"[^\"]*\"|[^,;[:space:]]+)", "$$1[REDACTED]") where IsString(log.body)'
+      - 'replace_pattern(log.body, "(?i)Bearer[[:space:]]+[A-Za-z0-9._~+/=-]+", "[REDACTED]") where IsString(log.body)'
+      - 'replace_pattern(log.body, "(?:sk|rk)[_-][A-Za-z0-9_*.-]{3,}", "[REDACTED]") where IsString(log.body)'
+      - 'replace_pattern(log.body, "eyJ[A-Za-z0-9_-]+[.]eyJ[A-Za-z0-9_-]+[.][A-Za-z0-9_-]+", "[REDACTED]") where IsString(log.body)'
+      - 'replace_pattern(log.body, "(?i)[A-Z0-9._%+-]+@[A-Z0-9.-]+[.][A-Z]{2,}", "[REDACTED]") where IsString(log.body)'
+      - 'replace_pattern(log.body, "(?s)-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----.*?-----END (?:RSA |EC |OPENSSH )?PRIVATE KEY-----", "[REDACTED]") where IsString(log.body)'
+  redaction/sensitive:
+    allow_all_keys: true
+    blocked_key_patterns:
+      - "(?i)(^|[._-])(authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)([._-]|$)"
+    blocked_values:
+      - "(?i)Bearer[[:space:]]+[A-Za-z0-9._~+/=-]+"
+      - "(?:sk|rk)[_-][A-Za-z0-9_*.-]{3,}"
+      - "eyJ[A-Za-z0-9_-]+[.]eyJ[A-Za-z0-9_-]+[.][A-Za-z0-9_-]+"
+      - "(?i)[A-Z0-9._%+-]+@[A-Z0-9.-]+[.][A-Z]{2,}"
+      - "(?s)-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----.*?-----END (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"
+    redact_all_types: true
+    summary: silent
   batch:
     send_batch_size: 2048
     timeout: 5s
@@ -63,13 +93,13 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [memory_limiter, batch]
+      processors: [memory_limiter, transform/redact, redaction/sensitive, batch]
       exporters: [otlphttp/traces]
     logs:
       receivers: [otlp]
-      processors: [memory_limiter, batch]
+      processors: [memory_limiter, transform/redact, redaction/sensitive, batch]
       exporters: [otlphttp/logs]
     metrics:
       receivers: [otlp]
-      processors: [memory_limiter, batch]
+      processors: [memory_limiter, redaction/sensitive, batch]
       exporters: [otlphttp/metrics]

--- a/packages/cli/src/assets/production.yaml
+++ b/packages/cli/src/assets/production.yaml
@@ -19,16 +19,16 @@ processors:
   transform/redact:
     error_mode: propagate
     trace_statements:
-      - 'replace_pattern(spanevent.name, "(?i)(\"(?:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)\"[[:space:]]*:[[:space:]]*)(?:\"[^\"]*\"|[^,}[:space:]]+)", "$$1\"[REDACTED]\"")'
-      - 'replace_pattern(spanevent.name, "(?i)((?:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)[[:space:]]*[=:][[:space:]]*)(?:\"[^\"]*\"|[^,;[:space:]]+)", "$$1[REDACTED]")'
+      - 'replace_pattern(spanevent.name, "(\"[A-Za-z0-9_.-]*(?i:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)(?:(?:[._-]|[A-Z0-9])[A-Za-z0-9_.-]*)?\"[[:space:]]*:[[:space:]]*)(?:\"(?:[^\"\\\\]|\\\\.)*\"|[^,}[:space:]]+)", "$$1\"[REDACTED]\"")'
+      - 'replace_pattern(spanevent.name, "([A-Za-z0-9_.-]*(?i:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)(?:(?:[._-]|[A-Z0-9])[A-Za-z0-9_.-]*)?[[:space:]]*[=:][[:space:]]*)(?:\"(?:[^\"\\\\]|\\\\.)*\"|[^,;[:space:]]+)", "$$1[REDACTED]")'
       - 'replace_pattern(spanevent.name, "(?i)Bearer[[:space:]]+[A-Za-z0-9._~+/=-]+", "[REDACTED]")'
       - 'replace_pattern(spanevent.name, "(?:sk|rk)[_-][A-Za-z0-9_*.-]{3,}", "[REDACTED]")'
       - 'replace_pattern(spanevent.name, "eyJ[A-Za-z0-9_-]+[.]eyJ[A-Za-z0-9_-]+[.][A-Za-z0-9_-]+", "[REDACTED]")'
       - 'replace_pattern(spanevent.name, "(?i)[A-Z0-9._%+-]+@[A-Z0-9.-]+[.][A-Z]{2,}", "[REDACTED]")'
       - 'replace_pattern(spanevent.name, "(?s)-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----.*?-----END (?:RSA |EC |OPENSSH )?PRIVATE KEY-----", "[REDACTED]")'
     log_statements:
-      - 'replace_pattern(log.body, "(?i)(\"(?:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)\"[[:space:]]*:[[:space:]]*)(?:\"[^\"]*\"|[^,}[:space:]]+)", "$$1\"[REDACTED]\"") where IsString(log.body)'
-      - 'replace_pattern(log.body, "(?i)((?:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)[[:space:]]*[=:][[:space:]]*)(?:\"[^\"]*\"|[^,;[:space:]]+)", "$$1[REDACTED]") where IsString(log.body)'
+      - 'replace_pattern(log.body, "(\"[A-Za-z0-9_.-]*(?i:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)(?:(?:[._-]|[A-Z0-9])[A-Za-z0-9_.-]*)?\"[[:space:]]*:[[:space:]]*)(?:\"(?:[^\"\\\\]|\\\\.)*\"|[^,}[:space:]]+)", "$$1\"[REDACTED]\"") where IsString(log.body)'
+      - 'replace_pattern(log.body, "([A-Za-z0-9_.-]*(?i:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)(?:(?:[._-]|[A-Z0-9])[A-Za-z0-9_.-]*)?[[:space:]]*[=:][[:space:]]*)(?:\"(?:[^\"\\\\]|\\\\.)*\"|[^,;[:space:]]+)", "$$1[REDACTED]") where IsString(log.body)'
       - 'replace_pattern(log.body, "(?i)Bearer[[:space:]]+[A-Za-z0-9._~+/=-]+", "[REDACTED]") where IsString(log.body)'
       - 'replace_pattern(log.body, "(?:sk|rk)[_-][A-Za-z0-9_*.-]{3,}", "[REDACTED]") where IsString(log.body)'
       - 'replace_pattern(log.body, "eyJ[A-Za-z0-9_-]+[.]eyJ[A-Za-z0-9_-]+[.][A-Za-z0-9_-]+", "[REDACTED]") where IsString(log.body)'
@@ -37,7 +37,7 @@ processors:
   redaction/sensitive:
     allow_all_keys: true
     blocked_key_patterns:
-      - "(?i)(^|[._-])(authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)([._-]|$)"
+      - "(?i:authorization|proxy[._-]?authorization|cookie|set[._-]?cookie|password|passwd|secret|token|api[._-]?key|apikey|access[._-]?key|client[._-]?secret|private[._-]?key|email|phone|cpf|cnpj|document)(?:[._-]|[A-Z0-9]|$)"
     blocked_values:
       - "(?i)Bearer[[:space:]]+[A-Za-z0-9._~+/=-]+"
       - "(?:sk|rk)[_-][A-Za-z0-9_*.-]{3,}"

--- a/packages/cli/test/CollectorAssets.bun.test.ts
+++ b/packages/cli/test/CollectorAssets.bun.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+
+const redactionBlock = (config: string): string => {
+  const start = config.indexOf("  transform/redact:");
+  const end = config.indexOf("  batch:", start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return config.slice(start, end);
+};
+
+describe("Collector assets", () => {
+  test("keep one redaction contract across local and production pipelines", async () => {
+    const [local, production] = await Promise.all([
+      Bun.file(new URL("../src/assets/local.yaml", import.meta.url)).text(),
+      Bun.file(new URL("../src/assets/production.yaml", import.meta.url)).text(),
+    ]);
+
+    expect(redactionBlock(local)).toBe(redactionBlock(production));
+    for (const config of [local, production]) {
+      expect(config).toContain("trace_statements:");
+      expect(config).toContain("log_statements:");
+      expect(config).toContain(
+        "processors: [memory_limiter, transform/redact, redaction/sensitive, batch]",
+      );
+      expect(config).toContain("processors: [memory_limiter, redaction/sensitive, batch]");
+    }
+  });
+});

--- a/packages/cli/test/CollectorAssets.bun.test.ts
+++ b/packages/cli/test/CollectorAssets.bun.test.ts
@@ -1,4 +1,21 @@
 import { describe, expect, test } from "bun:test";
+import { Schema } from "effect";
+
+const CollectorPipeline = Schema.Struct({
+  processors: Schema.Array(Schema.String),
+});
+
+const CollectorConfig = Schema.Struct({
+  service: Schema.Struct({
+    pipelines: Schema.Struct({
+      traces: CollectorPipeline,
+      logs: CollectorPipeline,
+      metrics: CollectorPipeline,
+    }),
+  }),
+});
+
+const decodeCollectorConfig = Schema.decodeUnknownSync(CollectorConfig);
 
 const redactionBlock = (config: string): string => {
   const start = config.indexOf("  transform/redact:");
@@ -6,6 +23,16 @@ const redactionBlock = (config: string): string => {
   expect(start).toBeGreaterThanOrEqual(0);
   expect(end).toBeGreaterThan(start);
   return config.slice(start, end);
+};
+
+const expectRedactionPipelines = (config: string): void => {
+  const parsed: unknown = Bun.YAML.parse(config);
+  const pipelines = decodeCollectorConfig(parsed).service.pipelines;
+  const tracesAndLogs = ["memory_limiter", "transform/redact", "redaction/sensitive", "batch"];
+  const metrics = ["memory_limiter", "redaction/sensitive", "batch"];
+  expect(pipelines.traces.processors).toEqual(tracesAndLogs);
+  expect(pipelines.logs.processors).toEqual(tracesAndLogs);
+  expect(pipelines.metrics.processors).toEqual(metrics);
 };
 
 describe("Collector assets", () => {
@@ -16,13 +43,16 @@ describe("Collector assets", () => {
     ]);
 
     expect(redactionBlock(local)).toBe(redactionBlock(production));
-    for (const config of [local, production]) {
-      expect(config).toContain("trace_statements:");
-      expect(config).toContain("log_statements:");
-      expect(config).toContain(
-        "processors: [memory_limiter, transform/redact, redaction/sensitive, batch]",
-      );
-      expect(config).toContain("processors: [memory_limiter, redaction/sensitive, batch]");
-    }
+    expectRedactionPipelines(local);
+    expectRedactionPipelines(production);
+
+    const withoutTraceAttributeRedaction = production.replace(
+      "processors: [memory_limiter, transform/redact, redaction/sensitive, batch]",
+      "processors: [memory_limiter, transform/redact, batch]",
+    );
+    expect(withoutTraceAttributeRedaction).not.toBe(production);
+    expect(() => expectRedactionPipelines(withoutTraceAttributeRedaction)).toThrow(
+      /redaction\/sensitive/,
+    );
   });
 });

--- a/packages/telemetry/test/axiomSupport.test.ts
+++ b/packages/telemetry/test/axiomSupport.test.ts
@@ -5,6 +5,7 @@ import {
   decodeAxiomEnvironment,
   findChildSpan,
   findLogs,
+  findMetric,
   findRootSpan,
   type AxiomEnvironment,
 } from "./support/axiom.ts";
@@ -15,11 +16,17 @@ const decodeAddressInfo = Schema.decodeUnknownOption(AddressInfo);
 type RecordedQuery = {
   readonly path: string;
   readonly authorization: string;
-  readonly apl: string;
+  readonly query: string;
 };
 
-const QueryBody = Schema.Struct({ apl: Schema.String, startTime: Schema.String });
-const decodeQueryBody = Schema.decodeUnknownOption(QueryBody);
+const AplQueryBody = Schema.Struct({ apl: Schema.String, startTime: Schema.String });
+const MplQueryBody = Schema.Struct({
+  mpl: Schema.String,
+  startTime: Schema.String,
+  endTime: Schema.String,
+});
+const decodeAplQueryBody = Schema.decodeUnknownOption(AplQueryBody);
+const decodeMplQueryBody = Schema.decodeUnknownOption(MplQueryBody);
 
 type StubAxiom = {
   readonly env: AxiomEnvironment;
@@ -27,7 +34,10 @@ type StubAxiom = {
   readonly server: Server;
 };
 
-const startStubAxiom = (matches: ReadonlyArray<{ readonly data: unknown }>): Promise<StubAxiom> =>
+const startStubAxiom = (
+  matches: ReadonlyArray<{ readonly data: unknown }>,
+  metricsResponse = "{}",
+): Promise<StubAxiom> =>
   new Promise((resolve, reject) => {
     const queries: Array<RecordedQuery> = [];
     const server = createServer((request, response) => {
@@ -39,14 +49,23 @@ const startStubAxiom = (matches: ReadonlyArray<{ readonly data: unknown }>): Pro
         const parsed = Effect.runSync(
           Effect.try((): unknown => JSON.parse(body)).pipe(Effect.option),
         );
-        const query = parsed.pipe(Option.flatMap(decodeQueryBody));
+        const apl = parsed.pipe(
+          Option.flatMap(decodeAplQueryBody),
+          Option.map((query) => query.apl),
+        );
+        const mpl = parsed.pipe(
+          Option.flatMap(decodeMplQueryBody),
+          Option.map((query) => query.mpl),
+        );
         queries.push({
           path: request.url ?? "",
           authorization: request.headers.authorization ?? "",
-          apl: Option.match(query, { onNone: () => "", onSome: (value) => value.apl }),
+          query: Option.getOrElse(apl, () => Option.getOrElse(mpl, () => "")),
         });
         response.writeHead(200, { "content-type": "application/json" });
-        response.end(JSON.stringify({ matches }));
+        response.end(
+          request.url?.startsWith("/v1/query/_mpl") ? metricsResponse : JSON.stringify({ matches }),
+        );
       });
     });
     server.listen(0, "127.0.0.1", () => {
@@ -61,6 +80,7 @@ const startStubAxiom = (matches: ReadonlyArray<{ readonly data: unknown }>): Pro
           AXIOM_TOKEN: "stub-token",
           AXIOM_DATASET_TRACES: "e2e-traces",
           AXIOM_DATASET_LOGS: "e2e-logs",
+          AXIOM_DATASET_METRICS: "e2e-metrics",
         }),
       );
       resolve({ env, queries, server });
@@ -101,9 +121,9 @@ describe("axiom query support", () => {
       assert.isDefined(query);
       assert.strictEqual(query.path, "/v1/datasets/_apl?format=legacy");
       assert.strictEqual(query.authorization, "Bearer stub-token");
-      assert.include(query.apl, "['e2e-traces']");
-      assert.include(query.apl, "['attributes.custom']['canary.run_id'] == 'test-run-1'");
-      assert.include(query.apl, "name == 'canary.operation'");
+      assert.include(query.query, "['e2e-traces']");
+      assert.include(query.query, "['attributes.custom']['canary.run_id'] == 'test-run-1'");
+      assert.include(query.query, "name == 'canary.operation'");
     }),
   );
 
@@ -129,8 +149,8 @@ describe("axiom query support", () => {
       assert.deepStrictEqual(Option.getOrThrow(child).parentSpanId, Option.some("span-1"));
       const query = stub.queries[0];
       assert.isDefined(query);
-      assert.include(query.apl, "trace_id == 'trace-1'");
-      assert.include(query.apl, "name == 'canary.child'");
+      assert.include(query.query, "trace_id == 'trace-1'");
+      assert.include(query.query, "name == 'canary.child'");
     }),
   );
 
@@ -163,7 +183,35 @@ describe("axiom query support", () => {
       assert.deepStrictEqual(log.eventSource, Option.none());
       const query = stub.queries[0];
       assert.isDefined(query);
-      assert.include(query.apl, "['e2e-logs']");
+      assert.include(query.query, "['e2e-logs']");
+    }),
+  );
+
+  it.live("queries the metrics dataset with MPL and returns the complete response", () =>
+    Effect.gen(function* () {
+      const metricsResponse = JSON.stringify({
+        series: [
+          {
+            tags: {
+              "canary.run_id": "test-run-1",
+              accessToken: "****",
+              tokenizer: "tokenizer-control",
+            },
+          },
+        ],
+      });
+      const stub = yield* Effect.promise(() => startStubAxiom([], metricsResponse));
+      const metric = yield* findMetric(stub.env, "test-run-1").pipe(
+        Effect.ensuring(Effect.sync(() => stub.server.close())),
+      );
+
+      assert.isTrue(Option.isSome(metric));
+      assert.include(Option.getOrThrow(metric).content, "tokenizer-control");
+      const query = stub.queries[0];
+      assert.isDefined(query);
+      assert.strictEqual(query.path, "/v1/query/_mpl?format=metrics-v2");
+      assert.include(query.query, "`e2e-metrics`:`canary.operations`");
+      assert.include(query.query, '`canary.run_id` == "test-run-1"');
     }),
   );
 });

--- a/packages/telemetry/test/canary.deployed.test.ts
+++ b/packages/telemetry/test/canary.deployed.test.ts
@@ -10,7 +10,7 @@ import {
   type AxiomLog,
   type AxiomSpan,
 } from "./support/axiom.ts";
-import { canaryRunId, emitCanary } from "./support/canary.ts";
+import { canaryRunId, canarySensitiveValues, emitCanary } from "./support/canary.ts";
 
 const deployedEnabled = process.env["OBSERVABILITY_E2E_DEPLOYED"] === "1";
 
@@ -19,6 +19,7 @@ type DeployedRun = {
   readonly child: AxiomSpan;
   readonly completed: AxiomLog;
   readonly browser: AxiomLog;
+  readonly redaction: AxiomLog;
 };
 
 const findDeployedRun = Effect.fn("findDeployedRun")(function* (
@@ -32,8 +33,14 @@ const findDeployedRun = Effect.fn("findDeployedRun")(function* (
       const logs = yield* findLogs(env, runId);
       const completed = logs.find((log) => log.eventName === "canary.completed");
       const browser = logs.find((log) => log.eventName === "canary.browser");
-      if (Option.isSome(child) && completed !== undefined && browser !== undefined) {
-        return { root: root.value, child: child.value, completed, browser };
+      const redaction = logs.find((log) => log.eventName === "canary.redaction");
+      if (
+        Option.isSome(child) &&
+        completed !== undefined &&
+        browser !== undefined &&
+        redaction !== undefined
+      ) {
+        return { root: root.value, child: child.value, completed, browser, redaction };
       }
     }
     yield* Effect.sleep("3 seconds");
@@ -75,6 +82,28 @@ describe.runIf(deployedEnabled)("deployed pipeline canary", () => {
 
         assert.deepStrictEqual(run.browser.eventSource, Option.some("browser"));
         assert.deepStrictEqual(run.browser.eventKind, Option.some("wide"));
+
+        const sensitive = canarySensitiveValues(runId);
+        const redactedValues = [
+          sensitive.authorization,
+          sensitive.password,
+          sensitive.token,
+          sensitive.email,
+        ];
+        const redactedRecords = [
+          Option.getOrThrow(run.root.events),
+          Option.getOrThrow(run.redaction.body),
+          Option.getOrThrow(run.redaction.authorization),
+          Option.getOrThrow(run.redaction.password),
+          Option.getOrThrow(run.redaction.safeMessage),
+        ];
+        for (const record of redactedRecords) {
+          for (const value of redactedValues) {
+            assert.notInclude(record, value);
+          }
+        }
+        assert.include(Option.getOrThrow(run.root.events), "[REDACTED]");
+        assert.include(Option.getOrThrow(run.redaction.body), "[REDACTED]");
       }),
     240_000,
   );

--- a/packages/telemetry/test/canary.deployed.test.ts
+++ b/packages/telemetry/test/canary.deployed.test.ts
@@ -5,9 +5,12 @@ import {
   decodeAxiomEnvironment,
   findChildSpan,
   findLogs,
+  findMetric,
   findRootSpan,
   type AxiomEnvironment,
   type AxiomLog,
+  type AxiomMetric,
+  type AxiomRedactionAttributes,
   type AxiomSpan,
 } from "./support/axiom.ts";
 import { canaryRunId, canarySensitiveValues, emitCanary } from "./support/canary.ts";
@@ -20,6 +23,7 @@ type DeployedRun = {
   readonly completed: AxiomLog;
   readonly browser: AxiomLog;
   readonly redaction: AxiomLog;
+  readonly metric: AxiomMetric;
 };
 
 const findDeployedRun = Effect.fn("findDeployedRun")(function* (
@@ -31,6 +35,7 @@ const findDeployedRun = Effect.fn("findDeployedRun")(function* (
     if (Option.isSome(root)) {
       const child = yield* findChildSpan(env, root.value.traceId);
       const logs = yield* findLogs(env, runId);
+      const metric = yield* findMetric(env, runId);
       const completed = logs.find((log) => log.eventName === "canary.completed");
       const browser = logs.find((log) => log.eventName === "canary.browser");
       const redaction = logs.find((log) => log.eventName === "canary.redaction");
@@ -38,9 +43,17 @@ const findDeployedRun = Effect.fn("findDeployedRun")(function* (
         Option.isSome(child) &&
         completed !== undefined &&
         browser !== undefined &&
-        redaction !== undefined
+        redaction !== undefined &&
+        Option.isSome(metric)
       ) {
-        return { root: root.value, child: child.value, completed, browser, redaction };
+        return {
+          root: root.value,
+          child: child.value,
+          completed,
+          browser,
+          redaction,
+          metric: metric.value,
+        };
       }
     }
     yield* Effect.sleep("3 seconds");
@@ -48,9 +61,36 @@ const findDeployedRun = Effect.fn("findDeployedRun")(function* (
   return yield* Effect.die(`The deployed canary run ${runId} was not found in Axiom.`);
 });
 
+const redactionAttributeValues = (attributes: AxiomRedactionAttributes): ReadonlyArray<string> => [
+  Option.getOrThrow(attributes.authorization),
+  Option.getOrThrow(attributes.password),
+  Option.getOrThrow(attributes.accessToken),
+  Option.getOrThrow(attributes.userPassword),
+  Option.getOrThrow(attributes.phoneNumber),
+  Option.getOrThrow(attributes.safeMessage),
+];
+
+const assertRedactionAttributes = (
+  attributes: AxiomRedactionAttributes,
+  sensitive: ReturnType<typeof canarySensitiveValues>,
+): void => {
+  for (const value of [
+    attributes.authorization,
+    attributes.password,
+    attributes.accessToken,
+    attributes.userPassword,
+    attributes.phoneNumber,
+  ]) {
+    assert.deepStrictEqual(value, Option.some("****"));
+  }
+  assert.deepStrictEqual(attributes.tokenizer, Option.some(sensitive.tokenizerValue));
+  assert.deepStrictEqual(attributes.documentation, Option.some(sensitive.documentationValue));
+  assert.include(Option.getOrThrow(attributes.safeMessage), "****");
+};
+
 describe.runIf(deployedEnabled)("deployed pipeline canary", () => {
   it.live(
-    "exports correlated traces and logs through the production collector to Axiom",
+    "exports redacted traces, logs and metrics through the production collector to Axiom",
     () =>
       Effect.gen(function* () {
         const axiom = yield* decodeAxiomEnvironment(process.env).pipe(Effect.orDie);
@@ -84,26 +124,29 @@ describe.runIf(deployedEnabled)("deployed pipeline canary", () => {
         assert.deepStrictEqual(run.browser.eventKind, Option.some("wide"));
 
         const sensitive = canarySensitiveValues(runId);
-        const redactedValues = [
-          sensitive.authorization,
-          sensitive.password,
-          sensitive.token,
-          sensitive.email,
+        assertRedactionAttributes(run.root.redaction, sensitive);
+        assertRedactionAttributes(run.redaction.redaction, sensitive);
+
+        const rootEvents = Option.getOrThrow(run.root.events);
+        const redactedBody = Option.getOrThrow(run.redaction.body);
+        const exportedContent = [
+          rootEvents,
+          redactedBody,
+          run.metric.content,
+          ...redactionAttributeValues(run.root.redaction),
+          ...redactionAttributeValues(run.redaction.redaction),
         ];
-        const redactedRecords = [
-          Option.getOrThrow(run.root.events),
-          Option.getOrThrow(run.redaction.body),
-          Option.getOrThrow(run.redaction.authorization),
-          Option.getOrThrow(run.redaction.password),
-          Option.getOrThrow(run.redaction.safeMessage),
-        ];
-        for (const record of redactedRecords) {
-          for (const value of redactedValues) {
-            assert.notInclude(record, value);
+        for (const content of exportedContent) {
+          for (const marker of sensitive.leakMarkers) {
+            assert.notInclude(content, marker);
           }
         }
-        assert.include(Option.getOrThrow(run.root.events), "[REDACTED]");
-        assert.include(Option.getOrThrow(run.redaction.body), "[REDACTED]");
+        for (const preservedValue of sensitive.preservedValues) {
+          assert.include(run.metric.content, preservedValue);
+        }
+        assert.include(run.metric.content, "****");
+        assert.include(rootEvents, "[REDACTED]");
+        assert.include(redactedBody, "[REDACTED]");
       }),
     240_000,
   );

--- a/packages/telemetry/test/canary.test.ts
+++ b/packages/telemetry/test/canary.test.ts
@@ -4,7 +4,7 @@ import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { TelemetryConfig } from "../src/TelemetryConfig.ts";
-import { canaryRunId, emitCanary } from "./support/canary.ts";
+import { canaryRunId, canarySensitiveValues, emitCanary } from "./support/canary.ts";
 
 const cliManifest: unknown = JSON.parse(
   await readFile(new URL("../../cli/package.json", import.meta.url).pathname, "utf8"),
@@ -28,12 +28,18 @@ const Attribute = Schema.Struct({
   value: AttributeValue,
 });
 
+const ExportedSpanEvent = Schema.Struct({
+  name: Schema.String,
+  attributes: Schema.Array(Attribute).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+});
+
 const ExportedSpan = Schema.Struct({
   traceId: Schema.String,
   spanId: Schema.String,
   parentSpanId: Schema.String.pipe(Schema.optionalKey),
   name: Schema.String,
   attributes: Schema.Array(Attribute).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  events: Schema.Array(ExportedSpanEvent).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
 });
 
 const ExportedResource = Schema.Struct({
@@ -51,6 +57,7 @@ const SpanExport = Schema.Struct({
 
 const ExportedLogRecord = Schema.Struct({
   traceId: Schema.String.pipe(Schema.optionalKey),
+  body: Schema.Struct({ stringValue: Schema.String.pipe(Schema.optionalKey) }),
   attributes: Schema.Array(Attribute).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
 });
 
@@ -176,6 +183,11 @@ const findRun = Effect.fn("findRun")(function* (runId: string) {
         Option.getOrUndefined(attributeValue(candidate.span.attributes, "canary.run_id")) === runId,
     );
     if (root !== undefined) {
+      const redactionSpanEvent = root.span.events.find(
+        (event) =>
+          Option.getOrUndefined(attributeValue(event.attributes, "event.name")) ===
+          "canary.redaction",
+      );
       const child = telemetryExport.spans.find(
         (candidate) =>
           candidate.span.parentSpanId === root.span.spanId &&
@@ -195,6 +207,13 @@ const findRun = Effect.fn("findRun")(function* (runId: string) {
           Option.getOrUndefined(attributeValue(candidate.log.attributes, "event.name")) ===
             "canary.browser",
       );
+      const redactionLog = telemetryExport.logs.find(
+        (candidate) =>
+          Option.getOrUndefined(attributeValue(candidate.log.attributes, "canary.run_id")) ===
+            runId &&
+          Option.getOrUndefined(attributeValue(candidate.log.attributes, "event.name")) ===
+            "canary.redaction",
+      );
       const metric = telemetryExport.metrics.find(
         (candidate) =>
           candidate.metric.name === "canary.operations" &&
@@ -202,12 +221,14 @@ const findRun = Effect.fn("findRun")(function* (runId: string) {
             runId,
       );
       if (
+        redactionSpanEvent !== undefined &&
         child !== undefined &&
         log !== undefined &&
         browserLog !== undefined &&
+        redactionLog !== undefined &&
         metric !== undefined
       ) {
-        return { root, child, log, browserLog, metric };
+        return { root, redactionSpanEvent, child, log, browserLog, redactionLog, metric };
       }
     }
     yield* Effect.sleep("500 millis");
@@ -272,6 +293,37 @@ describe.runIf(canaryEnabled)("pipeline canary", () => {
         );
         assert.strictEqual(run.metric.metric.name, "canary.operations");
         assert.strictEqual(run.metric.dataPoint.asDouble, 1);
+
+        const sensitive = canarySensitiveValues(runId);
+        const redactedValues = [
+          sensitive.authorization,
+          sensitive.password,
+          sensitive.token,
+          sensitive.email,
+        ];
+        const redactedBody = Option.getOrThrow(
+          Option.fromNullishOr(run.redactionLog.log.body.stringValue),
+        );
+        const redactedRecords = [
+          redactedBody,
+          run.redactionSpanEvent.name,
+          Option.getOrThrow(attributeValue(run.root.span.attributes, "authorization")),
+          Option.getOrThrow(attributeValue(run.root.span.attributes, "password")),
+          Option.getOrThrow(attributeValue(run.root.span.attributes, "safe.message")),
+          Option.getOrThrow(attributeValue(run.redactionLog.log.attributes, "authorization")),
+          Option.getOrThrow(attributeValue(run.redactionLog.log.attributes, "password")),
+          Option.getOrThrow(attributeValue(run.redactionLog.log.attributes, "safe.message")),
+          Option.getOrThrow(attributeValue(run.metric.dataPoint.attributes, "authorization")),
+          Option.getOrThrow(attributeValue(run.metric.dataPoint.attributes, "password")),
+          Option.getOrThrow(attributeValue(run.metric.dataPoint.attributes, "safe.message")),
+        ];
+        for (const record of redactedRecords) {
+          for (const value of redactedValues) {
+            assert.notInclude(record, value);
+          }
+        }
+        assert.include(redactedBody, "[REDACTED]");
+        assert.include(run.redactionSpanEvent.name, "[REDACTED]");
 
         for (const signalResource of [run.log.resource, run.metric.resource]) {
           assert.strictEqual(

--- a/packages/telemetry/test/canary.test.ts
+++ b/packages/telemetry/test/canary.test.ts
@@ -61,6 +61,20 @@ const ExportedLogRecord = Schema.Struct({
   attributes: Schema.Array(Attribute).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
 });
 
+const RedactedLogBody = Schema.Struct({
+  authorization: Schema.String,
+  password: Schema.String,
+  token: Schema.String,
+  email: Schema.String,
+  accessToken: Schema.String,
+  userPassword: Schema.String,
+  phoneNumber: Schema.String,
+  tokenizer: Schema.String,
+  documentation: Schema.String,
+});
+
+const decodeRedactedLogBody = Schema.decodeUnknownSync(RedactedLogBody);
+
 const LogExport = Schema.Struct({
   resourceLogs: Schema.Array(
     Schema.Struct({
@@ -101,6 +115,7 @@ type CanaryMetric = typeof ExportedMetric.Type;
 type CanaryMetricDataPoint = typeof MetricDataPoint.Type;
 
 type CanaryExport = {
+  readonly content: string;
   readonly spans: ReadonlyArray<{ readonly span: CanarySpan; readonly resource: CanaryResource }>;
   readonly logs: ReadonlyArray<{
     readonly log: CanaryLogRecord;
@@ -172,7 +187,7 @@ const readTelemetryExport = Effect.fn("readTelemetryExport")(function* (): Effec
       }
     }
   }
-  return { spans, logs, metrics };
+  return { content, spans, logs, metrics };
 });
 
 const findRun = Effect.fn("findRun")(function* (runId: string) {
@@ -228,7 +243,16 @@ const findRun = Effect.fn("findRun")(function* (runId: string) {
         redactionLog !== undefined &&
         metric !== undefined
       ) {
-        return { root, redactionSpanEvent, child, log, browserLog, redactionLog, metric };
+        return {
+          exportContent: telemetryExport.content,
+          root,
+          redactionSpanEvent,
+          child,
+          log,
+          browserLog,
+          redactionLog,
+          metric,
+        };
       }
     }
     yield* Effect.sleep("500 millis");
@@ -295,31 +319,47 @@ describe.runIf(canaryEnabled)("pipeline canary", () => {
         assert.strictEqual(run.metric.dataPoint.asDouble, 1);
 
         const sensitive = canarySensitiveValues(runId);
-        const redactedValues = [
-          sensitive.authorization,
-          sensitive.password,
-          sensitive.token,
-          sensitive.email,
-        ];
+        for (const marker of sensitive.leakMarkers) {
+          assert.notInclude(run.exportContent, marker);
+        }
+        for (const preservedValue of sensitive.preservedValues) {
+          assert.include(run.exportContent, preservedValue);
+        }
+
         const redactedBody = Option.getOrThrow(
           Option.fromNullishOr(run.redactionLog.log.body.stringValue),
         );
-        const redactedRecords = [
-          redactedBody,
-          run.redactionSpanEvent.name,
-          Option.getOrThrow(attributeValue(run.root.span.attributes, "authorization")),
-          Option.getOrThrow(attributeValue(run.root.span.attributes, "password")),
-          Option.getOrThrow(attributeValue(run.root.span.attributes, "safe.message")),
-          Option.getOrThrow(attributeValue(run.redactionLog.log.attributes, "authorization")),
-          Option.getOrThrow(attributeValue(run.redactionLog.log.attributes, "password")),
-          Option.getOrThrow(attributeValue(run.redactionLog.log.attributes, "safe.message")),
-          Option.getOrThrow(attributeValue(run.metric.dataPoint.attributes, "authorization")),
-          Option.getOrThrow(attributeValue(run.metric.dataPoint.attributes, "password")),
-          Option.getOrThrow(attributeValue(run.metric.dataPoint.attributes, "safe.message")),
+        const decodedRedactedBody = decodeRedactedLogBody(JSON.parse(redactedBody));
+        for (const value of [
+          decodedRedactedBody.authorization,
+          decodedRedactedBody.password,
+          decodedRedactedBody.token,
+          decodedRedactedBody.email,
+          decodedRedactedBody.accessToken,
+          decodedRedactedBody.userPassword,
+          decodedRedactedBody.phoneNumber,
+        ]) {
+          assert.strictEqual(value, "[REDACTED]");
+        }
+        assert.strictEqual(decodedRedactedBody.tokenizer, sensitive.tokenizerValue);
+        assert.strictEqual(decodedRedactedBody.documentation, sensitive.documentationValue);
+
+        const redactedAttributeKeys: ReadonlyArray<string> = [
+          "authorization",
+          "password",
+          "accessToken",
+          "userPassword",
+          "phoneNumber",
         ];
-        for (const record of redactedRecords) {
-          for (const value of redactedValues) {
-            assert.notInclude(record, value);
+        const redactedAttributeSets = [
+          run.root.span.attributes,
+          run.redactionSpanEvent.attributes,
+          run.redactionLog.log.attributes,
+          run.metric.dataPoint.attributes,
+        ];
+        for (const attributes of redactedAttributeSets) {
+          for (const key of redactedAttributeKeys) {
+            assert.strictEqual(Option.getOrThrow(attributeValue(attributes, key)), "****");
           }
         }
         assert.include(redactedBody, "[REDACTED]");

--- a/packages/telemetry/test/support/axiom.ts
+++ b/packages/telemetry/test/support/axiom.ts
@@ -49,28 +49,30 @@ const runQuery = (env: AxiomEnvironment, apl: string): Effect.Effect<ReadonlyArr
     return decoded.matches.map((match) => match.data);
   });
 
-const runMetricsQuery = (env: AxiomEnvironment, mpl: string): Effect.Effect<string> =>
-  Effect.gen(function* () {
-    const response = yield* Effect.promise((signal) =>
-      fetch(`${env.AXIOM_URL}/v1/query/_mpl?format=metrics-v2`, {
-        method: "POST",
-        headers: {
-          authorization: `Bearer ${env.AXIOM_TOKEN}`,
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({ mpl, startTime: queryStartTime(), endTime: queryEndTime() }),
-        signal,
-      }),
+const runMetricsQuery = Effect.fn("runMetricsQuery")(function* (
+  env: AxiomEnvironment,
+  mpl: string,
+): Effect.fn.Return<string, never> {
+  const response = yield* Effect.promise((signal) =>
+    fetch(`${env.AXIOM_URL}/v1/query/_mpl?format=metrics-v2`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${env.AXIOM_TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ mpl, startTime: queryStartTime(), endTime: queryEndTime() }),
+      signal,
+    }),
+  );
+  const payload: unknown = yield* Effect.promise(() => response.json());
+  if (!response.ok) {
+    return yield* Effect.die(
+      `Axiom metrics query failed with status ${response.status}: ${JSON.stringify(payload).slice(0, 500)}`,
     );
-    const payload: unknown = yield* Effect.promise(() => response.json());
-    if (!response.ok) {
-      return yield* Effect.die(
-        `Axiom metrics query failed with status ${response.status}: ${JSON.stringify(payload).slice(0, 500)}`,
-      );
-    }
-    const decoded = yield* decodeMetricsResponse(payload).pipe(Effect.orDie);
-    return JSON.stringify(decoded);
-  });
+  }
+  const decoded = yield* decodeMetricsResponse(payload).pipe(Effect.orDie);
+  return JSON.stringify(decoded);
+});
 
 const OptionalString = Schema.NullOr(Schema.String).pipe(Schema.optionalKey);
 

--- a/packages/telemetry/test/support/axiom.ts
+++ b/packages/telemetry/test/support/axiom.ts
@@ -56,6 +56,7 @@ const AxiomSpanRow = Schema.Struct({
   service_name: OptionalString,
   service_version: OptionalString,
   environment: OptionalString,
+  events: OptionalString,
 });
 
 const decodeAxiomSpanRow = Schema.decodeUnknownOption(AxiomSpanRow);
@@ -68,6 +69,7 @@ export type AxiomSpan = {
   readonly serviceName: Option.Option<string>;
   readonly serviceVersion: Option.Option<string>;
   readonly environment: Option.Option<string>;
+  readonly events: Option.Option<string>;
 };
 
 const toAxiomSpan = (row: typeof AxiomSpanRow.Type): AxiomSpan => ({
@@ -80,10 +82,11 @@ const toAxiomSpan = (row: typeof AxiomSpanRow.Type): AxiomSpan => ({
   serviceName: Option.fromNullishOr(row.service_name),
   serviceVersion: Option.fromNullishOr(row.service_version),
   environment: Option.fromNullishOr(row.environment),
+  events: Option.fromNullishOr(row.events),
 });
 
 const spanProjection =
-  "project trace_id, span_id, parent_span_id, name, service_name = ['service.name'], service_version = ['service.version'], environment = tostring(['resource.custom']['deployment.environment.name'])";
+  "project trace_id, span_id, parent_span_id, name, service_name = ['service.name'], service_version = ['service.version'], environment = tostring(['resource.custom']['deployment.environment.name']), events = tostring(events)";
 
 export const findRootSpan = (
   env: AxiomEnvironment,
@@ -123,6 +126,10 @@ const AxiomLogRow = Schema.Struct({
   event_kind: OptionalString,
   event_source: OptionalString,
   service_name: OptionalString,
+  body: OptionalString,
+  authorization: OptionalString,
+  password: OptionalString,
+  safe_message: OptionalString,
 });
 
 const decodeAxiomLogRow = Schema.decodeUnknownOption(AxiomLogRow);
@@ -133,6 +140,10 @@ export type AxiomLog = {
   readonly eventKind: Option.Option<string>;
   readonly eventSource: Option.Option<string>;
   readonly serviceName: Option.Option<string>;
+  readonly body: Option.Option<string>;
+  readonly authorization: Option.Option<string>;
+  readonly password: Option.Option<string>;
+  readonly safeMessage: Option.Option<string>;
 };
 
 const toAxiomLog = (row: typeof AxiomLogRow.Type): AxiomLog => ({
@@ -141,6 +152,10 @@ const toAxiomLog = (row: typeof AxiomLogRow.Type): AxiomLog => ({
   eventKind: Option.fromNullishOr(row.event_kind),
   eventSource: Option.fromNullishOr(row.event_source),
   serviceName: Option.fromNullishOr(row.service_name),
+  body: Option.fromNullishOr(row.body),
+  authorization: Option.fromNullishOr(row.authorization),
+  password: Option.fromNullishOr(row.password),
+  safeMessage: Option.fromNullishOr(row.safe_message),
 });
 
 export const findLogs = (
@@ -149,7 +164,7 @@ export const findLogs = (
 ): Effect.Effect<ReadonlyArray<AxiomLog>> =>
   runQuery(
     env,
-    `['${env.AXIOM_DATASET_LOGS}'] | where ['attributes.custom']['canary.run_id'] == '${runId}' | project trace_id, event_name = tostring(['attributes.custom']['event.name']), event_kind = tostring(['attributes.custom']['event.kind']), event_source = tostring(['attributes.custom']['event.source']), service_name = ['service.name']`,
+    `['${env.AXIOM_DATASET_LOGS}'] | where ['attributes.custom']['canary.run_id'] == '${runId}' | project trace_id, event_name = tostring(['attributes.custom']['event.name']), event_kind = tostring(['attributes.custom']['event.kind']), event_source = tostring(['attributes.custom']['event.source']), service_name = ['service.name'], body = tostring(body), authorization = tostring(['attributes.custom']['authorization']), password = tostring(['attributes.custom']['password']), safe_message = tostring(['attributes.custom']['safe.message'])`,
   ).pipe(
     Effect.map((rows) =>
       rows.flatMap((row) =>

--- a/packages/telemetry/test/support/axiom.ts
+++ b/packages/telemetry/test/support/axiom.ts
@@ -7,6 +7,7 @@ const AxiomEnvironment = Schema.Struct({
   AXIOM_TOKEN: Schema.NonEmptyString,
   AXIOM_DATASET_TRACES: Schema.NonEmptyString,
   AXIOM_DATASET_LOGS: Schema.NonEmptyString,
+  AXIOM_DATASET_METRICS: Schema.NonEmptyString,
 });
 
 export type AxiomEnvironment = typeof AxiomEnvironment.Type;
@@ -20,8 +21,10 @@ const QueryResponse = Schema.Struct({
 });
 
 const decodeQueryResponse = Schema.decodeUnknownEffect(QueryResponse);
+const decodeMetricsResponse = Schema.decodeUnknownEffect(Schema.Json);
 
 const queryStartTime = (): string => new Date(Date.now() - 30 * 60 * 1000).toISOString();
+const queryEndTime = (): string => new Date().toISOString();
 
 const runQuery = (env: AxiomEnvironment, apl: string): Effect.Effect<ReadonlyArray<unknown>> =>
   Effect.gen(function* () {
@@ -46,7 +49,70 @@ const runQuery = (env: AxiomEnvironment, apl: string): Effect.Effect<ReadonlyArr
     return decoded.matches.map((match) => match.data);
   });
 
+const runMetricsQuery = (env: AxiomEnvironment, mpl: string): Effect.Effect<string> =>
+  Effect.gen(function* () {
+    const response = yield* Effect.promise((signal) =>
+      fetch(`${env.AXIOM_URL}/v1/query/_mpl?format=metrics-v2`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${env.AXIOM_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ mpl, startTime: queryStartTime(), endTime: queryEndTime() }),
+        signal,
+      }),
+    );
+    const payload: unknown = yield* Effect.promise(() => response.json());
+    if (!response.ok) {
+      return yield* Effect.die(
+        `Axiom metrics query failed with status ${response.status}: ${JSON.stringify(payload).slice(0, 500)}`,
+      );
+    }
+    const decoded = yield* decodeMetricsResponse(payload).pipe(Effect.orDie);
+    return JSON.stringify(decoded);
+  });
+
 const OptionalString = Schema.NullOr(Schema.String).pipe(Schema.optionalKey);
+
+const AxiomRedactionRowFields = {
+  authorization: OptionalString,
+  password: OptionalString,
+  access_token: OptionalString,
+  user_password: OptionalString,
+  phone_number: OptionalString,
+  tokenizer: OptionalString,
+  documentation: OptionalString,
+  safe_message: OptionalString,
+};
+
+const AxiomRedactionRow = Schema.Struct(AxiomRedactionRowFields);
+
+type AxiomRedactionRow = typeof AxiomRedactionRow.Type;
+
+export type AxiomRedactionAttributes = {
+  readonly authorization: Option.Option<string>;
+  readonly password: Option.Option<string>;
+  readonly accessToken: Option.Option<string>;
+  readonly userPassword: Option.Option<string>;
+  readonly phoneNumber: Option.Option<string>;
+  readonly tokenizer: Option.Option<string>;
+  readonly documentation: Option.Option<string>;
+  readonly safeMessage: Option.Option<string>;
+};
+
+const toAxiomRedactionAttributes = (row: AxiomRedactionRow): AxiomRedactionAttributes => ({
+  authorization: Option.fromNullishOr(row.authorization),
+  password: Option.fromNullishOr(row.password),
+  accessToken: Option.fromNullishOr(row.access_token),
+  userPassword: Option.fromNullishOr(row.user_password),
+  phoneNumber: Option.fromNullishOr(row.phone_number),
+  tokenizer: Option.fromNullishOr(row.tokenizer),
+  documentation: Option.fromNullishOr(row.documentation),
+  safeMessage: Option.fromNullishOr(row.safe_message),
+});
+
+const redactionProjection =
+  "authorization = tostring(['attributes.custom']['authorization']), password = tostring(['attributes.custom']['password']), access_token = tostring(['attributes.custom']['accessToken']), user_password = tostring(['attributes.custom']['userPassword']), phone_number = tostring(['attributes.custom']['phoneNumber']), tokenizer = tostring(['attributes.custom']['tokenizer']), documentation = tostring(['attributes.custom']['documentation']), safe_message = tostring(['attributes.custom']['safe.message'])";
 
 const AxiomSpanRow = Schema.Struct({
   trace_id: Schema.NonEmptyString,
@@ -57,6 +123,7 @@ const AxiomSpanRow = Schema.Struct({
   service_version: OptionalString,
   environment: OptionalString,
   events: OptionalString,
+  ...AxiomRedactionRowFields,
 });
 
 const decodeAxiomSpanRow = Schema.decodeUnknownOption(AxiomSpanRow);
@@ -70,6 +137,7 @@ export type AxiomSpan = {
   readonly serviceVersion: Option.Option<string>;
   readonly environment: Option.Option<string>;
   readonly events: Option.Option<string>;
+  readonly redaction: AxiomRedactionAttributes;
 };
 
 const toAxiomSpan = (row: typeof AxiomSpanRow.Type): AxiomSpan => ({
@@ -83,10 +151,10 @@ const toAxiomSpan = (row: typeof AxiomSpanRow.Type): AxiomSpan => ({
   serviceVersion: Option.fromNullishOr(row.service_version),
   environment: Option.fromNullishOr(row.environment),
   events: Option.fromNullishOr(row.events),
+  redaction: toAxiomRedactionAttributes(row),
 });
 
-const spanProjection =
-  "project trace_id, span_id, parent_span_id, name, service_name = ['service.name'], service_version = ['service.version'], environment = tostring(['resource.custom']['deployment.environment.name']), events = tostring(events)";
+const spanProjection = `project trace_id, span_id, parent_span_id, name, service_name = ['service.name'], service_version = ['service.version'], environment = tostring(['resource.custom']['deployment.environment.name']), events = tostring(events), ${redactionProjection}`;
 
 export const findRootSpan = (
   env: AxiomEnvironment,
@@ -127,9 +195,7 @@ const AxiomLogRow = Schema.Struct({
   event_source: OptionalString,
   service_name: OptionalString,
   body: OptionalString,
-  authorization: OptionalString,
-  password: OptionalString,
-  safe_message: OptionalString,
+  ...AxiomRedactionRowFields,
 });
 
 const decodeAxiomLogRow = Schema.decodeUnknownOption(AxiomLogRow);
@@ -141,9 +207,7 @@ export type AxiomLog = {
   readonly eventSource: Option.Option<string>;
   readonly serviceName: Option.Option<string>;
   readonly body: Option.Option<string>;
-  readonly authorization: Option.Option<string>;
-  readonly password: Option.Option<string>;
-  readonly safeMessage: Option.Option<string>;
+  readonly redaction: AxiomRedactionAttributes;
 };
 
 const toAxiomLog = (row: typeof AxiomLogRow.Type): AxiomLog => ({
@@ -153,9 +217,7 @@ const toAxiomLog = (row: typeof AxiomLogRow.Type): AxiomLog => ({
   eventSource: Option.fromNullishOr(row.event_source),
   serviceName: Option.fromNullishOr(row.service_name),
   body: Option.fromNullishOr(row.body),
-  authorization: Option.fromNullishOr(row.authorization),
-  password: Option.fromNullishOr(row.password),
-  safeMessage: Option.fromNullishOr(row.safe_message),
+  redaction: toAxiomRedactionAttributes(row),
 });
 
 export const findLogs = (
@@ -164,7 +226,7 @@ export const findLogs = (
 ): Effect.Effect<ReadonlyArray<AxiomLog>> =>
   runQuery(
     env,
-    `['${env.AXIOM_DATASET_LOGS}'] | where ['attributes.custom']['canary.run_id'] == '${runId}' | project trace_id, event_name = tostring(['attributes.custom']['event.name']), event_kind = tostring(['attributes.custom']['event.kind']), event_source = tostring(['attributes.custom']['event.source']), service_name = ['service.name'], body = tostring(body), authorization = tostring(['attributes.custom']['authorization']), password = tostring(['attributes.custom']['password']), safe_message = tostring(['attributes.custom']['safe.message'])`,
+    `['${env.AXIOM_DATASET_LOGS}'] | where ['attributes.custom']['canary.run_id'] == '${runId}' | project trace_id, event_name = tostring(['attributes.custom']['event.name']), event_kind = tostring(['attributes.custom']['event.kind']), event_source = tostring(['attributes.custom']['event.source']), service_name = ['service.name'], body = tostring(body), ${redactionProjection}`,
   ).pipe(
     Effect.map((rows) =>
       rows.flatMap((row) =>
@@ -173,5 +235,22 @@ export const findLogs = (
           Option.match({ onNone: () => [], onSome: (log) => [log] }),
         ),
       ),
+    ),
+  );
+
+export type AxiomMetric = {
+  readonly content: string;
+};
+
+export const findMetric = (
+  env: AxiomEnvironment,
+  runId: string,
+): Effect.Effect<Option.Option<AxiomMetric>> =>
+  runMetricsQuery(
+    env,
+    `\`${env.AXIOM_DATASET_METRICS}\`:\`canary.operations\` | where \`canary.run_id\` == "${runId}"`,
+  ).pipe(
+    Effect.map((content) =>
+      content.includes(runId) ? Option.some({ content }) : Option.none<AxiomMetric>(),
     ),
   );

--- a/packages/telemetry/test/support/canary.ts
+++ b/packages/telemetry/test/support/canary.ts
@@ -18,16 +18,54 @@ export const canaryRunId = (): string => {
 };
 
 export const canarySensitiveValues = (runId: string) => {
-  const authorization = `Bearer auth-${runId}`;
-  const password = `password-${runId}`;
-  const token = `sk-${runId}`;
-  const email = `${runId}@example.test`;
+  const compactRunId = runId.replaceAll("-", "");
+  const authorizationMarker = `authorizationmarker${compactRunId}`;
+  const passwordMarker = `passwordmarker${compactRunId}`;
+  const tokenMarker = `tokenmarker${compactRunId}`;
+  const emailMarker = `emailmarker${compactRunId}`;
+  const accessTokenMarker = `accesstokenmarker${compactRunId}`;
+  const userPasswordMarker = `userpasswordmarker${compactRunId}`;
+  const phoneNumberMarker = `phonenumbermarker${compactRunId}`;
+  const authorization = `Bearer ${authorizationMarker}`;
+  const password = `opaque-${passwordMarker}-value`;
+  const token = `sk-${tokenMarker}`;
+  const email = `${emailMarker}@example.test`;
+  const accessToken = `opaque-${accessTokenMarker}-value`;
+  const userPassword = `prefix"${userPasswordMarker}`;
+  const phoneNumber = `opaque-${phoneNumberMarker}-value`;
+  const tokenizerValue = `tokenizercontrol${compactRunId}`;
+  const documentationValue = `documentationcontrol${compactRunId}`;
   return {
     authorization,
     password,
     token,
     email,
-    serializedBody: JSON.stringify({ authorization, password, token, email }),
+    accessToken,
+    userPassword,
+    phoneNumber,
+    leakMarkers: [
+      authorizationMarker,
+      passwordMarker,
+      tokenMarker,
+      emailMarker,
+      accessTokenMarker,
+      userPasswordMarker,
+      phoneNumberMarker,
+    ],
+    tokenizerValue,
+    documentationValue,
+    preservedValues: [tokenizerValue, documentationValue],
+    serializedBody: JSON.stringify({
+      authorization,
+      password,
+      token,
+      email,
+      accessToken,
+      userPassword,
+      phoneNumber,
+      tokenizer: tokenizerValue,
+      documentation: documentationValue,
+    }),
   };
 };
 
@@ -37,6 +75,11 @@ export const emitCanary = (config: TelemetryConfig, runId: string): Effect.Effec
     "canary.run_id": runId,
     authorization: sensitive.authorization,
     password: sensitive.password,
+    accessToken: sensitive.accessToken,
+    userPassword: sensitive.userPassword,
+    phoneNumber: sensitive.phoneNumber,
+    tokenizer: sensitive.tokenizerValue,
+    documentation: sensitive.documentationValue,
     "safe.message": `token=${sensitive.token} email=${sensitive.email}`,
   };
   return Effect.gen(function* () {

--- a/packages/telemetry/test/support/canary.ts
+++ b/packages/telemetry/test/support/canary.ts
@@ -17,13 +17,41 @@ export const canaryRunId = (): string => {
   return `test-${user === "" ? "ci" : user}-${Date.now()}-${entropy}`;
 };
 
-export const emitCanary = (config: TelemetryConfig, runId: string): Effect.Effect<void> =>
-  Effect.gen(function* () {
+export const canarySensitiveValues = (runId: string) => {
+  const authorization = `Bearer auth-${runId}`;
+  const password = `password-${runId}`;
+  const token = `sk-${runId}`;
+  const email = `${runId}@example.test`;
+  return {
+    authorization,
+    password,
+    token,
+    email,
+    serializedBody: JSON.stringify({ authorization, password, token, email }),
+  };
+};
+
+export const emitCanary = (config: TelemetryConfig, runId: string): Effect.Effect<void> => {
+  const sensitive = canarySensitiveValues(runId);
+  const sensitiveAttributes = {
+    "canary.run_id": runId,
+    authorization: sensitive.authorization,
+    password: sensitive.password,
+    "safe.message": `token=${sensitive.token} email=${sensitive.email}`,
+  };
+  return Effect.gen(function* () {
     const operationCounter = Metric.counter("canary.operations", {
-      attributes: { "canary.run_id": runId },
+      attributes: sensitiveAttributes,
     });
     yield* Effect.sleep("10 millis").pipe(Effect.withSpan("canary.child"));
     yield* WideEvent.emit("canary.completed", { "canary.run_id": runId });
+    yield* Effect.logInfo(sensitive.serializedBody).pipe(
+      Effect.annotateLogs({
+        ...sensitiveAttributes,
+        "event.name": "canary.redaction",
+        "event.kind": "wide",
+      }),
+    );
     yield* ingestBrowserEvents({
       version: 1,
       events: [
@@ -37,8 +65,7 @@ export const emitCanary = (config: TelemetryConfig, runId: string): Effect.Effec
     }).pipe(Effect.orDie);
     yield* Metric.update(operationCounter, 1);
   }).pipe(
-    Effect.withSpan("canary.operation", {
-      attributes: { "canary.run_id": runId },
-    }),
+    Effect.withSpan("canary.operation", { attributes: sensitiveAttributes }),
     Effect.provide(Telemetry.layer(config)),
   );
+};


### PR DESCRIPTION
## Redaction contract

- Mask sensitive attributes in traces, logs, and metric datapoints.
- Redact serialized log bodies and span event names.
- Handle escaped JSON strings and camelCase sensitive keys.
- Preserve benign keys such as `tokenizer` and `documentation`.
- Keep the local and production Collector policies identical.

## Evidence

- `868b40a` reproduces the escaped JSON and camelCase leaks.
- `3e04f1f` closes both Collector bypasses.
- `cd406af` verifies every pipeline processor sequence.
- `e66e046` adds deployed trace, log, and metric checks.

## Verification

- `bun check`
- `bun run build`
- `bun run test`
- `bun run test:package`
- Collector validation for `local.yaml` and `production.yaml`
- Local end-to-end canary against Collector `0.159.0`
- Full exporter scan for run-scoped leak markers
- APL and MPL request contract tests

The credentialed deployed canary remains conditional on the Axiom CI credentials.

Linear: OBS-2
