### PR TITLE
Add observability verification skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist
 *.local
 *.log
 logs
+/.verification/
 .DS_Store
 
 .env

--- a/.pi/skills/verify-observability/SKILL.md
+++ b/.pi/skills/verify-observability/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: verify-observability
+description: Verify the observability CLI and local OpenTelemetry pipeline with disposable Docker state. Use after changes to stack lifecycle, telemetry export, redaction, package delivery, or project asset setup.
+---
+
+# Verify observability
+
+Drive the documented CLI and the local telemetry pipeline. Run all commands from the repository root in one Bash session.
+
+Read [the feature map](features/README.md) before a verification run. Use the selected feature file for the requested behavior.
+
+## Launch
+
+Require Bash, curl, netcat, Bun 1.4 or later, Docker Compose, and an active Docker daemon. The first launch can pull container images.
+
+Create one run identity and two separate directories:
+
+```bash
+export RUN_ID="verify-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+export STATE_ROOT="${TMPDIR:-/tmp}/observability-$RUN_ID"
+export ARTIFACT_ROOT="$PWD/.verification/observability/$RUN_ID"
+mkdir -p "$STATE_ROOT" "$ARTIFACT_ROOT"
+printf 'RUN_ID=%s\nSTATE_ROOT=%s\nARTIFACT_ROOT=%s\n' "$RUN_ID" "$STATE_ROOT" "$ARTIFACT_ROOT" > "$ARTIFACT_ROOT/run.env"
+```
+
+Refuse to start if another `observability-local` stack exists. The Compose project name and loopback ports are shared.
+
+```bash
+if docker ps -a --filter label=com.docker.compose.project=observability-local --format '{{.ID}}' | grep -q .; then
+  printf '%s\n' 'An observability-local stack already exists.' >&2
+  exit 1
+fi
+for port in 4317 4318 8000; do
+  if nc -z 127.0.0.1 "$port" > /dev/null 2>&1; then
+    printf 'Port %s already has a listener.\n' "$port" >&2
+    exit 1
+  fi
+done
+bun --version > "$ARTIFACT_ROOT/bun-version.txt"
+docker info --format '{{.ServerVersion}}' > "$ARTIFACT_ROOT/docker-version.txt"
+git rev-parse HEAD > "$ARTIFACT_ROOT/build-revision.txt"
+```
+
+Start the stack through the real CLI. Record the action and its output.
+
+```bash
+printf 'OBSERVABILITY_HOME=%q bun packages/cli/src/main.ts dev up > %q 2> %q\n' "$STATE_ROOT" "$ARTIFACT_ROOT/launch.stdout" "$ARTIFACT_ROOT/launch.stderr" >> "$ARTIFACT_ROOT/commands.txt"
+OBSERVABILITY_HOME="$STATE_ROOT" bun packages/cli/src/main.ts dev up > "$ARTIFACT_ROOT/launch.stdout" 2> "$ARTIFACT_ROOT/launch.stderr"
+printf '%s\n' "$?" > "$ARTIFACT_ROOT/launch.exit-code"
+test "$(cat "$ARTIFACT_ROOT/launch.exit-code")" = "0"
+export COMPOSE_FILE="$(find "$STATE_ROOT" -type f -name docker-compose.yml -print -quit)"
+test -n "$COMPOSE_FILE"
+printf 'COMPOSE_FILE=%s\n' "$COMPOSE_FILE" >> "$ARTIFACT_ROOT/run.env"
+```
+
+## Doctor
+
+Run this read-only check before a feature recipe:
+
+```bash
+bun packages/cli/src/main.ts --version > "$ARTIFACT_ROOT/cli-version.txt"
+docker compose -f "$COMPOSE_FILE" ps --status running --services | sort > "$ARTIFACT_ROOT/doctor.services"
+printf 'collector\nviewer\n' | diff -u - "$ARTIFACT_ROOT/doctor.services"
+curl --fail --silent --show-error http://127.0.0.1:8000/ > "$ARTIFACT_ROOT/viewer.html"
+printf 'bun packages/cli/src/main.ts dev status --file %q > %q 2> %q\n' "$COMPOSE_FILE" "$ARTIFACT_ROOT/status.stdout" "$ARTIFACT_ROOT/status.stderr" >> "$ARTIFACT_ROOT/commands.txt"
+bun packages/cli/src/main.ts dev status --file "$COMPOSE_FILE" > "$ARTIFACT_ROOT/status.stdout" 2> "$ARTIFACT_ROOT/status.stderr"
+printf '%s\n' "$?" > "$ARTIFACT_ROOT/status.exit-code"
+test "$(cat "$ARTIFACT_ROOT/status.exit-code")" = "0"
+```
+
+Continue only when both services run, the viewer responds, and the CLI status exits with code `0`.
+
+## Drive
+
+Use [Pipeline canary](features/pipeline-canary.md) as the baseline proof:
+
+```bash
+printf 'OBSERVABILITY_HOME=%q OBSERVABILITY_E2E=1 bun run test:canary > %q 2> %q\n' "$STATE_ROOT" "$ARTIFACT_ROOT/canary.stdout" "$ARTIFACT_ROOT/canary.stderr" >> "$ARTIFACT_ROOT/commands.txt"
+OBSERVABILITY_HOME="$STATE_ROOT" OBSERVABILITY_E2E=1 bun run test:canary > "$ARTIFACT_ROOT/canary.stdout" 2> "$ARTIFACT_ROOT/canary.stderr"
+printf '%s\n' "$?" > "$ARTIFACT_ROOT/canary.exit-code"
+test "$(cat "$ARTIFACT_ROOT/canary.exit-code")" = "0"
+export EXPORT_FILE="$(find "$STATE_ROOT" -type f -path '*/data/otlp.jsonl' -print -quit)"
+test -n "$EXPORT_FILE"
+cp "$EXPORT_FILE" "$ARTIFACT_ROOT/otlp.jsonl"
+grep -Eo 'test-[a-z0-9-]+' "$ARTIFACT_ROOT/otlp.jsonl" | sort -u > "$ARTIFACT_ROOT/canary-run-ids.txt"
+test "$(wc -l < "$ARTIFACT_ROOT/canary-run-ids.txt" | tr -d ' ')" = "1"
+printf 'EXPORT_FILE=%s\n' "$EXPORT_FILE" >> "$ARTIFACT_ROOT/run.env"
+```
+
+Require exit code `0`. The canary proves correlated traces, logs, metrics, browser ingestion, resource attributes, and sensitive-data redaction.
+
+## Evidence
+
+Keep evidence under `.verification/observability/$RUN_ID`.
+
+Capture these facts for each proof:
+
+- the exact command;
+- stdout, stderr, and the exit code;
+- `doctor.services` and `status.stdout`;
+- the isolated `otlp.jsonl` export;
+- the canary run ID;
+- generated files for write-based CLI features.
+
+Capture the action and the result. Do not use the viewer page alone as proof. Verify file writes and telemetry exports through a second read.
+
+## Cleanup
+
+Run cleanup after success and after each failed attempt:
+
+```bash
+if test -n "${COMPOSE_FILE:-}" && test -f "$COMPOSE_FILE"; then
+  printf 'bun packages/cli/src/main.ts dev down --file %q > %q 2> %q\n' "$COMPOSE_FILE" "$ARTIFACT_ROOT/cleanup.stdout" "$ARTIFACT_ROOT/cleanup.stderr" >> "$ARTIFACT_ROOT/commands.txt"
+  bun packages/cli/src/main.ts dev down --file "$COMPOSE_FILE" > "$ARTIFACT_ROOT/cleanup.stdout" 2> "$ARTIFACT_ROOT/cleanup.stderr"
+  printf '%s\n' "$?" > "$ARTIFACT_ROOT/cleanup.exit-code"
+  test "$(cat "$ARTIFACT_ROOT/cleanup.exit-code")" = "0"
+fi
+if test -z "${STATE_ROOT:-}"; then
+  printf '%s\n' 'STATE_ROOT is empty. Cleanup stopped.' >&2
+  exit 1
+fi
+case "$STATE_ROOT" in
+  "${TMPDIR:-/tmp}"/observability-verify-*) rm -rf -- "$STATE_ROOT" ;;
+  *) printf 'STATE_ROOT is outside the verification prefix: %s\n' "$STATE_ROOT" >&2; exit 1 ;;
+esac
+test ! -e "$STATE_ROOT"
+test -d "$ARTIFACT_ROOT"
+```
+
+Keep the evidence directory after cleanup. Never stop containers by process name or container name.
+
+## Helpers
+
+The repository owns the verification commands:
+
+- `bun packages/cli/src/main.ts` drives the CLI.
+- `bun run test:canary` drives the local telemetry pipeline.
+- `bun run test:package` verifies packed artifacts from an external consumer directory.
+
+Do not add a second wrapper unless a repository command cannot express a required user path.

--- a/.pi/skills/verify-observability/features/README.md
+++ b/.pi/skills/verify-observability/features/README.md
@@ -1,0 +1,48 @@
+# Observability verification map
+
+This directory defines the maintained user-facing verification paths for the observability CLI and telemetry pipeline.
+
+## Baseline preconditions
+
+- Run commands from the repository root in Bash.
+- Use the disposable `STATE_ROOT` from the parent skill.
+- Keep evidence in `.verification/observability/$RUN_ID`.
+- Require Bun 1.4 or later.
+- Require Docker for stack and pipeline features.
+- Refuse to drive a stack that this run did not start.
+- Keep Axiom and Sentry credentials out of local verification.
+
+## Drive conventions
+
+- Start each recipe from its listed preconditions.
+- Drive the CLI through `bun packages/cli/src/main.ts`.
+- Use `OBSERVABILITY_HOME="$STATE_ROOT"` for CLI state.
+- Use one Compose project at a time because the project name and ports are fixed.
+- Record each command, stdout, stderr, and exit code.
+- Read generated files or exported telemetry after each write.
+- Run cleanup after success and after each failed attempt.
+
+## Proof and skip reports
+
+- Capture the user action and its observable result.
+- Keep proof artifacts after cleanup.
+- Report Docker, port, credential, and network preconditions that block a path.
+- Do not substitute unit tests for a listed CLI or pipeline entry point.
+- Do not report the deployed canary as verified without dedicated Axiom datasets.
+
+## Feature entry contract
+
+Each feature file contains exactly four H2 sections in this order:
+
+1. `Sub-features` names the supported behavior.
+2. `How to get to it (user POV)` lists each user entry point.
+3. `Driving it with verify-observability` gives exact commands and observable results.
+4. `Gotchas` names conditions that can invalidate a run.
+
+## Features
+
+- [Local stack lifecycle](./local-stack-lifecycle.md) covers isolated launch, status, viewer readiness, and teardown.
+- [Pipeline canary](./pipeline-canary.md) covers correlated traces, logs, metrics, and browser events.
+- [Sensitive-data redaction](./sensitive-data-redaction.md) covers blocked fields, blocked values, and preserved controls.
+- [Project asset setup](./project-provisioning.md) covers asset creation, idempotency, conflict protection, and forced replacement.
+- [Package delivery](./package-delivery.md) covers packed files, external imports, declarations, CLI help, and local asset setup.

--- a/.pi/skills/verify-observability/features/local-stack-lifecycle.md
+++ b/.pi/skills/verify-observability/features/local-stack-lifecycle.md
@@ -1,0 +1,44 @@
+# Local stack lifecycle
+
+The CLI starts, inspects, and stops the local Collector and telemetry viewer through Docker Compose.
+
+## Sub-features
+
+- `stack-up` starts the Collector and the viewer.
+- `stack-status` reports both services through the CLI.
+- `stack-viewer` exposes the viewer only on loopback.
+- `stack-down` removes the containers that the run started.
+- `stack-isolation` keeps generated assets outside the user state directory.
+
+## How to get to it (user POV)
+
+- Run `observability dev up` from a terminal.
+- Run `observability dev status` from a terminal.
+- Open `http://127.0.0.1:8000/`.
+- Run `observability dev down` from a terminal.
+
+## Driving it with verify-observability
+
+Preconditions:
+
+- Docker is available.
+- Ports `4317`, `4318`, and `8000` have no listeners.
+- No container has the Compose project label `observability-local`.
+- The parent skill created `STATE_ROOT` and `ARTIFACT_ROOT`.
+
+- **Launch.** Run `OBSERVABILITY_HOME="$STATE_ROOT" bun packages/cli/src/main.ts dev up`. Exit code `0` means Docker Compose accepted the stack and waited for startup.
+- **Identify ownership.** Find `docker-compose.yml` under `STATE_ROOT`. The file path must belong to this run.
+- **Verify services.** Run `docker compose -f "$COMPOSE_FILE" ps --status running --services`. The sorted output is exactly `collector` and `viewer`.
+- **Verify CLI status.** Run `bun packages/cli/src/main.ts dev status --file "$COMPOSE_FILE"`. Exit code `0` and stdout list both services.
+- **Verify viewer.** Run `curl --fail --silent --show-error http://127.0.0.1:8000/`. The response body is non-empty.
+- **Capture proof.** Save the launch output, status output, active service list, viewer response, and exit codes under `ARTIFACT_ROOT`.
+- **Stop.** Run `bun packages/cli/src/main.ts dev down --file "$COMPOSE_FILE"`. Exit code `0` confirms Compose removed the owned stack.
+- **Confirm teardown.** Run `docker compose -f "$COMPOSE_FILE" ps --all --services`. The output is empty.
+
+## Gotchas
+
+- The Compose project name is fixed. Two verification runs cannot use the stack concurrently.
+- The ports are fixed and loopback-only. Do not remap them without a separate verified Compose file.
+- `dev status` without `--file` prepares assets. Use the owned Compose file for a read-only status check.
+- The first launch can pull images from the network.
+- Cleanup removes `STATE_ROOT` only after Compose teardown.

--- a/.pi/skills/verify-observability/features/package-delivery.md
+++ b/.pi/skills/verify-observability/features/package-delivery.md
@@ -1,0 +1,39 @@
+# Package delivery
+
+The package smoke test verifies the published file set and both packages from a temporary external consumer project.
+
+## Sub-features
+
+- `package-files` includes each required runtime file and excludes source and test files.
+- `package-imports` loads every public telemetry entrypoint from an external project.
+- `package-types` checks generated declarations through the external TypeScript compiler.
+- `package-cli` executes help and status through the packed CLI binary.
+- `package-assets` verifies local stack assets and provisioned production assets from the packed CLI.
+
+## How to get to it (user POV)
+
+- Run `bun run test:package` from the repository root.
+- Inspect the command output for the first failed package operation.
+
+## Driving it with verify-observability
+
+Preconditions:
+
+- Bun dependencies are installed.
+- Docker is available because the packed CLI runs `dev status`.
+- `ARTIFACT_ROOT` exists.
+- No package publish command runs in this recipe.
+
+- **Build packages.** Run `bun run test:package`. The script builds both package distributions before it creates archives.
+- **Verify archives.** Require exit code `0`. The script checks required files and rejects packaged `src` and `test` directories.
+- **Verify imports.** Require exit code `0`. The temporary consumer imports each public telemetry entrypoint.
+- **Verify declarations.** Require exit code `0`. The external TypeScript compiler checks package declarations without source specifiers.
+- **Verify the CLI.** Require exit code `0`. The packed binary prints help, prepares local stack assets, and provisions production assets.
+- **Capture proof.** Save the exact command, stdout, stderr, and exit code under `ARTIFACT_ROOT`.
+
+## Gotchas
+
+- The smoke test creates archives and a consumer under a temporary directory. It removes that directory before exit.
+- The smoke test does not publish either package.
+- Docker must be active even though the smoke test does not start the local stack.
+- A successful source import does not replace this proof. The recipe executes the packed artifacts.

--- a/.pi/skills/verify-observability/features/pipeline-canary.md
+++ b/.pi/skills/verify-observability/features/pipeline-canary.md
@@ -1,0 +1,40 @@
+# Pipeline canary
+
+The local canary emits telemetry through the real OTLP endpoint and verifies the Collector file export.
+
+## Sub-features
+
+- `pipeline-trace` exports a root span and a correlated child span.
+- `pipeline-log` exports a correlated wide-event log.
+- `pipeline-browser` ingests and exports a browser event.
+- `pipeline-metric` exports the `canary.operations` counter.
+- `pipeline-resource` preserves service and environment attributes.
+
+## How to get to it (user POV)
+
+- Start the local stack with `observability dev up`.
+- Run the repository canary with `OBSERVABILITY_E2E=1 bun run test:canary`.
+- Inspect the isolated Collector export at `data/otlp.jsonl` under `STATE_ROOT`.
+
+## Driving it with verify-observability
+
+Preconditions:
+
+- The local stack passed the parent skill doctor check.
+- `OBSERVABILITY_HOME` points to `STATE_ROOT`.
+- `ARTIFACT_ROOT` exists.
+
+- **Emit telemetry.** Run `OBSERVABILITY_HOME="$STATE_ROOT" OBSERVABILITY_E2E=1 bun run test:canary`. The test exits with code `0`.
+- **Read the export.** Find `data/otlp.jsonl` under `STATE_ROOT`. The file exists and has content.
+- **Identify the run.** Extract `test-[a-z0-9-]+` values from the export. Exactly one unique canary run ID exists in the isolated file.
+- **Verify correlation.** Use the canary result as the assertion source. It verifies the trace ID, span parent, correlated log, browser event, and metric value.
+- **Verify resources.** Use the canary result as the assertion source. It verifies `service.name`, `service.version`, and `deployment.environment.name` across signals.
+- **Capture proof.** Copy `otlp.jsonl` and save the canary output, exit code, and extracted run ID under `ARTIFACT_ROOT`.
+
+## Gotchas
+
+- The test skips unless `OBSERVABILITY_E2E=1` is set.
+- The canary reads the CLI package version to derive the default export path.
+- A shared `OBSERVABILITY_HOME` can mix old events into the proof. Always use `STATE_ROOT`.
+- The viewer page is not the assertion source. The canary reads the Collector file export.
+- The deployed canary is a separate feature with credential and dataset requirements.

--- a/.pi/skills/verify-observability/features/project-provisioning.md
+++ b/.pi/skills/verify-observability/features/project-provisioning.md
@@ -1,0 +1,40 @@
+# Project asset setup
+
+The CLI writes production Collector and Kamal accessory assets into a disposable target project.
+
+## Sub-features
+
+- `provision-create` creates both production assets.
+- `provision-render` replaces the project-name template in dataset names.
+- `provision-idempotent` reports unchanged files on a repeated run.
+- `provision-conflict` preserves a local modification and reports a typed conflict.
+- `provision-force` replaces the modified generated file only when the user selects `--force`.
+
+## How to get to it (user POV)
+
+- Run `observability provision --dir <project> --name <name>`.
+- Run the same command again to verify idempotency.
+- Run the command with `--force` to replace a modified generated file.
+
+## Driving it with verify-observability
+
+Preconditions:
+
+- The parent skill created `STATE_ROOT` and `ARTIFACT_ROOT`.
+- `PROVISION_TARGET="$STATE_ROOT/provision-target"` does not contain user files.
+- No `--environment` flag is present.
+
+- **Create the target.** Run `mkdir -p "$PROVISION_TARGET"`.
+- **Provision assets.** Run `bun packages/cli/src/main.ts provision --dir "$PROVISION_TARGET" --name verify-app`. Exit code `0` and stdout report two created files.
+- **Read generated state.** Read `observability/collector.yaml` and `observability/kamal.accessory.yml` under `PROVISION_TARGET`. The Collector uses `${env:AXIOM_TOKEN}`. The accessory contains `verify-app-traces`, `verify-app-logs`, and `verify-app-metrics`.
+- **Verify idempotency.** Run the same command again. Exit code `0` and stdout report both files as unchanged.
+- **Create a conflict.** Replace the disposable `collector.yaml` content with `receivers: {}`. Run the command without `--force`. Exit code `1`, stderr contains `OBS_CLI_PROVISION_CONFLICT`, and the file still contains `receivers: {}`.
+- **Verify force.** Run the command with `--force`. Exit code `0`, stdout reports the Collector as updated, and the production Collector content returns.
+- **Capture proof.** Copy both final assets and save every command output and exit code under `ARTIFACT_ROOT`.
+
+## Gotchas
+
+- Never use a real project directory for this recipe.
+- The `--environment` flag creates remote Axiom and Sentry resources. Keep it absent.
+- The `--force` flag can replace local edits. Use it only inside `PROVISION_TARGET`.
+- The command prints deployment guidance after local asset setup. That text does not mean that a deployment occurred.

--- a/.pi/skills/verify-observability/features/sensitive-data-redaction.md
+++ b/.pi/skills/verify-observability/features/sensitive-data-redaction.md
@@ -1,0 +1,39 @@
+# Sensitive-data redaction
+
+The local pipeline removes configured secret fields and secret values while it preserves unrelated control values.
+
+## Sub-features
+
+- `redaction-attributes` replaces sensitive attribute values with `****`.
+- `redaction-bodies` replaces sensitive values in log bodies with `[REDACTED]`.
+- `redaction-events` replaces sensitive values in span event names.
+- `redaction-negative-controls` preserves words that only contain sensitive substrings.
+- `redaction-signals` applies the policy to traces, logs, and metrics.
+
+## How to get to it (user POV)
+
+- Start the local stack with `observability dev up`.
+- Run `OBSERVABILITY_E2E=1 bun run test:canary`.
+- Inspect the isolated Collector export for redacted and preserved values.
+
+## Driving it with verify-observability
+
+Preconditions:
+
+- The local stack passed the parent skill doctor check.
+- The pipeline canary uses a fresh `STATE_ROOT`.
+- `ARTIFACT_ROOT` exists.
+
+- **Emit markers.** Run `OBSERVABILITY_HOME="$STATE_ROOT" OBSERVABILITY_E2E=1 bun run test:canary`. The canary creates unique sensitive markers for this run.
+- **Verify blocked fields.** Require canary exit code `0`. The assertions cover authorization, password, access token, user password, and phone number attributes.
+- **Verify blocked values.** Require canary exit code `0`. The assertions reject bearer tokens, secret-key patterns, email addresses, and serialized secret fields.
+- **Verify output replacements.** Search the copied export for `****` and `[REDACTED]`. Both replacement forms exist.
+- **Verify negative controls.** Require canary exit code `0`. The assertions preserve the generated `tokenizer` and `documentation` control values.
+- **Capture proof.** Keep the canary output, isolated export, run ID, and replacement search output under `ARTIFACT_ROOT`.
+
+## Gotchas
+
+- Do not print the generated pre-redaction values outside the canary process.
+- Do not use production credentials or production datasets.
+- A visible replacement does not prove that every marker disappeared. Require the full canary result.
+- A canary pass does not verify the deployed Collector configuration. Use the deployed canary only with dedicated E2E datasets.


### PR DESCRIPTION
Adds a project-local Pi skill for the observability CLI and local OpenTelemetry pipeline.

The skill uses disposable Docker state, retains proof under `.verification/`, and refuses shared ports or Compose state. Its feature map covers stack lifecycle, pipeline correlation, redaction, project assets, and packed package delivery.

Verified with:

- `bun run check`
- `bun run test`
- `bun run test:package`
- Full launch, doctor, local canary, evidence, and cleanup flow
- Port-collision and unsafe-cleanup rejection probes
- Pi skill loading and structural validation