### PR TITLE
Add observability verification skill

### DIFF
--- a/.agents/skills/verify-observability/SKILL.md
+++ b/.agents/skills/verify-observability/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: verify-observability
+description: Verify the Observability CLI and local OpenTelemetry pipeline. Use after changes to CLI commands, Collector assets, telemetry export, redaction, or package delivery.
+---
+
+# Verify observability
+
+Drive the built CLI and the local telemetry pipeline. Run all commands from the repository root in one Bash session.
+
+Read [the feature map](features/README.md) before a verification run. Select each feature that the change affects.
+
+## Launch
+
+The primary user interface is the short-lived `observability` CLI. Build it once, then start each command with isolated state.
+
+Require Bash, Bun 1.4 or later, and the installed repository dependencies. Docker features also require curl, netcat, Docker Compose, and an active daemon.
+
+```bash
+set -euo pipefail
+export RUN_ID="verify-$(date -u +%Y%m%dT%H%M%SZ)-$$-$RANDOM"
+export STATE_ROOT="${TMPDIR:-/tmp}/observability-$RUN_ID"
+export ARTIFACT_ROOT="$PWD/.verification/observability/$RUN_ID"
+export PROVISION_TARGET="$STATE_ROOT/provision-target"
+export CLI="$PWD/packages/cli/dist/main.js"
+mkdir -p "$STATE_ROOT" "$ARTIFACT_ROOT"
+printf 'RUN_ID=%q\nSTATE_ROOT=%q\nARTIFACT_ROOT=%q\nPROVISION_TARGET=%q\nCLI=%q\n' "$RUN_ID" "$STATE_ROOT" "$ARTIFACT_ROOT" "$PROVISION_TARGET" "$CLI" > "$ARTIFACT_ROOT/run.env"
+printf 'bun run build > %q 2> %q\n' "$ARTIFACT_ROOT/build.stdout" "$ARTIFACT_ROOT/build.stderr" > "$ARTIFACT_ROOT/commands.txt"
+bun run build > "$ARTIFACT_ROOT/build.stdout" 2> "$ARTIFACT_ROOT/build.stderr"
+printf '%s\n' "$?" > "$ARTIFACT_ROOT/build.exit-code"
+test "$(cat "$ARTIFACT_ROOT/build.exit-code")" = "0"
+test -f "$CLI"
+bun --version > "$ARTIFACT_ROOT/bun-version.txt"
+git rev-parse HEAD > "$ARTIFACT_ROOT/build-revision.txt"
+```
+
+The CLI does not keep a process alive. Start the local stack only for a feature that requires it.
+
+Two file-based runs can use separate `STATE_ROOT` values. Two local stack runs cannot share ports or the fixed Compose project name.
+
+## Doctor
+
+Run this read-only check before each feature recipe:
+
+```bash
+EXPECTED_VERSION="$(bun -e 'const manifest = await Bun.file("packages/cli/package.json").json(); console.log(manifest.version)')"
+printf 'bun %q --version > %q\n' "$CLI" "$ARTIFACT_ROOT/cli-version.txt" >> "$ARTIFACT_ROOT/commands.txt"
+bun "$CLI" --version > "$ARTIFACT_ROOT/cli-version.txt"
+test "$(cat "$ARTIFACT_ROOT/cli-version.txt")" = "observability v$EXPECTED_VERSION"
+printf 'bun %q --help > %q\n' "$CLI" "$ARTIFACT_ROOT/cli-help.txt" >> "$ARTIFACT_ROOT/commands.txt"
+bun "$CLI" --help > "$ARTIFACT_ROOT/cli-help.txt"
+for command in dev auth provision env; do
+  grep -Eq "^[[:space:]]+$command[[:space:]]" "$ARTIFACT_ROOT/cli-help.txt"
+done
+test "$(git rev-parse HEAD)" = "$(cat "$ARTIFACT_ROOT/build-revision.txt")"
+```
+
+Stop if the version, command list, or revision differs. Rebuild before another check.
+
+For a local stack recipe, also run its service doctor after `dev up`. Never drive an existing shared stack.
+
+## Drive
+
+Use [Project asset setup](features/project-provisioning.md) as the safe baseline proof:
+
+```bash
+mkdir -p "$PROVISION_TARGET" "$ARTIFACT_ROOT/project-provisioning"
+printf 'OBSERVABILITY_HOME=%q bun %q provision --dir %q --name verify-app\n' "$STATE_ROOT" "$CLI" "$PROVISION_TARGET" >> "$ARTIFACT_ROOT/commands.txt"
+OBSERVABILITY_HOME="$STATE_ROOT" bun "$CLI" provision --dir "$PROVISION_TARGET" --name verify-app > "$ARTIFACT_ROOT/project-provisioning/create.stdout" 2> "$ARTIFACT_ROOT/project-provisioning/create.stderr"
+printf '%s\n' "$?" > "$ARTIFACT_ROOT/project-provisioning/create.exit-code"
+grep -F 'created  observability/collector.yaml' "$ARTIFACT_ROOT/project-provisioning/create.stdout"
+grep -F 'created  observability/kamal.accessory.yml' "$ARTIFACT_ROOT/project-provisioning/create.stdout"
+grep -F '${env:AXIOM_TOKEN}' "$PROVISION_TARGET/observability/collector.yaml"
+for dataset in verify-app-traces verify-app-logs verify-app-metrics; do
+  grep -F "$dataset" "$PROVISION_TARGET/observability/kamal.accessory.yml"
+done
+cp "$PROVISION_TARGET/observability/collector.yaml" "$ARTIFACT_ROOT/project-provisioning/first-collector.yaml"
+cp "$PROVISION_TARGET/observability/kamal.accessory.yml" "$ARTIFACT_ROOT/project-provisioning/first-kamal.accessory.yml"
+printf 'OBSERVABILITY_HOME=%q bun %q provision --dir %q --name verify-app\n' "$STATE_ROOT" "$CLI" "$PROVISION_TARGET" >> "$ARTIFACT_ROOT/commands.txt"
+OBSERVABILITY_HOME="$STATE_ROOT" bun "$CLI" provision --dir "$PROVISION_TARGET" --name verify-app > "$ARTIFACT_ROOT/project-provisioning/repeat.stdout" 2> "$ARTIFACT_ROOT/project-provisioning/repeat.stderr"
+printf '%s\n' "$?" > "$ARTIFACT_ROOT/project-provisioning/repeat.exit-code"
+test "$(grep -c '^unchanged  observability/' "$ARTIFACT_ROOT/project-provisioning/repeat.stdout")" = "2"
+printf '%s\n' 'receivers: {}' > "$PROVISION_TARGET/observability/collector.yaml"
+printf 'OBSERVABILITY_HOME=%q bun %q provision --dir %q --name verify-app\n' "$STATE_ROOT" "$CLI" "$PROVISION_TARGET" >> "$ARTIFACT_ROOT/commands.txt"
+set +e
+OBSERVABILITY_HOME="$STATE_ROOT" bun "$CLI" provision --dir "$PROVISION_TARGET" --name verify-app > "$ARTIFACT_ROOT/project-provisioning/conflict.stdout" 2> "$ARTIFACT_ROOT/project-provisioning/conflict.stderr"
+CONFLICT_EXIT="$?"
+set -e
+printf '%s\n' "$CONFLICT_EXIT" > "$ARTIFACT_ROOT/project-provisioning/conflict.exit-code"
+test "$CONFLICT_EXIT" = "1"
+grep -F 'OBS_CLI_PROVISION_CONFLICT' "$ARTIFACT_ROOT/project-provisioning/conflict.stderr"
+test "$(cat "$PROVISION_TARGET/observability/collector.yaml")" = 'receivers: {}'
+printf 'OBSERVABILITY_HOME=%q bun %q provision --dir %q --name verify-app --force\n' "$STATE_ROOT" "$CLI" "$PROVISION_TARGET" >> "$ARTIFACT_ROOT/commands.txt"
+OBSERVABILITY_HOME="$STATE_ROOT" bun "$CLI" provision --dir "$PROVISION_TARGET" --name verify-app --force > "$ARTIFACT_ROOT/project-provisioning/force.stdout" 2> "$ARTIFACT_ROOT/project-provisioning/force.stderr"
+printf '%s\n' "$?" > "$ARTIFACT_ROOT/project-provisioning/force.exit-code"
+grep -F 'updated  observability/collector.yaml' "$ARTIFACT_ROOT/project-provisioning/force.stdout"
+grep -F '${env:AXIOM_TOKEN}' "$PROVISION_TARGET/observability/collector.yaml"
+cp "$PROVISION_TARGET/observability/collector.yaml" "$ARTIFACT_ROOT/project-provisioning/final-collector.yaml"
+cp "$PROVISION_TARGET/observability/kamal.accessory.yml" "$ARTIFACT_ROOT/project-provisioning/final-kamal.accessory.yml"
+```
+
+This recipe uses the real built CLI. It verifies creation, a second read, idempotency, conflict protection, and forced replacement.
+
+## Evidence
+
+Keep proof under `.verification/observability/$RUN_ID`.
+
+Capture these facts for each proof:
+
+- the exact user command.
+- stdout, stderr, and the exit code.
+- the build revision and CLI version.
+- the action and its resulting state.
+- a second read of each file or telemetry side effect.
+
+Exercise the real user path. Do not replace it with internal setters or test-only endpoints.
+
+Use mocks only at an existing production boundary. For dry-run modes, inspect files, network effects, and remote state.
+
+Do not trust the dry-run name. Verify each skipped side effect.
+
+## Cleanup
+
+Run cleanup after success and after each failed attempt:
+
+```bash
+if test -n "${COMPOSE_FILE:-}" && test -f "$COMPOSE_FILE"; then
+  printf 'bun %q dev down --file %q\n' "$CLI" "$COMPOSE_FILE" >> "$ARTIFACT_ROOT/commands.txt"
+  bun "$CLI" dev down --file "$COMPOSE_FILE" > "$ARTIFACT_ROOT/cleanup.stdout" 2> "$ARTIFACT_ROOT/cleanup.stderr"
+  printf '%s\n' "$?" > "$ARTIFACT_ROOT/cleanup.exit-code"
+  test "$(cat "$ARTIFACT_ROOT/cleanup.exit-code")" = "0"
+  test -z "$(docker compose -f "$COMPOSE_FILE" ps --all --services)"
+fi
+if test -z "${STATE_ROOT:-}"; then
+  printf '%s\n' 'STATE_ROOT is empty. Cleanup stopped.' >&2
+  exit 1
+fi
+case "$STATE_ROOT" in
+  "${TMPDIR:-/tmp}"/observability-verify-*) rm -rf -- "$STATE_ROOT" ;;
+  *) printf 'STATE_ROOT is outside the verification prefix: %s\n' "$STATE_ROOT" >&2; exit 1 ;;
+esac
+test ! -e "$STATE_ROOT"
+test -d "$ARTIFACT_ROOT"
+test -f "$ARTIFACT_ROOT/run.env"
+```
+
+Never stop containers by process name or container name. Remove only the state that this run created.
+
+Keep the evidence directory after cleanup.
+
+## Helpers
+
+The repository owns each verification command:
+
+- `bun packages/cli/dist/main.js` drives the built CLI.
+- `bun run test:canary` drives the local telemetry pipeline.
+- `bun run test:package` verifies packed artifacts from an external consumer directory.
+
+No extra helper script is required.

--- a/.agents/skills/verify-observability/features/README.md
+++ b/.agents/skills/verify-observability/features/README.md
@@ -1,0 +1,50 @@
+# Observability verification map
+
+This directory defines the maintained user paths for the Observability CLI and telemetry pipeline.
+
+## Baseline preconditions
+
+- Run commands from the repository root in Bash.
+- Build the CLI through the parent skill.
+- Use the disposable `STATE_ROOT` from the parent skill.
+- Keep evidence in `.verification/observability/$RUN_ID`.
+- Refuse to drive a local stack that this run did not start.
+- Keep production credentials out of local recipes.
+
+## Drive conventions
+
+- Start each recipe from its listed preconditions.
+- Drive the CLI through `bun "$CLI"`.
+- Set `OBSERVABILITY_HOME="$STATE_ROOT"` for CLI state.
+- Use one local stack at a time because its ports and Compose project name are fixed.
+- Record each command, stdout, stderr, and exit code.
+- Read generated files or exported telemetry after each write.
+- Run cleanup after success and after each failed attempt.
+
+## Proof and skip reports
+
+- Capture the user action and its observable result.
+- Keep proof artifacts after cleanup.
+- Report the exact precondition that blocks a path.
+- Do not substitute unit tests for a listed CLI or pipeline entry point.
+- Do not report remote resources without dedicated verification accounts.
+- Do not report the deployed canary without dedicated Axiom datasets.
+
+## Feature entry contract
+
+Each feature file contains exactly four H2 sections in this order.
+
+1. `Sub-features` names the supported behavior.
+2. `How to get to it (user POV)` lists each user entry point.
+3. `Driving it with verify-observability` gives exact commands and observable results.
+4. `Gotchas` names conditions that can invalidate a run.
+
+## Features
+
+- [Project asset setup](./project-provisioning.md) covers creation, idempotency, conflict protection, and forced replacement.
+- [Local stack lifecycle](./local-stack-lifecycle.md) covers launch, status, viewer readiness, and teardown.
+- [Pipeline canary](./pipeline-canary.md) covers traces, logs, metrics, browser events, and redaction.
+- [Provider authentication](./provider-authentication.md) covers protected login prompts, credential permissions, and provider status.
+- [Package delivery](./package-delivery.md) covers package files, imports, declarations, CLI help, and packaged assets.
+
+Remote environment creation is not a disposable recipe. The CLI has no command that deletes provider resources.

--- a/.agents/skills/verify-observability/features/local-stack-lifecycle.md
+++ b/.agents/skills/verify-observability/features/local-stack-lifecycle.md
@@ -1,0 +1,46 @@
+# Local stack lifecycle
+
+The CLI starts, inspects, and stops the local Collector and telemetry viewer through Docker Compose.
+
+## Sub-features
+
+- `stack-up` starts the Collector and the viewer.
+- `stack-status` reports both services through the CLI.
+- `stack-viewer` exposes the viewer only on loopback.
+- `stack-down` removes the containers that the run started.
+- `stack-isolation` keeps generated files outside the user state directory.
+
+## How to get to it (user POV)
+
+- Run `observability dev up` from a terminal.
+- Run `observability dev status` from a terminal.
+- Open `http://127.0.0.1:8000/`.
+- Run `observability dev down` from a terminal.
+
+## Driving it with verify-observability
+
+Preconditions:
+
+- Docker Compose and the Docker daemon are available.
+- Ports `4317`, `4318`, and `8000` have no listeners.
+- No container has the Compose project label `observability-local`.
+- The parent skill created `STATE_ROOT` and `ARTIFACT_ROOT`.
+
+- **Refuse shared state.** Run `docker ps -a --filter label=com.docker.compose.project=observability-local --format '{{.ID}}'`. Stop if the output is not empty.
+- **Verify ports.** Run `nc -z 127.0.0.1 <port>` for each fixed port. Stop if any command succeeds.
+- **Start the stack.** Run `OBSERVABILITY_HOME="$STATE_ROOT" bun "$CLI" dev up`. Require exit code `0`.
+- **Identify ownership.** Find `docker-compose.yml` under `STATE_ROOT`. Export its path as `COMPOSE_FILE`.
+- **Run the service doctor.** Run `docker compose -f "$COMPOSE_FILE" ps --status running --services | sort`. Require exactly `collector` and `viewer`.
+- **Verify CLI status.** Run `bun "$CLI" dev status --file "$COMPOSE_FILE"`. Require exit code `0` and both services.
+- **Verify the viewer.** Run `curl --fail --silent --show-error http://127.0.0.1:8000/`. Require a nonempty response.
+- **Capture proof.** Save launch output, status output, the service list, the viewer response, and all exit codes.
+- **Stop the stack.** Run `bun "$CLI" dev down --file "$COMPOSE_FILE"`. Require exit code `0`.
+- **Verify teardown.** Run `docker compose -f "$COMPOSE_FILE" ps --all --services`. Require empty output.
+
+## Gotchas
+
+- The Compose project name is fixed.
+- Two local stack runs cannot execute at the same time.
+- The ports are fixed and loopback-only.
+- The first start can pull container images from the network.
+- Run cleanup after every failed start.

--- a/.agents/skills/verify-observability/features/package-delivery.md
+++ b/.agents/skills/verify-observability/features/package-delivery.md
@@ -1,0 +1,40 @@
+# Package delivery
+
+The package smoke test verifies the published file set from a temporary external consumer project.
+
+## Sub-features
+
+- `package-files` includes each required runtime file and excludes source and test files.
+- `package-imports` loads every public telemetry entrypoint outside the repository.
+- `package-types` checks generated declarations through the external TypeScript compiler.
+- `package-cli` executes help and status through the packed CLI binary.
+- `package-assets` verifies local and production files from the packed CLI.
+
+## How to get to it (user POV)
+
+- Run `bun run test:package` from the repository root.
+- Inspect the command result for the first failed package operation.
+
+## Driving it with verify-observability
+
+Preconditions:
+
+- Bun dependencies are installed.
+- Docker is available because the packed CLI runs `dev status`.
+- `ARTIFACT_ROOT` exists.
+- No package publish command runs in this recipe.
+
+- **Run the package proof.** Run `bun run test:package`. The script builds both package distributions.
+- **Verify archives.** Require exit code `0`. The script checks required files and rejects `src` and `test` directories.
+- **Verify imports.** Require exit code `0`. The temporary consumer imports each public telemetry entrypoint.
+- **Verify declarations.** Require exit code `0`. The external TypeScript compiler checks the package declarations.
+- **Verify the CLI.** Require exit code `0`. The packed binary prints help and prepares local stack files.
+- **Verify production files.** Require exit code `0`. The packed binary writes Collector and Kamal files into disposable state.
+- **Capture proof.** Save the exact command, stdout, stderr, and exit code under `ARTIFACT_ROOT/package-delivery`.
+
+## Gotchas
+
+- The smoke test removes its temporary consumer before exit.
+- The smoke test does not publish either package.
+- Docker must run even though the smoke test does not start the local stack.
+- A source import does not replace this package proof.

--- a/.agents/skills/verify-observability/features/pipeline-canary.md
+++ b/.agents/skills/verify-observability/features/pipeline-canary.md
@@ -1,0 +1,43 @@
+# Pipeline canary
+
+The local canary sends telemetry through OTLP and verifies the Collector file export.
+
+## Sub-features
+
+- `pipeline-trace` exports a root span and a correlated child span.
+- `pipeline-log` exports a correlated wide-event log.
+- `pipeline-browser` accepts and exports a browser event.
+- `pipeline-metric` exports the `canary.operations` counter.
+- `pipeline-resource` preserves service and environment attributes.
+- `pipeline-redaction` removes secret fields and secret values across all signals.
+
+## How to get to it (user POV)
+
+- Start the local stack with `observability dev up`.
+- Run `OBSERVABILITY_E2E=1 bun run test:canary`.
+- Inspect `data/otlp.jsonl` under the isolated `STATE_ROOT`.
+
+## Driving it with verify-observability
+
+Preconditions:
+
+- The local stack passed the service doctor.
+- `OBSERVABILITY_HOME` points to `STATE_ROOT`.
+- `ARTIFACT_ROOT` exists.
+
+- **Send telemetry.** Run `OBSERVABILITY_HOME="$STATE_ROOT" OBSERVABILITY_E2E=1 bun run test:canary`. Require exit code `0`.
+- **Read the export.** Find `data/otlp.jsonl` under `STATE_ROOT`. Require a nonempty file.
+- **Identify the run.** Extract values that match `test-[a-z0-9-]+`. Require one unique canary run ID in fresh state.
+- **Verify correlation.** Require the canary result. It verifies trace IDs, span parentage, a correlated log, a browser event, and a metric.
+- **Verify resources.** Require the canary result. It verifies the service name, version, and deployment environment.
+- **Verify redaction.** Require the canary result. It rejects generated secrets and preserves the negative controls.
+- **Verify replacements.** Search the export for `****` and `[REDACTED]`. Require both replacement forms.
+- **Capture proof.** Copy `otlp.jsonl`. Save the command result, run ID, and replacement search output.
+
+## Gotchas
+
+- The test skips unless `OBSERVABILITY_E2E=1` is set.
+- Shared state can mix old events into the proof.
+- The viewer page is not the assertion source.
+- Do not print generated secret markers outside the canary process.
+- The local canary does not verify the deployed Collector.

--- a/.agents/skills/verify-observability/features/project-provisioning.md
+++ b/.agents/skills/verify-observability/features/project-provisioning.md
@@ -1,0 +1,41 @@
+# Project asset setup
+
+The CLI writes production Collector and Kamal accessory files into a target project.
+
+## Sub-features
+
+- `provision-create` creates both production files.
+- `provision-render` replaces the project template in dataset names.
+- `provision-idempotent` reports unchanged files on a repeated run.
+- `provision-conflict` preserves a local edit and reports a typed conflict.
+- `provision-force` replaces the edited generated file only with `--force`.
+
+## How to get to it (user POV)
+
+- Run `observability provision --dir <project> --name <name>`.
+- Run the same command again to verify idempotency.
+- Run the command with `--force` to replace an edited generated file.
+
+## Driving it with verify-observability
+
+Preconditions:
+
+- The parent skill created `STATE_ROOT` and `ARTIFACT_ROOT`.
+- `PROVISION_TARGET="$STATE_ROOT/provision-target"` contains no user files.
+- The command contains no `--environment` flag.
+
+- **Create the target.** Run `mkdir -p "$PROVISION_TARGET"`.
+- **Provision the files.** Run `OBSERVABILITY_HOME="$STATE_ROOT" bun "$CLI" provision --dir "$PROVISION_TARGET" --name verify-app`. Require exit code `0` and two `created` lines.
+- **Read the state.** Read both files under `PROVISION_TARGET/observability`. Require `${env:AXIOM_TOKEN}` and all three `verify-app` dataset names.
+- **Verify idempotency.** Run the same CLI command. Require exit code `0` and two `unchanged` lines.
+- **Create a conflict.** Replace the disposable `collector.yaml` with `receivers: {}`. Run the command without `--force`.
+- **Verify protection.** Require exit code `1` and `OBS_CLI_PROVISION_CONFLICT`. Require the edited file to remain unchanged.
+- **Replace the edit.** Run the command with `--force`. Require exit code `0` and an `updated` Collector line.
+- **Capture proof.** Save all command results. Copy the first and final files to `ARTIFACT_ROOT/project-provisioning`.
+
+## Gotchas
+
+- Never use a real project directory for this recipe.
+- The `--environment` flag creates remote Axiom and Sentry resources.
+- The `--force` flag can replace local edits.
+- Deployment guidance in stdout does not prove that a deployment occurred.

--- a/.agents/skills/verify-observability/features/provider-authentication.md
+++ b/.agents/skills/verify-observability/features/provider-authentication.md
@@ -1,0 +1,45 @@
+# Provider authentication
+
+The CLI validates Axiom and Sentry administrator credentials and stores them in isolated local state.
+
+## Sub-features
+
+- `auth-axiom` validates an Axiom personal access token.
+- `auth-sentry` validates a Sentry organization token.
+- `auth-storage` writes the credential file with owner-only permissions.
+- `auth-status` validates both stored credentials again.
+
+## How to get to it (user POV)
+
+- Run `observability auth login axiom --organization-id <id>`.
+- Enter the token at `Axiom personal access token`.
+- Run `observability auth login sentry --organization <slug> --team <slug>`.
+- Enter the token at `Sentry organization auth token`.
+- Run `observability auth status`.
+
+## Driving it with verify-observability
+
+Preconditions:
+
+- Use dedicated verification credentials for both providers.
+- Export `AXIOM_ORGANIZATION_ID`, `SENTRY_ORGANIZATION`, and `SENTRY_TEAM`.
+- The parent skill created a fresh `STATE_ROOT`.
+- Use a PTY that protects secret input.
+
+- **Start Axiom login.** Run `OBSERVABILITY_HOME="$STATE_ROOT" bun "$CLI" auth login axiom --organization-id "$AXIOM_ORGANIZATION_ID"` in the PTY.
+- **Enter the Axiom token.** Wait for the exact protected prompt. Send the token through the host secret-input facility.
+- **Verify Axiom.** Require exit code `0` and `Authenticated with Axiom as <identity>.` Do not save the typed token.
+- **Start Sentry login.** Run `OBSERVABILITY_HOME="$STATE_ROOT" bun "$CLI" auth login sentry --organization "$SENTRY_ORGANIZATION" --team "$SENTRY_TEAM"` in the PTY.
+- **Enter the Sentry token.** Wait for the exact protected prompt. Send the token through the host secret-input facility.
+- **Verify Sentry.** Require exit code `0` and `Authenticated with Sentry organization <identity>.` Do not save the typed token.
+- **Verify the file.** Locate `credentials.json` under `STATE_ROOT`. Require file mode `0600` and parent mode `0700`.
+- **Verify status.** Run `OBSERVABILITY_HOME="$STATE_ROOT" bun "$CLI" auth status`. Require both identities and the isolated credential path.
+- **Capture proof.** Save redacted transcripts, exit codes, identities, path, and permission modes.
+
+## Gotchas
+
+- Never pass provider tokens as command arguments.
+- Never store provider tokens in evidence.
+- The login commands call live provider APIs.
+- A copied credential file is not proof of valid authentication.
+- Cleanup removes the isolated local credentials but does not revoke provider tokens.

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist
 *.local
 *.log
 logs
+/.verification/
 .DS_Store
 
 .env


### PR DESCRIPTION
## Summary
- add a project-local verification skill under `.agents/skills`
- map the CLI, local stack, pipeline, authentication, and package delivery paths
- retain disposable verification evidence outside version control

## Verification
- `bun run check`
- executed launch, doctor, project provisioning, conflict, force, and cleanup paths