### PR TITLE
fix(telemetry): propagate NestJS trace context

### DIFF
--- a/packages/telemetry/src/nestjs/TelemetryInterceptor.ts
+++ b/packages/telemetry/src/nestjs/TelemetryInterceptor.ts
@@ -1,6 +1,6 @@
 import type { CallHandler, ExecutionContext, NestInterceptor } from "@nestjs/common";
-import { Context, Effect, Exit, Option, Schema } from "effect";
-import type { Clock, ManagedRuntime, Tracer } from "effect";
+import { Context, Effect, Exit, Option, Schema, Tracer } from "effect";
+import type { Clock, ManagedRuntime } from "effect";
 import { Observable } from "rxjs";
 
 const HttpRequestBoundary = Schema.Struct({
@@ -8,6 +8,21 @@ const HttpRequestBoundary = Schema.Struct({
 });
 
 const decodeHttpRequestBoundary = Schema.decodeUnknownOption(HttpRequestBoundary);
+
+const TraceparentRequest = Schema.Struct({
+  headers: Schema.Struct({
+    traceparent: Schema.String.check(
+      Schema.isPattern(/^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/),
+      Schema.makeFilter(
+        (traceparent) =>
+          traceparent.slice(3, 35) !== "00000000000000000000000000000000" &&
+          traceparent.slice(36, 52) !== "0000000000000000",
+      ),
+    ),
+  }),
+});
+
+const parseTraceparentRequest = Schema.decodeUnknownOption(TraceparentRequest);
 
 const HttpResponseBoundary = Schema.Struct({
   statusCode: Schema.Number.check(Schema.isInt()),
@@ -66,21 +81,35 @@ export class TelemetryInterceptor<RuntimeError> implements NestInterceptor {
     const clock = (this.#clock ??= this.#runtime.runSync(Effect.clockWith(Effect.succeed)));
     const httpContext = context.switchToHttp();
     const request = httpContext.getRequest<RequestReference>();
+    const traceparentRequest = httpContext.getRequest<typeof TraceparentRequest.Encoded>();
     const method = decodeHttpRequestBoundary(request).pipe(
       Option.map((boundary) => boundary.method.toUpperCase()),
       Option.getOrElse(() => "UNKNOWN"),
     );
     const controller = context.getClass().name;
     const handler = context.getHandler().name;
+    const parent = parseTraceparentRequest({ headers: traceparentRequest.headers }).pipe(
+      Option.map(({ headers }) => {
+        const traceparent = headers.traceparent;
+        return Tracer.externalSpan({
+          traceId: traceparent.slice(3, 35),
+          spanId: traceparent.slice(36, 52),
+          sampled: Number.parseInt(traceparent.slice(53, 55), 16) % 2 === 1,
+        });
+      }),
+    );
     const span = tracer.span({
       name: `${method} ${controller}.${handler}`,
-      parent: Option.none(),
+      parent,
       annotations: Context.empty(),
       links: [],
       startTime: clock.currentTimeNanosUnsafe(),
       kind: "server",
-      root: true,
-      sampled: true,
+      root: Option.isNone(parent),
+      sampled: Option.match(parent, {
+        onNone: () => true,
+        onSome: (remoteParent) => remoteParent.sampled,
+      }),
     });
     span.attribute("http.request.method", method);
     span.attribute("nestjs.controller", controller);

--- a/packages/telemetry/test/nestjs.test.ts
+++ b/packages/telemetry/test/nestjs.test.ts
@@ -143,6 +143,147 @@ describe("nestjs TelemetryInterceptor", () => {
     assert.deepStrictEqual(childSpan.parentSpanId, Option.some(boundarySpan.spanId));
   }, 30_000);
 
+  it("propagates strict W3C traceparent context through real NestJS HTTP requests", async () => {
+    const capture = await Effect.runPromise(Testing.makeCapture());
+    const runtime = ManagedRuntime.make(capture.layer);
+
+    class TraceparentController {
+      sampled(request: WeakKey): Promise<{ readonly route: string }> {
+        return runtime.runPromise(
+          Effect.succeed({ route: "sampled" }).pipe(
+            Effect.withSpan("sampled.child"),
+            withRequestSpan(request),
+          ),
+        );
+      }
+      unsampled(request: WeakKey): Promise<{ readonly route: string }> {
+        return runtime.runPromise(
+          Effect.succeed({ route: "unsampled" }).pipe(
+            Effect.withSpan("unsampled.child"),
+            withRequestSpan(request),
+          ),
+        );
+      }
+      absent(): { readonly route: string } {
+        return { route: "absent" };
+      }
+      malformed(): { readonly route: string } {
+        return { route: "malformed" };
+      }
+    }
+    Controller("traceparent")(TraceparentController);
+    Get("sampled")(
+      TraceparentController.prototype,
+      "sampled",
+      methodDescriptor(TraceparentController.prototype, "sampled"),
+    );
+    Get("unsampled")(
+      TraceparentController.prototype,
+      "unsampled",
+      methodDescriptor(TraceparentController.prototype, "unsampled"),
+    );
+    Get("absent")(
+      TraceparentController.prototype,
+      "absent",
+      methodDescriptor(TraceparentController.prototype, "absent"),
+    );
+    Get("malformed")(
+      TraceparentController.prototype,
+      "malformed",
+      methodDescriptor(TraceparentController.prototype, "malformed"),
+    );
+    Req()(TraceparentController.prototype, "sampled", 0);
+    Req()(TraceparentController.prototype, "unsampled", 0);
+
+    class TraceparentModule {}
+    Module({ controllers: [TraceparentController] })(TraceparentModule);
+
+    const app = await NestFactory.create(TraceparentModule, { logger: false });
+    app.useGlobalInterceptors(new TelemetryInterceptor(runtime));
+    await app.listen(0);
+    const address = decodeAddressInfo(app.getHttpServer().address());
+    assert.isTrue(Option.isSome(address));
+    const baseUrl = `http://127.0.0.1:${Option.getOrThrow(address).port}`;
+    const traceId = "0af7651916cd43dd8448eb211c80319c";
+    const parentSpanId = "b7ad6b7169203331";
+
+    const sampled = await fetch(`${baseUrl}/traceparent/sampled`, {
+      headers: { traceparent: `00-${traceId}-${parentSpanId}-01` },
+    });
+    assert.strictEqual(sampled.status, 200);
+    assert.deepStrictEqual(await sampled.json(), { route: "sampled" });
+
+    const absent = await fetch(`${baseUrl}/traceparent/absent`);
+    assert.strictEqual(absent.status, 200);
+    assert.deepStrictEqual(await absent.json(), { route: "absent" });
+
+    const malformedTraceparents = [
+      `01-${traceId}-${parentSpanId}-01`,
+      `00-${traceId}-${parentSpanId}`,
+      `00-${traceId}-${parentSpanId}-01-extra`,
+      `00-${traceId}-${parentSpanId}-0`,
+      `00-${traceId}-${parentSpanId}-0g`,
+      `00-${traceId.toUpperCase()}-${parentSpanId}-01`,
+      `00-${traceId}-${parentSpanId.toUpperCase()}-01`,
+      `00-${traceId}-${parentSpanId}-A1`,
+      `00-${traceId}-${parentSpanId}-01, 00-${traceId}-${parentSpanId}-01`,
+      `00-z${traceId.slice(1)}-${parentSpanId}-01`,
+      `00-${"0".repeat(32)}-${parentSpanId}-01`,
+      `00-${traceId}-${"0".repeat(16)}-01`,
+    ];
+    for (const traceparent of malformedTraceparents) {
+      const malformed = await fetch(`${baseUrl}/traceparent/malformed`, {
+        headers: { traceparent },
+      });
+      assert.strictEqual(malformed.status, 200);
+      assert.deepStrictEqual(await malformed.json(), { route: "malformed" });
+    }
+
+    const unsampled = await fetch(`${baseUrl}/traceparent/unsampled`, {
+      headers: { traceparent: `00-${traceId}-${parentSpanId}-00` },
+    });
+    assert.strictEqual(unsampled.status, 200);
+    assert.deepStrictEqual(await unsampled.json(), { route: "unsampled" });
+
+    await app.close();
+    await runtime.dispose();
+    const telemetry = await Effect.runPromise(capture.telemetry);
+
+    const sampledSpan = telemetry.spans.find(
+      (span) => span.name === "GET TraceparentController.sampled",
+    );
+    const sampledChild = telemetry.spans.find((span) => span.name === "sampled.child");
+    assert.isDefined(sampledSpan);
+    assert.isDefined(sampledChild);
+    assert.strictEqual(sampledSpan.traceId, traceId);
+    assert.deepStrictEqual(sampledSpan.parentSpanId, Option.some(parentSpanId));
+    assert.strictEqual(sampledChild.traceId, traceId);
+    assert.deepStrictEqual(sampledChild.parentSpanId, Option.some(sampledSpan.spanId));
+
+    const absentSpan = telemetry.spans.find(
+      (span) => span.name === "GET TraceparentController.absent",
+    );
+    assert.isDefined(absentSpan);
+    assert.isTrue(Option.isNone(absentSpan.parentSpanId));
+
+    const malformedSpans = telemetry.spans.filter(
+      (span) => span.name === "GET TraceparentController.malformed",
+    );
+    assert.lengthOf(malformedSpans, malformedTraceparents.length);
+    for (const malformedSpan of malformedSpans) {
+      assert.isTrue(Option.isNone(malformedSpan.parentSpanId));
+    }
+
+    assert.notInclude(
+      telemetry.spans.map((span) => span.name),
+      "GET TraceparentController.unsampled",
+    );
+    assert.notInclude(
+      telemetry.spans.map((span) => span.name),
+      "unsampled.child",
+    );
+  }, 30_000);
+
   it("ends the span as cancelled when the response observable unsubscribes", async () => {
     const capture = await Effect.runPromise(Testing.makeCapture());
     const runtime = ManagedRuntime.make(capture.layer);


### PR DESCRIPTION
Continues a valid W3C `traceparent` through the NestJS server span. Absent and malformed headers keep the existing sampled-root behavior.

The private boundary parser rejects invalid versions, field lengths, uppercase values, nonhexadecimal values, duplicate headers, and zero identifiers. A valid unsampled parent remains unsampled, so the Effect OTLP exporter emits neither the server span nor its child spans.

Verification:

- `bunx vp test run packages/telemetry/test/nestjs.test.ts packages/telemetry/test/browserEndpoint.test.ts`
- `bun check`
- `CI=1 bunx vp lint`
- `bun run test:package`

Linear: https://linear.app/equipe-tech/issue/OBS-3/propagate-w3c-trace-context-through-the-nestjs-interceptor
