### PR TITLE
feat(collector): normalize deployment environment attributes

### DIFF
--- a/.agents/skills/verify-observability/features/pipeline-canary.md
+++ b/.agents/skills/verify-observability/features/pipeline-canary.md
@@ -8,7 +8,7 @@ The local canary sends telemetry through OTLP and verifies the Collector file ex
 - `pipeline-log` exports a correlated wide-event log.
 - `pipeline-browser` accepts and exports a browser event.
 - `pipeline-metric` exports the `canary.operations` counter.
-- `pipeline-resource` preserves service and environment attributes.
+- `pipeline-resource` exports service attributes and equal `deployment.environment.name` and `deployment.environment` resource values for all signals.
 - `pipeline-redaction` removes secret fields and secret values across all signals.
 
 ## How to get to it (user POV)
@@ -29,7 +29,7 @@ Preconditions:
 - **Read the export.** Find `data/otlp.jsonl` under `STATE_ROOT`. Require a nonempty file.
 - **Identify the run.** Extract values that match `test-[a-z0-9-]+`. Require one unique canary run ID in fresh state.
 - **Verify correlation.** Require the canary result. It verifies trace IDs, span parentage, a correlated log, a browser event, and a metric.
-- **Verify resources.** Require the canary result. It verifies the service name, version, and deployment environment.
+- **Verify resources.** Require the canary result. It verifies service fields and equal canonical and transition environment values for all signals.
 - **Verify redaction.** Require the canary result. It rejects generated secrets and preserves the negative controls.
 - **Verify replacements.** Search the export for `****` and `[REDACTED]`. Require both replacement forms.
 - **Capture proof.** Copy `otlp.jsonl`. Save the command result, run ID, and replacement search output.

--- a/docs/environment-management.md
+++ b/docs/environment-management.md
@@ -4,6 +4,36 @@ O pacote trata o ambiente como um atributo OpenTelemetry. `OTEL_DEPLOYMENT_ENVIR
 
 A aplicação envia os três sinais para um Collector. Ela não contém credenciais do Axiom e não conhece os nomes dos datasets.
 
+## O atributo canônico preserva consultas durante a transição
+
+O atributo canônico de resource para logs, traces e métricas é `deployment.environment.name`.
+
+O Collector também exporta `deployment.environment` como alias de transição.
+
+- Se somente o atributo canônico existe, o Collector copia seu valor para o alias.
+- Se somente o alias existe, o Collector copia seu valor para o atributo canônico.
+- Se ambos existem com valores diferentes, o atributo canônico substitui o alias.
+- Se nenhum existe, o Collector não altera o resource.
+
+A regra usa somente atributos de resource. Atributos de spans, eventos, logs ou pontos de métricas não são entradas para a migração.
+
+Use o campo canônico nas novas consultas Axiom:
+
+```apl
+['project-production-traces'] | where ['resource.custom']['deployment.environment.name'] == 'production'
+```
+
+As consultas existentes com o alias continuam válidas durante a transição:
+
+```apl
+['project-production-traces'] | where ['resource.custom']['deployment.environment'] == 'production'
+```
+
+A remoção do alias requer duas condições:
+
+- Todos os produtores suportados enviam o atributo canônico.
+- Nenhuma consulta, painel ou alerta usa o alias durante um período completo de retenção dos datasets.
+
 ## O ambiente local não usa contas externas
 
 O ambiente local usa `http://localhost:4318` como endpoint padrão. O Collector local envia os sinais para o `otel-desktop-viewer`.

--- a/packages/cli/src/assets/local.yaml
+++ b/packages/cli/src/assets/local.yaml
@@ -11,6 +11,23 @@ processors:
     check_interval: 1s
     limit_mib: 256
     spike_limit_mib: 64
+  transform/environment:
+    error_mode: propagate
+    trace_statements:
+      - context: resource
+        statements:
+          - 'set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil'
+          - 'set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment.name"] != nil'
+    log_statements:
+      - context: resource
+        statements:
+          - 'set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil'
+          - 'set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment.name"] != nil'
+    metric_statements:
+      - context: resource
+        statements:
+          - 'set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil'
+          - 'set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment.name"] != nil'
   transform/redact:
     error_mode: propagate
     trace_statements:
@@ -58,13 +75,15 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [memory_limiter, transform/redact, redaction/sensitive, batch]
+      processors:
+        [memory_limiter, transform/environment, transform/redact, redaction/sensitive, batch]
       exporters: [otlp/viewer, file/telemetry]
     logs:
       receivers: [otlp]
-      processors: [memory_limiter, transform/redact, redaction/sensitive, batch]
+      processors:
+        [memory_limiter, transform/environment, transform/redact, redaction/sensitive, batch]
       exporters: [otlp/viewer, file/telemetry]
     metrics:
       receivers: [otlp]
-      processors: [memory_limiter, redaction/sensitive, batch]
+      processors: [memory_limiter, transform/environment, redaction/sensitive, batch]
       exporters: [otlp/viewer, file/telemetry]

--- a/packages/cli/src/assets/production.yaml
+++ b/packages/cli/src/assets/production.yaml
@@ -16,6 +16,23 @@ processors:
     check_interval: 1s
     limit_mib: 512
     spike_limit_mib: 128
+  transform/environment:
+    error_mode: propagate
+    trace_statements:
+      - context: resource
+        statements:
+          - 'set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil'
+          - 'set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment.name"] != nil'
+    log_statements:
+      - context: resource
+        statements:
+          - 'set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil'
+          - 'set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment.name"] != nil'
+    metric_statements:
+      - context: resource
+        statements:
+          - 'set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil'
+          - 'set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment.name"] != nil'
   transform/redact:
     error_mode: propagate
     trace_statements:
@@ -93,13 +110,15 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [memory_limiter, transform/redact, redaction/sensitive, batch]
+      processors:
+        [memory_limiter, transform/environment, transform/redact, redaction/sensitive, batch]
       exporters: [otlphttp/traces]
     logs:
       receivers: [otlp]
-      processors: [memory_limiter, transform/redact, redaction/sensitive, batch]
+      processors:
+        [memory_limiter, transform/environment, transform/redact, redaction/sensitive, batch]
       exporters: [otlphttp/logs]
     metrics:
       receivers: [otlp]
-      processors: [memory_limiter, redaction/sensitive, batch]
+      processors: [memory_limiter, transform/environment, redaction/sensitive, batch]
       exporters: [otlphttp/metrics]

--- a/packages/cli/test/CollectorAssets.bun.test.ts
+++ b/packages/cli/test/CollectorAssets.bun.test.ts
@@ -5,7 +5,20 @@ const CollectorPipeline = Schema.Struct({
   processors: Schema.Array(Schema.String),
 });
 
+const TransformStatementGroup = Schema.Struct({
+  context: Schema.String,
+  statements: Schema.Array(Schema.String),
+});
+
 const CollectorConfig = Schema.Struct({
+  processors: Schema.Struct({
+    "transform/environment": Schema.Struct({
+      error_mode: Schema.String,
+      trace_statements: Schema.Array(TransformStatementGroup),
+      log_statements: Schema.Array(TransformStatementGroup),
+      metric_statements: Schema.Array(TransformStatementGroup),
+    }),
+  }),
   service: Schema.Struct({
     pipelines: Schema.Struct({
       traces: CollectorPipeline,
@@ -17,41 +30,76 @@ const CollectorConfig = Schema.Struct({
 
 const decodeCollectorConfig = Schema.decodeUnknownSync(CollectorConfig);
 
-const redactionBlock = (config: string): string => {
-  const start = config.indexOf("  transform/redact:");
-  const end = config.indexOf("  batch:", start);
+const collectorBlock = (config: string, startMarker: string, endMarker: string): string => {
+  const start = config.indexOf(startMarker);
+  const end = config.indexOf(endMarker, start);
   expect(start).toBeGreaterThanOrEqual(0);
   expect(end).toBeGreaterThan(start);
   return config.slice(start, end);
 };
 
-const expectRedactionPipelines = (config: string): void => {
+const environmentBlock = (config: string): string =>
+  collectorBlock(config, "  transform/environment:", "  transform/redact:");
+
+const redactionBlock = (config: string): string =>
+  collectorBlock(config, "  transform/redact:", "  batch:");
+
+const legacyToCanonical =
+  'set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil';
+const canonicalToLegacy =
+  'set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment.name"] != nil';
+
+const expectCollectorContract = (config: string): void => {
   const parsed: unknown = Bun.YAML.parse(config);
-  const pipelines = decodeCollectorConfig(parsed).service.pipelines;
-  const tracesAndLogs = ["memory_limiter", "transform/redact", "redaction/sensitive", "batch"];
-  const metrics = ["memory_limiter", "redaction/sensitive", "batch"];
+  const decoded = decodeCollectorConfig(parsed);
+  const environment = decoded.processors["transform/environment"];
+  const statementGroups = [
+    environment.trace_statements,
+    environment.log_statements,
+    environment.metric_statements,
+  ];
+  expect(environment.error_mode).toBe("propagate");
+  for (const statementGroup of statementGroups) {
+    expect(statementGroup).toEqual([
+      {
+        context: "resource",
+        statements: [legacyToCanonical, canonicalToLegacy],
+      },
+    ]);
+  }
+
+  const pipelines = decoded.service.pipelines;
+  const tracesAndLogs = [
+    "memory_limiter",
+    "transform/environment",
+    "transform/redact",
+    "redaction/sensitive",
+    "batch",
+  ];
+  const metrics = ["memory_limiter", "transform/environment", "redaction/sensitive", "batch"];
   expect(pipelines.traces.processors).toEqual(tracesAndLogs);
   expect(pipelines.logs.processors).toEqual(tracesAndLogs);
   expect(pipelines.metrics.processors).toEqual(metrics);
 };
 
 describe("Collector assets", () => {
-  test("keep one redaction contract across local and production pipelines", async () => {
+  test("keep environment transition and redaction contracts across local and production", async () => {
     const [local, production] = await Promise.all([
       Bun.file(new URL("../src/assets/local.yaml", import.meta.url)).text(),
       Bun.file(new URL("../src/assets/production.yaml", import.meta.url)).text(),
     ]);
 
+    expect(environmentBlock(local)).toBe(environmentBlock(production));
     expect(redactionBlock(local)).toBe(redactionBlock(production));
-    expectRedactionPipelines(local);
-    expectRedactionPipelines(production);
+    expectCollectorContract(local);
+    expectCollectorContract(production);
 
     const withoutTraceAttributeRedaction = production.replace(
-      "processors: [memory_limiter, transform/redact, redaction/sensitive, batch]",
-      "processors: [memory_limiter, transform/redact, batch]",
+      "transform/redact, redaction/sensitive",
+      "transform/redact",
     );
     expect(withoutTraceAttributeRedaction).not.toBe(production);
-    expect(() => expectRedactionPipelines(withoutTraceAttributeRedaction)).toThrow(
+    expect(() => expectCollectorContract(withoutTraceAttributeRedaction)).toThrow(
       /redaction\/sensitive/,
     );
   });

--- a/packages/telemetry/test/axiomSupport.test.ts
+++ b/packages/telemetry/test/axiomSupport.test.ts
@@ -233,9 +233,10 @@ describe("axiom query support", () => {
       assert.isDefined(query);
       assert.strictEqual(query.path, "/v1/query/_mpl?format=metrics-v2");
       assert.include(query.query, "`e2e-metrics`:`canary.operations`");
-      assert.include(query.query, '`canary.run_id` == "test-run-1"');
-      assert.include(query.query, '`deployment.environment.name` == "e2e"');
-      assert.include(query.query, '`deployment.environment` == "e2e"');
+      assert.include(
+        query.query,
+        '`canary.run_id` == "test-run-1" and `deployment.environment.name` == "e2e" and `deployment.environment` == "e2e"',
+      );
     }),
   );
 });

--- a/packages/telemetry/test/axiomSupport.test.ts
+++ b/packages/telemetry/test/axiomSupport.test.ts
@@ -235,6 +235,7 @@ describe("axiom query support", () => {
       assert.include(query.query, "`e2e-metrics`:`canary.operations`");
       assert.include(query.query, '`canary.run_id` == "test-run-1"');
       assert.include(query.query, '`deployment.environment.name` == "e2e"');
+      assert.include(query.query, '`deployment.environment` == "e2e"');
     }),
   );
 });

--- a/packages/telemetry/test/axiomSupport.test.ts
+++ b/packages/telemetry/test/axiomSupport.test.ts
@@ -100,7 +100,8 @@ describe("axiom query support", () => {
               name: "canary.operation",
               service_name: "observability-canary",
               service_version: "0.1.0",
-              environment: "e2e",
+              environment_name: "e2e",
+              environment_alias: "e2e",
             },
           },
         ]),
@@ -115,7 +116,8 @@ describe("axiom query support", () => {
       assert.strictEqual(span.spanId, "span-1");
       assert.deepStrictEqual(span.parentSpanId, Option.none());
       assert.deepStrictEqual(span.serviceName, Option.some("observability-canary"));
-      assert.deepStrictEqual(span.environment, Option.some("e2e"));
+      assert.deepStrictEqual(span.environmentName, Option.some("e2e"));
+      assert.deepStrictEqual(span.environmentAlias, span.environmentName);
 
       const query = stub.queries[0];
       assert.isDefined(query);
@@ -124,6 +126,14 @@ describe("axiom query support", () => {
       assert.include(query.query, "['e2e-traces']");
       assert.include(query.query, "['attributes.custom']['canary.run_id'] == 'test-run-1'");
       assert.include(query.query, "name == 'canary.operation'");
+      assert.include(
+        query.query,
+        "environment_name = tostring(['resource.custom']['deployment.environment.name'])",
+      );
+      assert.include(
+        query.query,
+        "environment_alias = tostring(['resource.custom']['deployment.environment'])",
+      );
     }),
   );
 
@@ -165,6 +175,8 @@ describe("axiom query support", () => {
               event_kind: "wide",
               event_source: null,
               service_name: "observability-canary",
+              environment_name: "e2e",
+              environment_alias: "e2e",
             },
           },
           { data: { unrelated: true } },
@@ -181,9 +193,19 @@ describe("axiom query support", () => {
       assert.deepStrictEqual(log.traceId, Option.some("trace-1"));
       assert.deepStrictEqual(log.eventKind, Option.some("wide"));
       assert.deepStrictEqual(log.eventSource, Option.none());
+      assert.deepStrictEqual(log.environmentName, Option.some("e2e"));
+      assert.deepStrictEqual(log.environmentAlias, log.environmentName);
       const query = stub.queries[0];
       assert.isDefined(query);
       assert.include(query.query, "['e2e-logs']");
+      assert.include(
+        query.query,
+        "environment_name = tostring(['resource.custom']['deployment.environment.name'])",
+      );
+      assert.include(
+        query.query,
+        "environment_alias = tostring(['resource.custom']['deployment.environment'])",
+      );
     }),
   );
 
@@ -201,7 +223,7 @@ describe("axiom query support", () => {
         ],
       });
       const stub = yield* Effect.promise(() => startStubAxiom([], metricsResponse));
-      const metric = yield* findMetric(stub.env, "test-run-1").pipe(
+      const metric = yield* findMetric(stub.env, "test-run-1", "e2e").pipe(
         Effect.ensuring(Effect.sync(() => stub.server.close())),
       );
 
@@ -212,6 +234,7 @@ describe("axiom query support", () => {
       assert.strictEqual(query.path, "/v1/query/_mpl?format=metrics-v2");
       assert.include(query.query, "`e2e-metrics`:`canary.operations`");
       assert.include(query.query, '`canary.run_id` == "test-run-1"');
+      assert.include(query.query, '`deployment.environment.name` == "e2e"');
     }),
   );
 });

--- a/packages/telemetry/test/canary.deployed.test.ts
+++ b/packages/telemetry/test/canary.deployed.test.ts
@@ -16,6 +16,7 @@ import {
 import { canaryRunId, canarySensitiveValues, emitCanary } from "./support/canary.ts";
 
 const deployedEnabled = process.env["OBSERVABILITY_E2E_DEPLOYED"] === "1";
+const canaryEnvironment = "e2e";
 
 type DeployedRun = {
   readonly root: AxiomSpan;
@@ -35,7 +36,7 @@ const findDeployedRun = Effect.fn("findDeployedRun")(function* (
     if (Option.isSome(root)) {
       const child = yield* findChildSpan(env, root.value.traceId);
       const logs = yield* findLogs(env, runId);
-      const metric = yield* findMetric(env, runId);
+      const metric = yield* findMetric(env, runId, canaryEnvironment);
       const completed = logs.find((log) => log.eventName === "canary.completed");
       const browser = logs.find((log) => log.eventName === "canary.browser");
       const redaction = logs.find((log) => log.eventName === "canary.redaction");
@@ -70,6 +71,15 @@ const redactionAttributeValues = (attributes: AxiomRedactionAttributes): Readonl
   Option.getOrThrow(attributes.safeMessage),
 ];
 
+const assertEnvironmentAliases = (
+  environmentName: Option.Option<string>,
+  environmentAlias: Option.Option<string>,
+  expected: string,
+): void => {
+  assert.deepStrictEqual(environmentName, Option.some(expected));
+  assert.deepStrictEqual(environmentAlias, environmentName);
+};
+
 const assertRedactionAttributes = (
   attributes: AxiomRedactionAttributes,
   sensitive: ReturnType<typeof canarySensitiveValues>,
@@ -99,7 +109,7 @@ describe.runIf(deployedEnabled)("deployed pipeline canary", () => {
         const config = new TelemetryConfig({
           serviceName: "observability-canary",
           serviceVersion: "0.1.0",
-          environment: "e2e",
+          environment: canaryEnvironment,
           otlpEndpoint: new URL(endpoint),
         });
 
@@ -114,11 +124,20 @@ describe.runIf(deployedEnabled)("deployed pipeline canary", () => {
 
         assert.deepStrictEqual(run.root.serviceName, Option.some("observability-canary"));
         assert.deepStrictEqual(run.root.serviceVersion, Option.some("0.1.0"));
-        assert.deepStrictEqual(run.root.environment, Option.some("e2e"));
+        assertEnvironmentAliases(
+          run.root.environmentName,
+          run.root.environmentAlias,
+          canaryEnvironment,
+        );
 
         assert.deepStrictEqual(run.completed.traceId, Option.some(run.root.traceId));
         assert.deepStrictEqual(run.completed.eventKind, Option.some("wide"));
         assert.deepStrictEqual(run.completed.serviceName, Option.some("observability-canary"));
+        assertEnvironmentAliases(
+          run.completed.environmentName,
+          run.completed.environmentAlias,
+          canaryEnvironment,
+        );
 
         assert.deepStrictEqual(run.browser.eventSource, Option.some("browser"));
         assert.deepStrictEqual(run.browser.eventKind, Option.some("wide"));

--- a/packages/telemetry/test/canary.test.ts
+++ b/packages/telemetry/test/canary.test.ts
@@ -136,6 +136,17 @@ const attributeValue = (
     Option.flatMap((attribute) => Option.fromNullishOr(attribute.value.stringValue)),
   );
 
+const assertEnvironmentAliases = (resource: CanaryResource, expected: string): void => {
+  const canonical = Option.getOrUndefined(
+    attributeValue(resource.attributes, "deployment.environment.name"),
+  );
+  const legacy = Option.getOrUndefined(
+    attributeValue(resource.attributes, "deployment.environment"),
+  );
+  assert.strictEqual(canonical, expected);
+  assert.strictEqual(legacy, canonical);
+};
+
 const readTelemetryExport = Effect.fn("readTelemetryExport")(function* (): Effect.fn.Return<
   CanaryExport,
   never
@@ -293,10 +304,7 @@ describe.runIf(canaryEnabled)("pipeline canary", () => {
           Option.getOrUndefined(attributeValue(resource, "service.version")),
           "0.1.0",
         );
-        assert.strictEqual(
-          Option.getOrUndefined(attributeValue(resource, "deployment.environment.name")),
-          "test",
-        );
+        assertEnvironmentAliases(run.root.resource, "test");
 
         assert.strictEqual(run.log.log.traceId, run.root.span.traceId);
         assert.strictEqual(
@@ -374,12 +382,7 @@ describe.runIf(canaryEnabled)("pipeline canary", () => {
             Option.getOrUndefined(attributeValue(signalResource.attributes, "service.version")),
             "0.1.0",
           );
-          assert.strictEqual(
-            Option.getOrUndefined(
-              attributeValue(signalResource.attributes, "deployment.environment.name"),
-            ),
-            "test",
-          );
+          assertEnvironmentAliases(signalResource, "test");
         }
       }),
     60_000,

--- a/packages/telemetry/test/support/axiom.ts
+++ b/packages/telemetry/test/support/axiom.ts
@@ -260,7 +260,7 @@ export const findMetric = (
 ): Effect.Effect<Option.Option<AxiomMetric>> =>
   runMetricsQuery(
     env,
-    `\`${env.AXIOM_DATASET_METRICS}\`:\`canary.operations\` | where \`canary.run_id\` == "${runId}" and \`deployment.environment.name\` == "${environment}"`,
+    `\`${env.AXIOM_DATASET_METRICS}\`:\`canary.operations\` | where \`canary.run_id\` == "${runId}" and \`deployment.environment.name\` == "${environment}" and \`deployment.environment\` == "${environment}"`,
   ).pipe(
     Effect.map((content) =>
       content.includes(runId) ? Option.some({ content }) : Option.none<AxiomMetric>(),

--- a/packages/telemetry/test/support/axiom.ts
+++ b/packages/telemetry/test/support/axiom.ts
@@ -123,7 +123,8 @@ const AxiomSpanRow = Schema.Struct({
   name: Schema.NonEmptyString,
   service_name: OptionalString,
   service_version: OptionalString,
-  environment: OptionalString,
+  environment_name: OptionalString,
+  environment_alias: OptionalString,
   events: OptionalString,
   ...AxiomRedactionRowFields,
 });
@@ -137,7 +138,8 @@ export type AxiomSpan = {
   readonly name: string;
   readonly serviceName: Option.Option<string>;
   readonly serviceVersion: Option.Option<string>;
-  readonly environment: Option.Option<string>;
+  readonly environmentName: Option.Option<string>;
+  readonly environmentAlias: Option.Option<string>;
   readonly events: Option.Option<string>;
   readonly redaction: AxiomRedactionAttributes;
 };
@@ -151,12 +153,13 @@ const toAxiomSpan = (row: typeof AxiomSpanRow.Type): AxiomSpan => ({
   name: row.name,
   serviceName: Option.fromNullishOr(row.service_name),
   serviceVersion: Option.fromNullishOr(row.service_version),
-  environment: Option.fromNullishOr(row.environment),
+  environmentName: Option.fromNullishOr(row.environment_name),
+  environmentAlias: Option.fromNullishOr(row.environment_alias),
   events: Option.fromNullishOr(row.events),
   redaction: toAxiomRedactionAttributes(row),
 });
 
-const spanProjection = `project trace_id, span_id, parent_span_id, name, service_name = ['service.name'], service_version = ['service.version'], environment = tostring(['resource.custom']['deployment.environment.name']), events = tostring(events), ${redactionProjection}`;
+const spanProjection = `project trace_id, span_id, parent_span_id, name, service_name = ['service.name'], service_version = ['service.version'], environment_name = tostring(['resource.custom']['deployment.environment.name']), environment_alias = tostring(['resource.custom']['deployment.environment']), events = tostring(events), ${redactionProjection}`;
 
 export const findRootSpan = (
   env: AxiomEnvironment,
@@ -196,6 +199,8 @@ const AxiomLogRow = Schema.Struct({
   event_kind: OptionalString,
   event_source: OptionalString,
   service_name: OptionalString,
+  environment_name: OptionalString,
+  environment_alias: OptionalString,
   body: OptionalString,
   ...AxiomRedactionRowFields,
 });
@@ -208,6 +213,8 @@ export type AxiomLog = {
   readonly eventKind: Option.Option<string>;
   readonly eventSource: Option.Option<string>;
   readonly serviceName: Option.Option<string>;
+  readonly environmentName: Option.Option<string>;
+  readonly environmentAlias: Option.Option<string>;
   readonly body: Option.Option<string>;
   readonly redaction: AxiomRedactionAttributes;
 };
@@ -218,6 +225,8 @@ const toAxiomLog = (row: typeof AxiomLogRow.Type): AxiomLog => ({
   eventKind: Option.fromNullishOr(row.event_kind),
   eventSource: Option.fromNullishOr(row.event_source),
   serviceName: Option.fromNullishOr(row.service_name),
+  environmentName: Option.fromNullishOr(row.environment_name),
+  environmentAlias: Option.fromNullishOr(row.environment_alias),
   body: Option.fromNullishOr(row.body),
   redaction: toAxiomRedactionAttributes(row),
 });
@@ -228,7 +237,7 @@ export const findLogs = (
 ): Effect.Effect<ReadonlyArray<AxiomLog>> =>
   runQuery(
     env,
-    `['${env.AXIOM_DATASET_LOGS}'] | where ['attributes.custom']['canary.run_id'] == '${runId}' | project trace_id, event_name = tostring(['attributes.custom']['event.name']), event_kind = tostring(['attributes.custom']['event.kind']), event_source = tostring(['attributes.custom']['event.source']), service_name = ['service.name'], body = tostring(body), ${redactionProjection}`,
+    `['${env.AXIOM_DATASET_LOGS}'] | where ['attributes.custom']['canary.run_id'] == '${runId}' | project trace_id, event_name = tostring(['attributes.custom']['event.name']), event_kind = tostring(['attributes.custom']['event.kind']), event_source = tostring(['attributes.custom']['event.source']), service_name = ['service.name'], environment_name = tostring(['resource.custom']['deployment.environment.name']), environment_alias = tostring(['resource.custom']['deployment.environment']), body = tostring(body), ${redactionProjection}`,
   ).pipe(
     Effect.map((rows) =>
       rows.flatMap((row) =>
@@ -247,10 +256,11 @@ export type AxiomMetric = {
 export const findMetric = (
   env: AxiomEnvironment,
   runId: string,
+  environment: string,
 ): Effect.Effect<Option.Option<AxiomMetric>> =>
   runMetricsQuery(
     env,
-    `\`${env.AXIOM_DATASET_METRICS}\`:\`canary.operations\` | where \`canary.run_id\` == "${runId}"`,
+    `\`${env.AXIOM_DATASET_METRICS}\`:\`canary.operations\` | where \`canary.run_id\` == "${runId}" and \`deployment.environment.name\` == "${environment}"`,
   ).pipe(
     Effect.map((content) =>
       content.includes(runId) ? Option.some({ content }) : Option.none<AxiomMetric>(),


### PR DESCRIPTION
## Summary

- Normalize `deployment.environment.name` and `deployment.environment` at the Collector resource boundary.
- Preserve canonical precedence across traces, logs, and metrics.
- Extend local and deployed canaries for the transition alias.
- Document canonical queries and alias removal conditions.

## Verification

- Collector 0.159.0 validated both assets.
- The local pipeline canary passed at `ad363ea38eb82c6fa7a9c121be1c123151fac254`.
- The 15-case signal matrix and four non-resource checks passed.
- `bun check`, `bun run test`, and `bun run test:package` passed.
- Independent review passed at the current SHA.
- The deployed Axiom canary skipped because dedicated credentials were absent.

Linear: https://linear.app/equipe-tech/issue/OBS-4/align-opentelemetry-environment-attributes-across-all-signals
