### PR TITLE
feat(telemetry): complete NestJS HTTP span semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ O pacote `@equipe-tech/observability` publica um subpath por runtime:
 
 O contrato do endpoint `/_telemetry/events` vive em `BrowserEvents` no entrypoint raiz. O servidor faz o parse com `parseBrowserEventBatch` e re-emite os eventos como wide events com atributos de servidor (`event.source`, `browser.event.id`).
 
-O adapter `./nestjs` publica o endpoint pronto: registre `createBrowserEventsController(runtime)` nos controllers do módulo. O controller responde `202 { accepted }` e rejeita batches inválidos com `400 { code, message, correlationId }`, onde `correlationId` é o `trace_id` do span da requisição. O limite de corpo bruto pertence ao transporte HTTP; o Express responde `413` acima do limite configurado.
+O adapter `./nestjs` publica o endpoint pronto: registre `createBrowserEventsController(runtime)` nos controllers do módulo. O controller responde `202 { accepted }` e rejeita batches inválidos com `400 { code, message, correlationId }`. O valor `correlationId` é um identificador seguro para suporte. O limite de corpo bruto pertence ao transporte HTTP; o Express responde `413` acima do limite configurado.
+
+Consulte [Semântica HTTP do adapter NestJS](docs/nestjs-http-semantics.md) para rotas, status, proxy, privacidade e exclusões.
 
 ## Desenvolvimento
 

--- a/docs/nestjs-http-semantics.md
+++ b/docs/nestjs-http-semantics.md
@@ -1,0 +1,55 @@
+# Semântica HTTP do adapter NestJS
+
+O adapter segue OpenTelemetry HTTP Semantic Conventions v1.44.0 para spans de servidor.
+
+O suporte usa NestJS com Express. O adapter não declara suporte ao Fastify.
+
+## Nomes e rotas
+
+O nome usa o método normalizado e o template completo da rota.
+
+Duas URLs com parâmetros diferentes produzem o mesmo nome e o mesmo atributo `http.route`.
+
+Um método desconhecido usa `_OTHER` em `http.request.method`. O nome usa `HTTP` como prefixo.
+
+Uma rota não encontrada não produz span. O interceptor global executa depois da seleção da rota.
+
+## Política de URL
+
+O atributo `url.path` preserva segmentos estáticos verificados. O adapter substitui parâmetros e wildcards por `REDACTED`.
+
+O adapter omite `url.path` quando o template usa uma gramática complexa ou não corresponde ao caminho.
+
+O adapter nunca exporta `url.query` ou `url.full`. Esta regra é uma exceção de privacidade ao requisito condicional da convenção.
+
+## Proxy e rede
+
+A política padrão `direct` ignora todos os headers de encaminhamento.
+
+Essa política usa o endereço e a porta do socket para `client.address` e `network.peer.*`.
+
+A política `framework` usa somente `request.ip`, `request.protocol` e `request.hostname` resolvidos pelo Express.
+
+Configure `trust proxy` no Express antes de usar `framework`. Uma configuração incorreta permite atributos de rede falsos.
+
+## Status
+
+| Resposta                          | Status OpenTelemetry | `error.type`        |
+| --------------------------------- | -------------------- | ------------------- |
+| 1xx, 2xx ou 3xx                   | Unset                | ausente             |
+| 4xx                               | Unset                | ausente             |
+| 5xx                               | Error                | código decimal      |
+| Conexão fechada antes de `finish` | Error                | `connection_closed` |
+| Cancelamento local intencional    | Unset                | ausente             |
+
+O evento `finish` do Express fornece o código final. Assim, um filtro de exceção não deixa o valor provisório `200` no span.
+
+Mensagens de exceção não entram no status de spans HTTP.
+
+## Exclusões
+
+O adapter exclui `/health` e `/_telemetry/events` por padrão.
+
+A opção `healthRouteTemplates` adiciona templates exatos. Ela não remove as exclusões padrão.
+
+O desligamento futuro do módulo pode fechar a admissão, aguardar requisições ativas e interromper somente os spans restantes.

--- a/packages/telemetry/src/Telemetry.ts
+++ b/packages/telemetry/src/Telemetry.ts
@@ -1,27 +1,59 @@
-import { Effect, Layer } from "effect";
-import { FetchHttpClient, type HttpClient } from "effect/unstable/http";
-import { Otlp } from "effect/unstable/observability";
+import { Duration, Effect, Layer } from "effect";
+import { FetchHttpClient, type HttpClient, HttpClientRequest } from "effect/unstable/http";
+import {
+  OtlpExporter,
+  OtlpLogger,
+  OtlpMetrics,
+  OtlpSerialization,
+} from "effect/unstable/observability";
 import type { EnvironmentVariables, InvalidTelemetryEnvironment } from "./TelemetryConfig.ts";
 import { telemetryConfigFromEnv, type TelemetryConfig } from "./TelemetryConfig.ts";
+import { layerHttpServerOtlpTracer } from "./nestjs/HttpServerOtlpTracer.ts";
+
+export type OtlpLayerOptions = {
+  readonly shutdownTimeout?: Duration.Input | undefined;
+};
 
 export const layerOtlp = (
   config: TelemetryConfig,
-): Layer.Layer<never, never, HttpClient.HttpClient> =>
-  Otlp.layerJson({
-    baseUrl: config.otlpEndpoint.toString(),
-    resource: {
-      serviceName: config.serviceName,
-      serviceVersion: config.serviceVersion,
-      attributes: {
-        "deployment.environment.name": config.environment,
-      },
+  options: OtlpLayerOptions = {},
+): Layer.Layer<OtlpExporter.Flusher, never, HttpClient.HttpClient> => {
+  const base = HttpClientRequest.get(config.otlpEndpoint.toString());
+  const url = (path: string): string => HttpClientRequest.appendUrl(base, path).url;
+  const resource = {
+    serviceName: config.serviceName,
+    serviceVersion: config.serviceVersion,
+    attributes: {
+      "deployment.environment.name": config.environment,
     },
-  });
+  };
+  return Layer.mergeAll(
+    OtlpLogger.layer({
+      url: url("/v1/logs"),
+      resource,
+      shutdownTimeout: options.shutdownTimeout,
+    }),
+    OtlpMetrics.layer({
+      url: url("/v1/metrics"),
+      resource,
+      shutdownTimeout: options.shutdownTimeout,
+    }),
+    layerHttpServerOtlpTracer({
+      url: url("/v1/traces"),
+      resource,
+      shutdownTimeout: options.shutdownTimeout,
+    }),
+  ).pipe(Layer.provide(OtlpSerialization.layerJson));
+};
 
-export const layer = (config: TelemetryConfig): Layer.Layer<never> =>
-  layerOtlp(config).pipe(Layer.provide(FetchHttpClient.layer));
+export const layer = (
+  config: TelemetryConfig,
+  options: OtlpLayerOptions = {},
+): Layer.Layer<OtlpExporter.Flusher> =>
+  layerOtlp(config, options).pipe(Layer.provide(FetchHttpClient.layer));
 
 export const layerFromEnv = (
   env: EnvironmentVariables,
-): Layer.Layer<never, InvalidTelemetryEnvironment> =>
-  Layer.unwrap(Effect.map(telemetryConfigFromEnv(env), layer));
+  options: OtlpLayerOptions = {},
+): Layer.Layer<OtlpExporter.Flusher, InvalidTelemetryEnvironment> =>
+  Layer.unwrap(Effect.map(telemetryConfigFromEnv(env), (config) => layer(config, options)));

--- a/packages/telemetry/src/nestjs/HttpRoutePolicy.ts
+++ b/packages/telemetry/src/nestjs/HttpRoutePolicy.ts
@@ -1,0 +1,289 @@
+import { Option, Predicate, Schema } from "effect";
+import { isIP } from "node:net";
+
+const maxMethodLength = 32;
+const maxRouteLength = 256;
+const maxTargetLength = 2048;
+const maxAddressLength = 128;
+
+const HttpMethod = Schema.NonEmptyString.check(
+  Schema.isMaxLength(maxMethodLength),
+  Schema.isPattern(/^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/),
+);
+
+const RouteTemplate = Schema.NonEmptyString.check(
+  Schema.isMaxLength(maxRouteLength),
+  Schema.isPattern(/^\/[\x21-\x7e]*$/),
+  Schema.makeFilter(
+    (route) =>
+      !route.includes("//") &&
+      !route.includes("\\") &&
+      !route.includes("?") &&
+      !route.includes("#") &&
+      !route.includes("@") &&
+      !route.includes("://"),
+    { expected: "a bounded absolute route template without a URL authority or query" },
+  ),
+);
+
+const RequestTarget = Schema.NonEmptyString.check(Schema.isMaxLength(maxTargetLength));
+const NetworkAddress = Schema.NonEmptyString.check(
+  Schema.isMaxLength(maxAddressLength),
+  Schema.makeFilter((address) => isIP(address) !== 0, { expected: "an IP address" }),
+);
+const ServerAddress = Schema.NonEmptyString.check(
+  Schema.isMaxLength(maxAddressLength),
+  Schema.isPattern(/^[A-Za-z0-9.:[\]_-]+$/),
+);
+const NetworkPort = Schema.Number.check(
+  Schema.isInt(),
+  Schema.isBetween({ minimum: 1, maximum: 65_535 }),
+);
+
+const HttpRequestBoundary = Schema.Struct({ method: HttpMethod });
+const ExpressRouteBoundary = Schema.Struct({ route: Schema.Struct({ path: RouteTemplate }) });
+const FastifyRouteBoundary = Schema.Struct({
+  routeOptions: Schema.Struct({ url: RouteTemplate }),
+});
+const HttpTargetBoundary = Schema.Struct({
+  originalUrl: RequestTarget.pipe(Schema.optionalKey),
+  url: RequestTarget.pipe(Schema.optionalKey),
+});
+const FrameworkProtocol = Schema.Literals(["http", "https"]);
+
+const decodeHttpRequestBoundary = Schema.decodeUnknownOption(HttpRequestBoundary);
+const decodeExpressRouteBoundary = Schema.decodeUnknownOption(ExpressRouteBoundary);
+const decodeFastifyRouteBoundary = Schema.decodeUnknownOption(FastifyRouteBoundary);
+const decodeHttpTargetBoundary = Schema.decodeUnknownOption(HttpTargetBoundary);
+const decodeNetworkAddress = Schema.decodeUnknownOption(NetworkAddress);
+const decodeServerAddress = Schema.decodeUnknownOption(ServerAddress);
+const decodeNetworkPort = Schema.decodeUnknownOption(NetworkPort);
+const decodeEncryptedSocket = Schema.decodeUnknownOption(Schema.Boolean);
+const decodeFrameworkProtocol = Schema.decodeUnknownOption(FrameworkProtocol);
+const decodeRouteTemplates = Schema.decodeUnknownOption(Schema.Array(RouteTemplate));
+
+const knownMethods = new Set([
+  "CONNECT",
+  "DELETE",
+  "GET",
+  "HEAD",
+  "OPTIONS",
+  "PATCH",
+  "POST",
+  "PUT",
+  "TRACE",
+]);
+
+const defaultExcludedRoutes = ["/health", "/_telemetry/events"];
+const staticSegmentPattern = /^[A-Za-z0-9._~-]+$/;
+const parameterSegmentPattern = /^:[A-Za-z_][A-Za-z0-9_]*$/;
+const wildcardSegmentPattern = /^(?:\*[A-Za-z_][A-Za-z0-9_]*|\{\*[A-Za-z_][A-Za-z0-9_]*\})$/;
+
+export type ProxyPolicy = "direct" | "framework";
+
+export type TelemetryRoutePolicyOptions = {
+  readonly healthRouteTemplates?: ReadonlyArray<string> | undefined;
+  readonly proxyPolicy?: ProxyPolicy | undefined;
+};
+
+export type HttpServerRequest = {
+  readonly method: string;
+  readonly methodOriginal: Option.Option<string>;
+  readonly route: Option.Option<string>;
+  readonly spanName: string;
+  readonly urlPath: Option.Option<string>;
+  readonly urlScheme: Option.Option<string>;
+  readonly clientAddress: Option.Option<string>;
+  readonly networkPeerAddress: Option.Option<string>;
+  readonly networkPeerPort: Option.Option<number>;
+  readonly serverAddress: Option.Option<string>;
+};
+
+export type TelemetryRoutePolicy = {
+  readonly inspect: (request: WeakKey) => Option.Option<HttpServerRequest>;
+};
+
+const normalizeRoute = (route: string): string =>
+  route.length > 1 && route.endsWith("/") ? route.slice(0, -1) : route;
+
+const normalizedRoute = (request: WeakKey): Option.Option<string> =>
+  decodeExpressRouteBoundary(request).pipe(
+    Option.map((boundary) => normalizeRoute(boundary.route.path)),
+    Option.orElse(() =>
+      decodeFastifyRouteBoundary(request).pipe(
+        Option.map((boundary) => normalizeRoute(boundary.routeOptions.url)),
+      ),
+    ),
+  );
+
+const normalizedMethod = (
+  request: WeakKey,
+): { readonly method: string; readonly original: Option.Option<string> } =>
+  decodeHttpRequestBoundary(request).pipe(
+    Option.map((boundary) => boundary.method.toUpperCase()),
+    Option.match({
+      onNone: () => ({ method: "_OTHER", original: Option.none() }),
+      onSome: (method) =>
+        knownMethods.has(method)
+          ? { method, original: Option.none() }
+          : { method: "_OTHER", original: Option.some(method) },
+    }),
+  );
+
+const rawPath = (request: WeakKey): Option.Option<string> =>
+  decodeHttpTargetBoundary(request).pipe(
+    Option.flatMap((boundary) =>
+      Option.fromNullishOr(boundary.originalUrl).pipe(
+        Option.orElse(() => Option.fromNullishOr(boundary.url)),
+      ),
+    ),
+    Option.filter(
+      (target) =>
+        target.startsWith("/") &&
+        !target.startsWith("//") &&
+        !target.includes("#") &&
+        !target.includes("@") &&
+        !target.includes("://"),
+    ),
+    Option.map((target) => target.split("?", 1)[0] ?? "/"),
+    Option.map(normalizeRoute),
+  );
+
+const scrubPath = (request: WeakKey, route: string): Option.Option<string> =>
+  rawPath(request).pipe(
+    Option.flatMap((path) => {
+      if (route === "/") {
+        return path === "/" ? Option.some("/") : Option.none();
+      }
+      const routeSegments = route.split("/").slice(1);
+      const pathSegments = path.split("/").slice(1);
+      const scrubbed: Array<string> = [];
+      for (let index = 0; index < routeSegments.length; index++) {
+        const routeSegment = routeSegments[index] ?? "";
+        const pathSegment = pathSegments[index];
+        if (
+          index === routeSegments.length - 1 &&
+          wildcardSegmentPattern.test(routeSegment) &&
+          pathSegment !== undefined
+        ) {
+          scrubbed.push("REDACTED");
+          return Option.some(`/${scrubbed.join("/")}`);
+        }
+        if (pathSegment === undefined) {
+          return Option.none();
+        }
+        if (parameterSegmentPattern.test(routeSegment)) {
+          scrubbed.push("REDACTED");
+        } else if (staticSegmentPattern.test(routeSegment) && routeSegment === pathSegment) {
+          scrubbed.push(routeSegment);
+        } else {
+          return Option.none();
+        }
+      }
+      if (pathSegments.length !== routeSegments.length) {
+        return Option.none();
+      }
+      return Option.some(scrubbed.length === 0 ? "/" : `/${scrubbed.join("/")}`);
+    }),
+  );
+
+const directNetwork = (
+  request: WeakKey,
+): Pick<
+  HttpServerRequest,
+  "urlScheme" | "clientAddress" | "networkPeerAddress" | "networkPeerPort" | "serverAddress"
+> => {
+  if (!Predicate.hasProperty(request, "socket")) {
+    return {
+      urlScheme: Option.some("http"),
+      clientAddress: Option.none(),
+      networkPeerAddress: Option.none(),
+      networkPeerPort: Option.none(),
+      serverAddress: Option.none(),
+    };
+  }
+  const socket = request.socket;
+  const address = Predicate.hasProperty(socket, "remoteAddress")
+    ? decodeNetworkAddress(socket.remoteAddress)
+    : Option.none<string>();
+  const port = Predicate.hasProperty(socket, "remotePort")
+    ? decodeNetworkPort(socket.remotePort)
+    : Option.none<number>();
+  const encrypted = Predicate.hasProperty(socket, "encrypted")
+    ? decodeEncryptedSocket(socket.encrypted)
+    : Option.none<boolean>();
+  return {
+    urlScheme: Option.some(Option.getOrElse(encrypted, () => false) ? "https" : "http"),
+    clientAddress: address,
+    networkPeerAddress: address,
+    networkPeerPort: port,
+    serverAddress: Option.none(),
+  };
+};
+
+const frameworkNetwork = (
+  request: WeakKey,
+): Pick<
+  HttpServerRequest,
+  "urlScheme" | "clientAddress" | "networkPeerAddress" | "networkPeerPort" | "serverAddress"
+> => {
+  const direct = directNetwork(request);
+  return {
+    urlScheme: Predicate.hasProperty(request, "protocol")
+      ? decodeFrameworkProtocol(request.protocol)
+      : Option.none(),
+    clientAddress: Predicate.hasProperty(request, "ip")
+      ? decodeNetworkAddress(request.ip)
+      : Option.none(),
+    networkPeerAddress: direct.networkPeerAddress,
+    networkPeerPort: direct.networkPeerPort,
+    serverAddress: Predicate.hasProperty(request, "hostname")
+      ? decodeServerAddress(request.hostname)
+      : Option.none(),
+  };
+};
+
+export const telemetryRoutePolicy = (
+  options: TelemetryRoutePolicyOptions = {},
+): TelemetryRoutePolicy => {
+  const additionalExclusions = decodeRouteTemplates(options.healthRouteTemplates ?? []).pipe(
+    Option.getOrThrowWith(
+      () => new TypeError("Telemetry health route templates must be bounded absolute paths."),
+    ),
+  );
+  const exclusions = new Set(
+    [...defaultExcludedRoutes, ...additionalExclusions].map(normalizeRoute),
+  );
+  const proxyPolicy = options.proxyPolicy ?? "direct";
+  if (proxyPolicy !== "direct" && proxyPolicy !== "framework") {
+    throw new TypeError("Telemetry proxy policy must be direct or framework.");
+  }
+  return {
+    inspect: (request) => {
+      const route = normalizedRoute(request);
+      if (Option.isSome(route) && exclusions.has(route.value)) {
+        return Option.none();
+      }
+      const requestMethod = normalizedMethod(request);
+      const network =
+        proxyPolicy === "framework" ? frameworkNetwork(request) : directNetwork(request);
+      const spanPrefix = requestMethod.method === "_OTHER" ? "HTTP" : requestMethod.method;
+      return Option.some({
+        method: requestMethod.method,
+        methodOriginal: requestMethod.original,
+        route,
+        spanName: Option.match(route, {
+          onNone: () => spanPrefix,
+          onSome: (routeTemplate) => `${spanPrefix} ${routeTemplate}`,
+        }),
+        urlPath: Option.flatMap(route, (routeTemplate) => scrubPath(request, routeTemplate)),
+        ...network,
+      });
+    },
+  };
+};
+
+export const inspectHttpServerRequest = (
+  request: WeakKey,
+  options: TelemetryRoutePolicyOptions = {},
+): Option.Option<HttpServerRequest> => telemetryRoutePolicy(options).inspect(request);

--- a/packages/telemetry/src/nestjs/HttpRoutePolicy.ts
+++ b/packages/telemetry/src/nestjs/HttpRoutePolicy.ts
@@ -120,13 +120,16 @@ const normalizedMethod = (
   request: WeakKey,
 ): { readonly method: string; readonly original: Option.Option<string> } =>
   decodeHttpRequestBoundary(request).pipe(
-    Option.map((boundary) => boundary.method.toUpperCase()),
     Option.match({
       onNone: () => ({ method: "_OTHER", original: Option.none() }),
-      onSome: (method) =>
-        knownMethods.has(method)
-          ? { method, original: Option.none() }
-          : { method: "_OTHER", original: Option.some(method) },
+      onSome: (boundary) => {
+        const normalized = boundary.method.toUpperCase();
+        const method = knownMethods.has(normalized) ? normalized : "_OTHER";
+        return {
+          method,
+          original: boundary.method === method ? Option.none() : Option.some(boundary.method),
+        };
+      },
     }),
   );
 

--- a/packages/telemetry/src/nestjs/HttpServerOtlpTracer.ts
+++ b/packages/telemetry/src/nestjs/HttpServerOtlpTracer.ts
@@ -1,0 +1,251 @@
+import { Cause, Duration, Effect, Layer, Option, Schema, Tracer } from "effect";
+import type { Exit } from "effect";
+import type { HttpClient } from "effect/unstable/http";
+import { OtlpExporter, OtlpResource, OtlpSerialization } from "effect/unstable/observability";
+
+const HttpStatusCode = Schema.Number.check(
+  Schema.isInt(),
+  Schema.isBetween({ minimum: 100, maximum: 599 }),
+);
+const decodeHttpStatusCode = Schema.decodeUnknownOption(HttpStatusCode);
+
+const statusCodeUnset = 0;
+const statusCodeOk = 1;
+const statusCodeError = 2;
+
+const spanKindCode = (kind: Tracer.SpanKind): number => {
+  switch (kind) {
+    case "internal":
+      return 1;
+    case "server":
+      return 2;
+    case "client":
+      return 3;
+    case "producer":
+      return 4;
+    case "consumer":
+      return 5;
+  }
+};
+
+type HttpTracerSpanOptions = {
+  readonly name: string;
+  readonly parent: Option.Option<Tracer.AnySpan>;
+  readonly annotations: Tracer.Span["annotations"];
+  readonly links: Array<Tracer.SpanLink>;
+  readonly startTime: bigint;
+  readonly kind: Tracer.SpanKind;
+  readonly sampled: boolean;
+};
+
+type OtlpStatus = {
+  readonly code: number;
+  readonly message?: string | undefined;
+};
+
+type OtlpEvent = {
+  readonly attributes: Array<OtlpResource.KeyValue>;
+  readonly name: string;
+  readonly timeUnixNano: string;
+  readonly droppedAttributesCount: number;
+};
+
+type OtlpLink = {
+  readonly attributes: Array<OtlpResource.KeyValue>;
+  readonly spanId: string;
+  readonly traceId: string;
+  readonly droppedAttributesCount: number;
+};
+
+type OtlpSpan = {
+  readonly traceId: string;
+  readonly spanId: string;
+  readonly parentSpanId: string | undefined;
+  readonly name: string;
+  readonly kind: number;
+  readonly startTimeUnixNano: string;
+  readonly endTimeUnixNano: string;
+  readonly attributes: Array<OtlpResource.KeyValue>;
+  readonly droppedAttributesCount: number;
+  readonly events: Array<OtlpEvent>;
+  readonly droppedEventsCount: number;
+  readonly status: OtlpStatus;
+  readonly links: Array<OtlpLink>;
+  readonly droppedLinksCount: number;
+};
+
+class ExportingSpan extends Tracer.NativeSpan {
+  readonly #exportSpan: (span: ExportingSpan) => void;
+  #ended = false;
+
+  constructor(options: HttpTracerSpanOptions, exportSpan: (span: ExportingSpan) => void) {
+    super(options);
+    this.#exportSpan = exportSpan;
+  }
+
+  override end(endTime: bigint, exit: Exit.Exit<unknown, unknown>): void {
+    if (this.#ended) {
+      return;
+    }
+    this.#ended = true;
+    super.end(endTime, exit);
+    if (this.sampled) {
+      this.#exportSpan(this);
+    }
+  }
+}
+
+const makeEvents = (span: ExportingSpan): Array<OtlpEvent> =>
+  span.events.map(([name, startTime, attributes]) => ({
+    name,
+    timeUnixNano: String(startTime),
+    attributes: OtlpResource.entriesToAttributes(Object.entries(attributes)),
+    droppedAttributesCount: 0,
+  }));
+
+const makeNonHttpStatus = (
+  span: ExportingSpan,
+  attributes: Array<OtlpResource.KeyValue>,
+  events: Array<OtlpEvent>,
+): OtlpStatus => {
+  if (span.status._tag !== "Ended") {
+    return { code: statusCodeUnset };
+  }
+  if (span.status.exit._tag === "Success") {
+    return { code: statusCodeOk };
+  }
+  if (Cause.hasInterruptsOnly(span.status.exit.cause)) {
+    attributes.push(
+      {
+        key: "span.label",
+        value: { stringValue: "⚠︎ Interrupted" },
+      },
+      {
+        key: "status.interrupted",
+        value: { boolValue: true },
+      },
+    );
+    return { code: statusCodeOk, message: "Interrupted" };
+  }
+  const errors = Cause.prettyErrors(span.status.exit.cause, { includeCauseInStack: true });
+  for (const error of errors) {
+    events.push({
+      name: "exception",
+      timeUnixNano: String(span.status.endTime),
+      droppedAttributesCount: 0,
+      attributes: OtlpResource.entriesToAttributes([
+        ["exception.type", error.name],
+        ["exception.message", error.message],
+        ["exception.stacktrace", error.stack ?? "No stack trace available"],
+      ]),
+    });
+  }
+  return errors.length === 0
+    ? { code: statusCodeError }
+    : { code: statusCodeError, message: errors[0]?.message };
+};
+
+const makeHttpStatus = (span: ExportingSpan): OtlpStatus => {
+  if (span.attributes.has("error.type")) {
+    return { code: statusCodeError };
+  }
+  return decodeHttpStatusCode(span.attributes.get("http.response.status_code")).pipe(
+    Option.match({
+      onNone: () => ({ code: statusCodeUnset }),
+      onSome: (status) => ({ code: status >= 500 ? statusCodeError : statusCodeUnset }),
+    }),
+  );
+};
+
+const makeOtlpSpan = (span: ExportingSpan): Option.Option<OtlpSpan> => {
+  if (span.status._tag !== "Ended") {
+    return Option.none();
+  }
+  const attributes = OtlpResource.entriesToAttributes(span.attributes.entries());
+  const events = makeEvents(span);
+  const isHttpServer = span.kind === "server" && span.attributes.has("http.request.method");
+  return Option.some({
+    traceId: span.traceId,
+    spanId: span.spanId,
+    parentSpanId: Option.getOrUndefined(Option.map(span.parent, (parent) => parent.spanId)),
+    name: span.name,
+    kind: spanKindCode(span.kind),
+    startTimeUnixNano: String(span.status.startTime),
+    endTimeUnixNano: String(span.status.endTime),
+    attributes,
+    droppedAttributesCount: 0,
+    events,
+    droppedEventsCount: 0,
+    status: isHttpServer ? makeHttpStatus(span) : makeNonHttpStatus(span, attributes, events),
+    links: span.links.map((link) => ({
+      traceId: link.span.traceId,
+      spanId: link.span.spanId,
+      attributes: OtlpResource.entriesToAttributes(Object.entries(link.attributes)),
+      droppedAttributesCount: 0,
+    })),
+    droppedLinksCount: 0,
+  });
+};
+
+export type HttpServerOtlpTracerOptions = {
+  readonly url: string;
+  readonly resource: {
+    readonly serviceName: string;
+    readonly serviceVersion: string;
+    readonly attributes: {
+      readonly "deployment.environment.name": string;
+    };
+  };
+  readonly shutdownTimeout?: Duration.Input | undefined;
+};
+
+const makeHttpServerOtlpTracer = Effect.fn("makeHttpServerOtlpTracer")(function* (
+  options: HttpServerOtlpTracerOptions,
+) {
+  const resource = yield* OtlpResource.fromConfig(options.resource);
+  const serialization = yield* OtlpSerialization.OtlpSerialization;
+  const exporter = yield* OtlpExporter.make({
+    label: "HttpServerOtlpTracer",
+    url: options.url,
+    headers: undefined,
+    exportInterval: Duration.seconds(5),
+    maxBatchSize: 1000,
+    body: (spans) => [
+      serialization.traces({
+        resourceSpans: [
+          {
+            resource,
+            scopeSpans: [
+              {
+                scope: { name: OtlpResource.serviceNameUnsafe(resource) },
+                spans,
+              },
+            ],
+          },
+        ],
+      }),
+      Effect.void,
+    ],
+    shutdownTimeout: options.shutdownTimeout ?? Duration.seconds(3),
+  });
+  return Tracer.make({
+    span: (spanOptions) =>
+      new ExportingSpan(spanOptions, (span) => {
+        const exported = makeOtlpSpan(span);
+        if (Option.isSome(exported)) {
+          exporter.push(exported.value);
+        }
+      }),
+  });
+});
+
+export const layerHttpServerOtlpTracer = (
+  options: HttpServerOtlpTracerOptions,
+): Layer.Layer<
+  OtlpExporter.Flusher,
+  never,
+  HttpClient.HttpClient | OtlpSerialization.OtlpSerialization
+> =>
+  Layer.effect(Tracer.Tracer, makeHttpServerOtlpTracer(options)).pipe(
+    Layer.provideMerge(OtlpExporter.layerFlusher),
+  );

--- a/packages/telemetry/src/nestjs/TelemetryInterceptor.ts
+++ b/packages/telemetry/src/nestjs/TelemetryInterceptor.ts
@@ -1,13 +1,13 @@
 import type { CallHandler, ExecutionContext, NestInterceptor } from "@nestjs/common";
-import { Context, Effect, Exit, Option, Schema, Tracer } from "effect";
+import { Context, Effect, Exit, Option, Predicate, Schema, Tracer } from "effect";
 import type { Clock, ManagedRuntime } from "effect";
+import { EventEmitter } from "node:events";
 import { Observable } from "rxjs";
-
-const HttpRequestBoundary = Schema.Struct({
-  method: Schema.NonEmptyString,
-});
-
-const decodeHttpRequestBoundary = Schema.decodeUnknownOption(HttpRequestBoundary);
+import {
+  telemetryRoutePolicy,
+  type ProxyPolicy,
+  type TelemetryRoutePolicy,
+} from "./HttpRoutePolicy.ts";
 
 const TraceparentRequest = Schema.Struct({
   headers: Schema.Struct({
@@ -25,21 +25,23 @@ const TraceparentRequest = Schema.Struct({
 const parseTraceparentRequest = Schema.decodeUnknownOption(TraceparentRequest);
 
 const HttpResponseBoundary = Schema.Struct({
-  statusCode: Schema.Number.check(Schema.isInt()),
+  statusCode: Schema.Number.check(Schema.isInt(), Schema.isBetween({ minimum: 100, maximum: 599 })),
 });
 
 const decodeHttpResponseBoundary = Schema.decodeUnknownOption(HttpResponseBoundary);
 
-const ClientErrorBoundary = Schema.Struct({
+const HttpErrorBoundary = Schema.Struct({
   status: Schema.Number.check(
     Schema.isInt(),
-    Schema.makeFilter((status) => status >= 400 && status <= 499, {
-      expected: "an HTTP client error status",
-    }),
-  ),
+    Schema.isBetween({ minimum: 100, maximum: 599 }),
+  ).pipe(Schema.optionalKey),
 });
+const ErrorType = Schema.NonEmptyString.check(Schema.isMaxLength(128));
 
-const decodeClientErrorBoundary = Schema.decodeUnknownOption(ClientErrorBoundary);
+const decodeHttpErrorBoundary = Schema.decodeUnknownOption(HttpErrorBoundary);
+const decodeErrorType = Schema.decodeUnknownOption(ErrorType);
+const decodeHeadersSent = Schema.decodeUnknownOption(Schema.Boolean);
+const decodeResponseEmitter = Schema.decodeUnknownOption(Schema.instanceOf(EventEmitter));
 
 export type RequestReference = WeakKey;
 
@@ -56,17 +58,80 @@ export const withRequestSpan =
       onSome: (span) => Effect.withParentSpan(effect, span),
     });
 
+type ActiveRequest = {
+  readonly interrupt: () => void;
+};
+
+export class TelemetryRequestTracker {
+  #accepting = true;
+  readonly #active = new Set<ActiveRequest>();
+  readonly #idleWaiters = new Set<() => void>();
+
+  get accepting(): boolean {
+    return this.#accepting;
+  }
+
+  register(activeRequest: ActiveRequest): Option.Option<() => void> {
+    if (!this.#accepting) {
+      return Option.none();
+    }
+    this.#active.add(activeRequest);
+    return Option.some(() => {
+      if (!this.#active.delete(activeRequest) || this.#active.size !== 0) {
+        return;
+      }
+      for (const resolve of this.#idleWaiters) {
+        resolve();
+      }
+      this.#idleWaiters.clear();
+    });
+  }
+
+  closeAdmission(): void {
+    this.#accepting = false;
+  }
+
+  waitForIdle(): Promise<void> {
+    if (this.#active.size === 0) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => this.#idleWaiters.add(resolve));
+  }
+
+  interruptActive(): void {
+    for (const activeRequest of this.#active) {
+      activeRequest.interrupt();
+    }
+  }
+}
+
+export type TelemetryInterceptorOptions = {
+  readonly healthRouteTemplates?: ReadonlyArray<string> | undefined;
+  readonly proxyPolicy?: ProxyPolicy | undefined;
+  readonly requestTracker?: TelemetryRequestTracker | undefined;
+};
+
 export class TelemetryInterceptor<RuntimeError> implements NestInterceptor {
   readonly #runtime: ManagedRuntime.ManagedRuntime<never, RuntimeError>;
+  readonly #routePolicy: TelemetryRoutePolicy;
+  readonly #requestTracker: TelemetryRequestTracker;
   #tracer: Tracer.Tracer | undefined;
   #clock: Clock.Clock | undefined;
 
-  constructor(runtime: ManagedRuntime.ManagedRuntime<never, RuntimeError>) {
+  constructor(
+    runtime: ManagedRuntime.ManagedRuntime<never, RuntimeError>,
+    options: TelemetryInterceptorOptions = {},
+  ) {
     this.#runtime = runtime;
+    this.#routePolicy = telemetryRoutePolicy({
+      healthRouteTemplates: options.healthRouteTemplates,
+      proxyPolicy: options.proxyPolicy,
+    });
+    this.#requestTracker = options.requestTracker ?? new TelemetryRequestTracker();
   }
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
-    if (context.getType() !== "http") {
+    if (context.getType() !== "http" || !this.#requestTracker.accepting) {
       return next.handle();
     }
     try {
@@ -77,17 +142,15 @@ export class TelemetryInterceptor<RuntimeError> implements NestInterceptor {
   }
 
   #instrument(context: ExecutionContext, next: CallHandler): Observable<unknown> {
-    const tracer = (this.#tracer ??= this.#runtime.runSync(Effect.tracer));
-    const clock = (this.#clock ??= this.#runtime.runSync(Effect.clockWith(Effect.succeed)));
     const httpContext = context.switchToHttp();
     const request = httpContext.getRequest<RequestReference>();
+    const requestDetails = this.#routePolicy.inspect(request);
+    if (Option.isNone(requestDetails)) {
+      return next.handle();
+    }
+    const tracer = (this.#tracer ??= this.#runtime.runSync(Effect.tracer));
+    const clock = (this.#clock ??= this.#runtime.runSync(Effect.clockWith(Effect.succeed)));
     const traceparentRequest = httpContext.getRequest<typeof TraceparentRequest.Encoded>();
-    const method = decodeHttpRequestBoundary(request).pipe(
-      Option.map((boundary) => boundary.method.toUpperCase()),
-      Option.getOrElse(() => "UNKNOWN"),
-    );
-    const controller = context.getClass().name;
-    const handler = context.getHandler().name;
     const parent = parseTraceparentRequest({ headers: traceparentRequest.headers }).pipe(
       Option.map(({ headers }) => {
         const traceparent = headers.traceparent;
@@ -98,8 +161,9 @@ export class TelemetryInterceptor<RuntimeError> implements NestInterceptor {
         });
       }),
     );
+    const details = requestDetails.value;
     const span = tracer.span({
-      name: `${method} ${controller}.${handler}`,
+      name: details.spanName,
       parent,
       annotations: Context.empty(),
       links: [],
@@ -111,53 +175,153 @@ export class TelemetryInterceptor<RuntimeError> implements NestInterceptor {
         onSome: (remoteParent) => remoteParent.sampled,
       }),
     });
-    span.attribute("http.request.method", method);
-    span.attribute("nestjs.controller", controller);
-    span.attribute("nestjs.handler", handler);
+    span.attribute("http.request.method", details.method);
+    if (Option.isSome(details.methodOriginal)) {
+      span.attribute("http.request.method_original", details.methodOriginal.value);
+    }
+    if (Option.isSome(details.route)) {
+      span.attribute("http.route", details.route.value);
+    }
+    if (Option.isSome(details.urlPath)) {
+      span.attribute("url.path", details.urlPath.value);
+    }
+    if (Option.isSome(details.urlScheme)) {
+      span.attribute("url.scheme", details.urlScheme.value);
+    }
+    if (Option.isSome(details.clientAddress)) {
+      span.attribute("client.address", details.clientAddress.value);
+    }
+    if (Option.isSome(details.networkPeerAddress)) {
+      span.attribute("network.peer.address", details.networkPeerAddress.value);
+    }
+    if (Option.isSome(details.networkPeerPort)) {
+      span.attribute("network.peer.port", details.networkPeerPort.value);
+    }
+    if (Option.isSome(details.serverAddress)) {
+      span.attribute("server.address", details.serverAddress.value);
+    }
     requestSpans.set(request, span);
+    const response = httpContext.getResponse<RequestReference>();
+    const responseEmitter = decodeResponseEmitter(response);
 
     return new Observable((subscriber) => {
-      let settled = false;
+      let ended = false;
+      let responseFinished = false;
+      let observableSettled = false;
+      let pendingExit: Exit.Exit<unknown, unknown> = Exit.succeed(undefined);
+      let pendingErrorType = Option.none<string>();
+      let release = (): void => {};
+
+      const responseStatus = (requireSent = false): Option.Option<number> => {
+        if (requireSent) {
+          const headersSent = Predicate.hasProperty(response, "headersSent")
+            ? decodeHeadersSent(response.headersSent)
+            : Option.none<boolean>();
+          if (!Option.getOrElse(headersSent, () => false)) {
+            return Option.none();
+          }
+        }
+        return decodeHttpResponseBoundary(response).pipe(
+          Option.map((boundary) => boundary.statusCode),
+        );
+      };
+
+      const removeResponseListeners = (): void => {
+        if (Option.isSome(responseEmitter)) {
+          responseEmitter.value.off("finish", onResponseFinish);
+          responseEmitter.value.off("close", onResponseClose);
+        }
+      };
+
       const finish = (
         exit: Exit.Exit<unknown, unknown>,
-        statusOverride: Option.Option<number>,
+        status: Option.Option<number>,
+        errorType: Option.Option<string>,
       ): void => {
-        if (settled) {
+        if (ended) {
           return;
         }
-        settled = true;
-        const status = statusOverride.pipe(
-          Option.orElse(() =>
-            decodeHttpResponseBoundary(httpContext.getResponse<RequestReference>()).pipe(
-              Option.map((boundary) => boundary.statusCode),
-            ),
-          ),
-        );
+        ended = true;
+        removeResponseListeners();
         if (Option.isSome(status)) {
           span.attribute("http.response.status_code", status.value);
         }
+        const finalErrorType = Option.contains(errorType, "connection_closed")
+          ? errorType
+          : Option.match(status, {
+              onNone: () => errorType,
+              onSome: (statusCode) => {
+                if (statusCode >= 500) {
+                  return Option.some(String(statusCode));
+                }
+                if (statusCode >= 400) {
+                  return Option.none<string>();
+                }
+                return errorType;
+              },
+            });
+        if (Option.isSome(finalErrorType)) {
+          span.attribute("error.type", finalErrorType.value);
+        }
+        requestSpans.delete(request);
+        release();
         span.end(clock.currentTimeNanosUnsafe(), exit);
       };
+
+      const onResponseFinish = (): void => {
+        responseFinished = true;
+        finish(pendingExit, responseStatus(), pendingErrorType);
+      };
+
+      const onResponseClose = (): void => {
+        if (!responseFinished) {
+          finish(Exit.interrupt(), responseStatus(true), Option.some("connection_closed"));
+        }
+      };
+
+      const registered = this.#requestTracker.register({
+        interrupt: () => finish(Exit.interrupt(), responseStatus(true), Option.none()),
+      });
+      if (Option.isNone(registered)) {
+        requestSpans.delete(request);
+        span.end(clock.currentTimeNanosUnsafe(), Exit.interrupt());
+        return next.handle().subscribe(subscriber);
+      }
+      release = registered.value;
+
+      if (Option.isSome(responseEmitter)) {
+        responseEmitter.value.on("finish", onResponseFinish);
+        responseEmitter.value.on("close", onResponseClose);
+      }
+
       const subscription = next.handle().subscribe({
         next: (value) => subscriber.next(value),
         error: (cause: unknown) => {
-          const clientError = decodeClientErrorBoundary(cause);
-          if (Option.isSome(clientError)) {
-            finish(Exit.succeed(undefined), Option.some(clientError.value.status));
-          } else {
-            finish(Exit.die(cause), Option.none());
+          observableSettled = true;
+          const errorBoundary = decodeHttpErrorBoundary(cause);
+          pendingExit = Exit.die(cause);
+          pendingErrorType = Predicate.hasProperty(cause, "name")
+            ? decodeErrorType(cause.name).pipe(Option.orElse(() => Option.some("exception")))
+            : Option.some("exception");
+          if (Option.isNone(responseEmitter)) {
+            const status = errorBoundary.pipe(
+              Option.flatMap((boundary) => Option.fromNullishOr(boundary.status)),
+            );
+            finish(pendingExit, status, pendingErrorType);
           }
           subscriber.error(cause);
         },
         complete: () => {
-          finish(Exit.succeed(undefined), Option.none());
+          observableSettled = true;
+          if (Option.isNone(responseEmitter)) {
+            finish(Exit.succeed(undefined), responseStatus(), Option.none());
+          }
           subscriber.complete();
         },
       });
       return () => {
-        if (!settled) {
-          span.attribute("http.request.cancelled", true);
-          finish(Exit.interrupt(), Option.none());
+        if (!observableSettled && Option.isNone(responseEmitter)) {
+          finish(Exit.interrupt(), responseStatus(), Option.none());
         }
         subscription.unsubscribe();
       };

--- a/packages/telemetry/src/nestjs/index.ts
+++ b/packages/telemetry/src/nestjs/index.ts
@@ -7,6 +7,9 @@ export {
 export {
   requestSpan,
   TelemetryInterceptor,
+  TelemetryRequestTracker,
   withRequestSpan,
   type RequestReference,
+  type TelemetryInterceptorOptions,
 } from "./TelemetryInterceptor.ts";
+export type { ProxyPolicy, TelemetryRoutePolicyOptions } from "./HttpRoutePolicy.ts";

--- a/packages/telemetry/src/testing/index.ts
+++ b/packages/telemetry/src/testing/index.ts
@@ -1,5 +1,6 @@
 import { Effect, Layer, Option, Ref, Schema, type Exit } from "effect";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+import { OtlpExporter } from "effect/unstable/observability";
 import { layerOtlp } from "../Telemetry.ts";
 import { TelemetryConfig } from "../TelemetryConfig.ts";
 
@@ -12,9 +13,12 @@ export type CapturedSpan = {
   readonly spanId: string;
   readonly parentSpanId: Option.Option<string>;
   readonly name: string;
+  readonly kind: number;
   readonly statusCode: number;
   readonly statusMessage: Option.Option<string>;
   readonly attributes: CapturedAttributes;
+  readonly eventNames: ReadonlyArray<string>;
+  readonly linkedSpanIds: ReadonlyArray<string>;
   readonly resourceAttributes: CapturedAttributes;
 };
 
@@ -72,11 +76,18 @@ const ExportedSpan = Schema.Struct({
   spanId: Schema.String,
   parentSpanId: Schema.String.pipe(Schema.optionalKey),
   name: Schema.String,
+  kind: Schema.Number.pipe(Schema.withDecodingDefault(Effect.succeed(0))),
   status: Schema.Struct({
     code: Schema.Number.pipe(Schema.withDecodingDefault(Effect.succeed(0))),
     message: Schema.String.pipe(Schema.optionalKey),
   }).pipe(Schema.withDecodingDefault(Effect.succeed({ code: 0 }))),
   attributes: Attributes,
+  events: Schema.Array(Schema.Struct({ name: Schema.String })).pipe(
+    Schema.withDecodingDefault(Effect.succeed([])),
+  ),
+  links: Schema.Array(Schema.Struct({ spanId: Schema.String })).pipe(
+    Schema.withDecodingDefault(Effect.succeed([])),
+  ),
 });
 
 const SpanExport = Schema.Struct({
@@ -200,9 +211,12 @@ const decodeCapturedTelemetry = Effect.fn("decodeCapturedTelemetry")(function* (
               spanId: span.spanId,
               parentSpanId: Option.fromNullishOr(span.parentSpanId),
               name: span.name,
+              kind: span.kind,
               statusCode: span.status.code,
               statusMessage: Option.fromNullishOr(span.status.message),
               attributes: toAttributes(span.attributes),
+              eventNames: span.events.map((event) => event.name),
+              linkedSpanIds: span.links.map((link) => link.spanId),
               resourceAttributes,
             });
           }
@@ -262,7 +276,7 @@ export type RunOptions = {
 };
 
 export type TelemetryCapture = {
-  readonly layer: Layer.Layer<never>;
+  readonly layer: Layer.Layer<OtlpExporter.Flusher>;
   readonly telemetry: Effect.Effect<CapturedTelemetry>;
 };
 

--- a/packages/telemetry/test/browserEndpoint.test.ts
+++ b/packages/telemetry/test/browserEndpoint.test.ts
@@ -59,7 +59,7 @@ const postEvents = (baseUrl: string, body: string): Promise<Response> =>
   });
 
 describe("browser events endpoint", () => {
-  it("accepts a valid batch with 202 and correlates the events to the request trace", async () => {
+  it("accepts a valid batch with 202 while the telemetry route stays excluded", async () => {
     const harness = await startApp(true);
     const response = await postEvents(
       harness.baseUrl,
@@ -81,22 +81,17 @@ describe("browser events endpoint", () => {
     assert.deepStrictEqual(await response.json(), { accepted: 2 });
 
     const telemetry = await harness.close();
-    const boundary = telemetry.spans.find(
-      (span) => span.name === "POST BrowserEventsController.events",
-    );
-    assert.isDefined(boundary);
-    assert.strictEqual(boundary.statusCode, 1);
-    assert.strictEqual(attributeOrUndefined(boundary.attributes, "http.response.status_code"), 202);
+    const boundary = telemetry.spans.find((span) => span.name.includes("/_telemetry/events"));
+    assert.isUndefined(boundary);
 
     const checkout = telemetry.logs.find(
       (log) => attributeOrUndefined(log.attributes, "event.name") === "checkout.completed",
     );
     assert.isDefined(checkout);
     assert.strictEqual(attributeOrUndefined(checkout.attributes, "event.source"), "browser");
-    assert.deepStrictEqual(checkout.traceId, Option.some(boundary.traceId));
   }, 30_000);
 
-  it("rejects an invalid batch with the public contract and the trace correlation id", async () => {
+  it("rejects an invalid batch with the public contract and a safe correlation id", async () => {
     const harness = await startApp(true);
     const response = await postEvents(harness.baseUrl, JSON.stringify({ nonsense: true }));
 
@@ -108,13 +103,9 @@ describe("browser events endpoint", () => {
     assert.notInclude(JSON.stringify(payload), "    at ");
 
     const telemetry = await harness.close();
-    const boundary = telemetry.spans.find(
-      (span) => span.name === "POST BrowserEventsController.events",
-    );
-    assert.isDefined(boundary);
-    assert.strictEqual(boundary.statusCode, 1);
-    assert.strictEqual(attributeOrUndefined(boundary.attributes, "http.response.status_code"), 400);
-    assert.strictEqual(rejection.correlationId, boundary.traceId);
+    const boundary = telemetry.spans.find((span) => span.name.includes("/_telemetry/events"));
+    assert.isUndefined(boundary);
+    assert.isTrue(rejection.correlationId.length > 0);
   }, 30_000);
 
   it("answers 400 to a malformed JSON body", async () => {

--- a/packages/telemetry/test/nestjs.test.ts
+++ b/packages/telemetry/test/nestjs.test.ts
@@ -2,22 +2,30 @@ import "reflect-metadata";
 import {
   Controller,
   Get,
-  NotFoundException,
+  HttpCode,
   Module,
+  NotFoundException,
+  Param,
   Req,
-  type CallHandler,
-  type ExecutionContext,
+  ServiceUnavailableException,
 } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
-import { ExecutionContextHost } from "@nestjs/core/helpers/execution-context-host.js";
-import { Effect, ManagedRuntime, Option, Schema } from "effect";
+import { ExpressAdapter } from "@nestjs/platform-express";
+import { Context, Effect, Exit, ManagedRuntime, Option, Schema, Tracer } from "effect";
+import { OtlpExporter } from "effect/unstable/observability";
+import type { AddressInfo } from "node:net";
 import { Observable } from "rxjs";
-import { assert, describe, expect, it } from "vite-plus/test";
-import { TelemetryInterceptor, withRequestSpan } from "../src/nestjs/index.ts";
+import { assert, describe, it } from "vite-plus/test";
+import { inspectHttpServerRequest } from "../src/nestjs/HttpRoutePolicy.ts";
+import {
+  TelemetryInterceptor,
+  TelemetryRequestTracker,
+  withRequestSpan,
+} from "../src/nestjs/index.ts";
 import * as Testing from "../src/testing/index.ts";
 
-const AddressInfo = Schema.Struct({ port: Schema.Number });
-const decodeAddressInfo = Schema.decodeUnknownOption(AddressInfo);
+const AddressBoundary = Schema.Struct({ port: Schema.Number });
+const decodeAddress = Schema.decodeUnknownOption(AddressBoundary);
 
 const attributeOrUndefined = (
   attributes: Testing.CapturedAttributes,
@@ -36,20 +44,45 @@ const methodDescriptor = <Prototype extends WeakKey>(
   return descriptor;
 };
 
+const applicationBaseUrl = (address: string | AddressInfo | null): string => {
+  const decoded = decodeAddress(address);
+  assert.isTrue(Option.isSome(decoded));
+  return `http://127.0.0.1:${Option.getOrThrow(decoded).port}`;
+};
+
+const findSpan = (telemetry: Testing.CapturedTelemetry, name: string): Testing.CapturedSpan => {
+  const span = telemetry.spans.find((candidate) => candidate.name === name);
+  assert.isDefined(span);
+  return span;
+};
+
 describe("nestjs TelemetryInterceptor", () => {
-  it("records boundary spans for success, client errors, defects and effect children", async () => {
+  it("records static, parameter, client error, defect, exclusion, and connection close semantics", async () => {
     const capture = await Effect.runPromise(Testing.makeCapture());
     const runtime = ManagedRuntime.make(capture.layer);
+    let startSlowRequest: (() => void) | undefined;
+    const slowRequestStarted = new Promise<void>((resolve) => {
+      startSlowRequest = resolve;
+    });
 
     class DemoController {
       ping(): { readonly ok: boolean } {
         return { ok: true };
       }
+      item(id: string): { readonly id: string } {
+        return { id };
+      }
+      redirect(): { readonly redirected: boolean } {
+        return { redirected: true };
+      }
       missing(): never {
         throw new NotFoundException("Recurso demo não foi encontrado.");
       }
       broken(): never {
-        throw new Error("kaput");
+        throw new Error("private defect text");
+      }
+      unavailable(): never {
+        throw new ServiceUnavailableException("private outage text");
       }
       effectful(request: WeakKey): Promise<{ readonly ok: boolean }> {
         return runtime.runPromise(
@@ -59,12 +92,34 @@ describe("nestjs TelemetryInterceptor", () => {
           ),
         );
       }
+      slow(): Observable<never> {
+        return new Observable(() => {
+          startSlowRequest?.();
+          return () => {};
+        });
+      }
     }
     Controller("demo")(DemoController);
     Get("ping")(
       DemoController.prototype,
       "ping",
       methodDescriptor(DemoController.prototype, "ping"),
+    );
+    Get("items/:id")(
+      DemoController.prototype,
+      "item",
+      methodDescriptor(DemoController.prototype, "item"),
+    );
+    Param("id")(DemoController.prototype, "item", 0);
+    Get("redirect")(
+      DemoController.prototype,
+      "redirect",
+      methodDescriptor(DemoController.prototype, "redirect"),
+    );
+    HttpCode(302)(
+      DemoController.prototype,
+      "redirect",
+      methodDescriptor(DemoController.prototype, "redirect"),
     );
     Get("missing")(
       DemoController.prototype,
@@ -76,71 +131,349 @@ describe("nestjs TelemetryInterceptor", () => {
       "broken",
       methodDescriptor(DemoController.prototype, "broken"),
     );
+    Get("unavailable")(
+      DemoController.prototype,
+      "unavailable",
+      methodDescriptor(DemoController.prototype, "unavailable"),
+    );
     Get("effectful")(
       DemoController.prototype,
       "effectful",
       methodDescriptor(DemoController.prototype, "effectful"),
     );
     Req()(DemoController.prototype, "effectful", 0);
+    Get("slow")(
+      DemoController.prototype,
+      "slow",
+      methodDescriptor(DemoController.prototype, "slow"),
+    );
+
+    class InternalController {
+      health(): { readonly ok: boolean } {
+        return { ok: true };
+      }
+      telemetry(): { readonly accepted: boolean } {
+        return { accepted: true };
+      }
+      ready(): { readonly ok: boolean } {
+        return { ok: true };
+      }
+      adjacent(): { readonly ok: boolean } {
+        return { ok: true };
+      }
+    }
+    Controller()(InternalController);
+    Get("health")(
+      InternalController.prototype,
+      "health",
+      methodDescriptor(InternalController.prototype, "health"),
+    );
+    Get("_telemetry/events")(
+      InternalController.prototype,
+      "telemetry",
+      methodDescriptor(InternalController.prototype, "telemetry"),
+    );
+    Get("ready")(
+      InternalController.prototype,
+      "ready",
+      methodDescriptor(InternalController.prototype, "ready"),
+    );
+    Get("healthcheck")(
+      InternalController.prototype,
+      "adjacent",
+      methodDescriptor(InternalController.prototype, "adjacent"),
+    );
 
     class AppModule {}
-    Module({ controllers: [DemoController] })(AppModule);
+    Module({ controllers: [DemoController, InternalController] })(AppModule);
 
     const app = await NestFactory.create(AppModule, { logger: false });
-    app.useGlobalInterceptors(new TelemetryInterceptor(runtime));
-    await app.listen(0);
-    const address = decodeAddressInfo(app.getHttpServer().address());
-    assert.isTrue(Option.isSome(address));
-    const baseUrl = `http://127.0.0.1:${Option.getOrThrow(address).port}`;
-
-    const ping = await fetch(`${baseUrl}/demo/ping`);
-    assert.strictEqual(ping.status, 200);
-    assert.deepStrictEqual(await ping.json(), { ok: true });
-
-    const missing = await fetch(`${baseUrl}/demo/missing`);
-    assert.strictEqual(missing.status, 404);
-
-    const broken = await fetch(`${baseUrl}/demo/broken`);
-    assert.strictEqual(broken.status, 500);
-
-    const effectful = await fetch(`${baseUrl}/demo/effectful`);
-    assert.strictEqual(effectful.status, 200);
-
-    await app.close();
-    await runtime.dispose();
-    const telemetry = await Effect.runPromise(capture.telemetry);
-
-    const pingSpan = telemetry.spans.find((span) => span.name === "GET DemoController.ping");
-    assert.isDefined(pingSpan);
-    assert.strictEqual(pingSpan.statusCode, 1);
-    assert.strictEqual(attributeOrUndefined(pingSpan.attributes, "http.request.method"), "GET");
-    assert.strictEqual(
-      attributeOrUndefined(pingSpan.attributes, "nestjs.controller"),
-      "DemoController",
+    app.useGlobalInterceptors(
+      new TelemetryInterceptor(runtime, { healthRouteTemplates: ["/ready/"] }),
     );
-    assert.strictEqual(attributeOrUndefined(pingSpan.attributes, "nestjs.handler"), "ping");
-    assert.strictEqual(attributeOrUndefined(pingSpan.attributes, "http.response.status_code"), 200);
+    await app.listen(0, "127.0.0.1");
+    const baseUrl = applicationBaseUrl(app.getHttpServer().address());
 
-    const missingSpan = telemetry.spans.find((span) => span.name === "GET DemoController.missing");
-    assert.isDefined(missingSpan);
-    assert.strictEqual(missingSpan.statusCode, 1);
+    try {
+      const ping = await fetch(`${baseUrl}/demo/ping?token=query-secret`, {
+        headers: {
+          forwarded: "for=203.0.113.8;proto=https;host=spoofed.example",
+          "x-forwarded-for": "203.0.113.8",
+          "x-forwarded-host": "spoofed.example",
+          "x-forwarded-proto": "https",
+        },
+      });
+      assert.strictEqual(ping.status, 200);
+      assert.deepStrictEqual(await ping.json(), { ok: true });
+
+      for (const id of ["first-secret-id", "second-secret-id"]) {
+        const item = await fetch(`${baseUrl}/demo/items/${id}?password=query-secret`);
+        assert.strictEqual(item.status, 200);
+        assert.deepStrictEqual(await item.json(), { id });
+      }
+
+      const redirect = await fetch(`${baseUrl}/demo/redirect`, { redirect: "manual" });
+      assert.strictEqual(redirect.status, 302);
+
+      const missing = await fetch(`${baseUrl}/demo/missing`);
+      assert.strictEqual(missing.status, 404);
+
+      const broken = await fetch(`${baseUrl}/demo/broken`);
+      assert.strictEqual(broken.status, 500);
+
+      const unavailable = await fetch(`${baseUrl}/demo/unavailable`);
+      assert.strictEqual(unavailable.status, 503);
+
+      const effectful = await fetch(`${baseUrl}/demo/effectful`);
+      assert.strictEqual(effectful.status, 200);
+
+      for (const excludedPath of ["/health", "/_telemetry/events", "/ready"]) {
+        const excluded = await fetch(`${baseUrl}${excludedPath}`);
+        assert.strictEqual(excluded.status, 200);
+      }
+
+      const adjacent = await fetch(`${baseUrl}/healthcheck`);
+      assert.strictEqual(adjacent.status, 200);
+
+      const unknown = await fetch(`${baseUrl}/not-a-route`);
+      assert.strictEqual(unknown.status, 404);
+
+      const abortController = new AbortController();
+      const slowResponse = fetch(`${baseUrl}/demo/slow`, { signal: abortController.signal }).catch(
+        () => undefined,
+      );
+      await slowRequestStarted;
+      abortController.abort();
+      await slowResponse;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const linked = Tracer.externalSpan({
+        traceId: "11111111111111111111111111111111",
+        spanId: "2222222222222222",
+      });
+      await runtime.runPromise(
+        Effect.gen(function* () {
+          const span = yield* Effect.currentSpan;
+          span.event("parity.event", 1n, { preserved: true });
+        }).pipe(
+          Effect.withSpan("non-http.parity", {
+            kind: "producer",
+            attributes: { "parity.attribute": "kept" },
+            links: [{ span: linked, attributes: { relationship: "test" } }],
+          }),
+        ),
+      );
+      await runtime.runPromise(
+        Effect.fail("non-http failure").pipe(Effect.withSpan("non-http.failure"), Effect.exit),
+      );
+      const tracer = runtime.runSync(Effect.tracer);
+      const clock = runtime.runSync(Effect.clockWith(Effect.succeed));
+      const cancellationSpan = tracer.span({
+        name: "GET /cancelled-fallback",
+        parent: Option.none(),
+        annotations: Context.empty(),
+        links: [],
+        startTime: clock.currentTimeNanosUnsafe(),
+        kind: "server",
+        root: true,
+        sampled: true,
+      });
+      cancellationSpan.attribute("http.request.method", "GET");
+      cancellationSpan.attribute("http.route", "/cancelled-fallback");
+      cancellationSpan.end(clock.currentTimeNanosUnsafe(), Exit.interrupt());
+      const defectSpan = tracer.span({
+        name: "POST /defect-without-status",
+        parent: Option.none(),
+        annotations: Context.empty(),
+        links: [],
+        startTime: clock.currentTimeNanosUnsafe(),
+        kind: "server",
+        root: true,
+        sampled: true,
+      });
+      defectSpan.attribute("http.request.method", "POST");
+      defectSpan.attribute("http.route", "/defect-without-status");
+      defectSpan.attribute("error.type", "TypeError");
+      defectSpan.end(clock.currentTimeNanosUnsafe(), Exit.die(new TypeError("private")));
+      const informationalSpan = tracer.span({
+        name: "GET /informational",
+        parent: Option.none(),
+        annotations: Context.empty(),
+        links: [],
+        startTime: clock.currentTimeNanosUnsafe(),
+        kind: "server",
+        root: true,
+        sampled: true,
+      });
+      informationalSpan.attribute("http.request.method", "GET");
+      informationalSpan.attribute("http.route", "/informational");
+      informationalSpan.attribute("http.response.status_code", 101);
+      informationalSpan.end(clock.currentTimeNanosUnsafe(), Exit.succeed(undefined));
+      await runtime.runPromise(Effect.flatMap(OtlpExporter.Flusher, (flusher) => flusher.flush));
+    } finally {
+      await app.close();
+      await runtime.dispose();
+    }
+
+    const telemetry = await Effect.runPromise(capture.telemetry);
+    const pingSpan = findSpan(telemetry, "GET /demo/ping");
+    assert.strictEqual(pingSpan.statusCode, 0);
+    assert.strictEqual(attributeOrUndefined(pingSpan.attributes, "http.request.method"), "GET");
+    assert.strictEqual(attributeOrUndefined(pingSpan.attributes, "http.route"), "/demo/ping");
+    assert.strictEqual(attributeOrUndefined(pingSpan.attributes, "url.path"), "/demo/ping");
+    assert.strictEqual(attributeOrUndefined(pingSpan.attributes, "url.scheme"), "http");
+    assert.strictEqual(attributeOrUndefined(pingSpan.attributes, "http.response.status_code"), 200);
+    assert.isDefined(attributeOrUndefined(pingSpan.attributes, "client.address"));
+    assert.notStrictEqual(
+      attributeOrUndefined(pingSpan.attributes, "client.address"),
+      "203.0.113.8",
+    );
+    assert.strictEqual(
+      attributeOrUndefined(pingSpan.attributes, "network.peer.address"),
+      attributeOrUndefined(pingSpan.attributes, "client.address"),
+    );
+    assert.isDefined(attributeOrUndefined(pingSpan.attributes, "network.peer.port"));
+    assert.isUndefined(attributeOrUndefined(pingSpan.attributes, "server.address"));
+    assert.isUndefined(attributeOrUndefined(pingSpan.attributes, "url.query"));
+    assert.isUndefined(attributeOrUndefined(pingSpan.attributes, "url.full"));
+    assert.isUndefined(attributeOrUndefined(pingSpan.attributes, "user_agent.original"));
+
+    const itemSpans = telemetry.spans.filter((span) => span.name === "GET /demo/items/:id");
+    assert.lengthOf(itemSpans, 2);
+    for (const itemSpan of itemSpans) {
+      assert.strictEqual(
+        attributeOrUndefined(itemSpan.attributes, "url.path"),
+        "/demo/items/REDACTED",
+      );
+      assert.strictEqual(
+        attributeOrUndefined(itemSpan.attributes, "http.route"),
+        "/demo/items/:id",
+      );
+    }
+
+    const redirectSpan = findSpan(telemetry, "GET /demo/redirect");
+    assert.strictEqual(redirectSpan.statusCode, 0);
+    assert.strictEqual(
+      attributeOrUndefined(redirectSpan.attributes, "http.response.status_code"),
+      302,
+    );
+
+    const missingSpan = findSpan(telemetry, "GET /demo/missing");
+    assert.strictEqual(missingSpan.statusCode, 0);
     assert.strictEqual(
       attributeOrUndefined(missingSpan.attributes, "http.response.status_code"),
       404,
     );
+    assert.isUndefined(attributeOrUndefined(missingSpan.attributes, "error.type"));
 
-    const brokenSpan = telemetry.spans.find((span) => span.name === "GET DemoController.broken");
-    assert.isDefined(brokenSpan);
+    const brokenSpan = findSpan(telemetry, "GET /demo/broken");
     assert.strictEqual(brokenSpan.statusCode, 2);
-
-    const boundarySpan = telemetry.spans.find(
-      (span) => span.name === "GET DemoController.effectful",
+    assert.strictEqual(
+      attributeOrUndefined(brokenSpan.attributes, "http.response.status_code"),
+      500,
     );
-    const childSpan = telemetry.spans.find((span) => span.name === "nest.child");
-    assert.isDefined(boundarySpan);
-    assert.isDefined(childSpan);
+    assert.strictEqual(attributeOrUndefined(brokenSpan.attributes, "error.type"), "500");
+    assert.isTrue(Option.isNone(brokenSpan.statusMessage));
+    assert.notInclude(brokenSpan.eventNames, "exception");
+
+    const unavailableSpan = findSpan(telemetry, "GET /demo/unavailable");
+    assert.strictEqual(unavailableSpan.statusCode, 2);
+    assert.strictEqual(
+      attributeOrUndefined(unavailableSpan.attributes, "http.response.status_code"),
+      503,
+    );
+    assert.strictEqual(attributeOrUndefined(unavailableSpan.attributes, "error.type"), "503");
+
+    const boundarySpan = findSpan(telemetry, "GET /demo/effectful");
+    const childSpan = findSpan(telemetry, "nest.child");
     assert.strictEqual(childSpan.traceId, boundarySpan.traceId);
     assert.deepStrictEqual(childSpan.parentSpanId, Option.some(boundarySpan.spanId));
+    assert.strictEqual(childSpan.statusCode, 1);
+
+    const slowSpan = findSpan(telemetry, "GET /demo/slow");
+    assert.strictEqual(slowSpan.statusCode, 2);
+    assert.strictEqual(
+      attributeOrUndefined(slowSpan.attributes, "error.type"),
+      "connection_closed",
+    );
+
+    for (const excludedSpanName of [
+      "GET /_telemetry/events",
+      "GET /health",
+      "GET /ready",
+      "GET /not-a-route",
+    ]) {
+      assert.isUndefined(telemetry.spans.find((span) => span.name === excludedSpanName));
+    }
+    assert.isDefined(telemetry.spans.find((span) => span.name === "GET /healthcheck"));
+
+    const paritySpan = findSpan(telemetry, "non-http.parity");
+    assert.strictEqual(paritySpan.statusCode, 1);
+    assert.strictEqual(paritySpan.kind, 4);
+    assert.deepStrictEqual(paritySpan.eventNames, ["parity.event"]);
+    assert.deepStrictEqual(paritySpan.linkedSpanIds, ["2222222222222222"]);
+    assert.strictEqual(attributeOrUndefined(paritySpan.attributes, "parity.attribute"), "kept");
+    assert.strictEqual(findSpan(telemetry, "non-http.failure").statusCode, 2);
+    const cancellationSpan = findSpan(telemetry, "GET /cancelled-fallback");
+    assert.strictEqual(cancellationSpan.statusCode, 0);
+    assert.isUndefined(attributeOrUndefined(cancellationSpan.attributes, "error.type"));
+    const defectSpan = findSpan(telemetry, "POST /defect-without-status");
+    assert.strictEqual(defectSpan.statusCode, 2);
+    assert.strictEqual(attributeOrUndefined(defectSpan.attributes, "error.type"), "TypeError");
+    assert.isTrue(Option.isNone(defectSpan.statusMessage));
+    assert.notInclude(defectSpan.eventNames, "exception");
+    assert.strictEqual(findSpan(telemetry, "GET /informational").statusCode, 0);
+  }, 30_000);
+
+  it("uses framework-resolved proxy values only after explicit opt-in", async () => {
+    const capture = await Effect.runPromise(Testing.makeCapture());
+    const runtime = ManagedRuntime.make(capture.layer);
+
+    class ProxyController {
+      ping(): { readonly ok: boolean } {
+        return { ok: true };
+      }
+    }
+    Controller("proxy")(ProxyController);
+    Get("ping")(
+      ProxyController.prototype,
+      "ping",
+      methodDescriptor(ProxyController.prototype, "ping"),
+    );
+
+    class ProxyModule {}
+    Module({ controllers: [ProxyController] })(ProxyModule);
+
+    const adapter = new ExpressAdapter();
+    adapter.set("trust proxy", "loopback");
+    const app = await NestFactory.create(ProxyModule, adapter, { logger: false });
+    app.useGlobalInterceptors(new TelemetryInterceptor(runtime, { proxyPolicy: "framework" }));
+    await app.listen(0, "127.0.0.1");
+    const baseUrl = applicationBaseUrl(app.getHttpServer().address());
+
+    try {
+      const response = await fetch(`${baseUrl}/proxy/ping`, {
+        headers: {
+          "x-forwarded-for": "198.51.100.7",
+          "x-forwarded-host": "trusted.example:8443",
+          "x-forwarded-proto": "https",
+        },
+      });
+      assert.strictEqual(response.status, 200);
+    } finally {
+      await app.close();
+      await runtime.dispose();
+    }
+
+    const span = findSpan(await Effect.runPromise(capture.telemetry), "GET /proxy/ping");
+    assert.strictEqual(attributeOrUndefined(span.attributes, "client.address"), "198.51.100.7");
+    assert.strictEqual(attributeOrUndefined(span.attributes, "url.scheme"), "https");
+    assert.strictEqual(attributeOrUndefined(span.attributes, "server.address"), "trusted.example");
+    assert.notStrictEqual(
+      attributeOrUndefined(span.attributes, "network.peer.address"),
+      "198.51.100.7",
+    );
+    assert.isUndefined(attributeOrUndefined(span.attributes, "server.port"));
   }, 30_000);
 
   it("propagates strict W3C traceparent context through real NestJS HTTP requests", async () => {
@@ -172,26 +505,13 @@ describe("nestjs TelemetryInterceptor", () => {
       }
     }
     Controller("traceparent")(TraceparentController);
-    Get("sampled")(
-      TraceparentController.prototype,
-      "sampled",
-      methodDescriptor(TraceparentController.prototype, "sampled"),
-    );
-    Get("unsampled")(
-      TraceparentController.prototype,
-      "unsampled",
-      methodDescriptor(TraceparentController.prototype, "unsampled"),
-    );
-    Get("absent")(
-      TraceparentController.prototype,
-      "absent",
-      methodDescriptor(TraceparentController.prototype, "absent"),
-    );
-    Get("malformed")(
-      TraceparentController.prototype,
-      "malformed",
-      methodDescriptor(TraceparentController.prototype, "malformed"),
-    );
+    for (const method of ["sampled", "unsampled", "absent", "malformed"]) {
+      Get(method)(
+        TraceparentController.prototype,
+        method,
+        methodDescriptor(TraceparentController.prototype, method),
+      );
+    }
     Req()(TraceparentController.prototype, "sampled", 0);
     Req()(TraceparentController.prototype, "unsampled", 0);
 
@@ -200,23 +520,10 @@ describe("nestjs TelemetryInterceptor", () => {
 
     const app = await NestFactory.create(TraceparentModule, { logger: false });
     app.useGlobalInterceptors(new TelemetryInterceptor(runtime));
-    await app.listen(0);
-    const address = decodeAddressInfo(app.getHttpServer().address());
-    assert.isTrue(Option.isSome(address));
-    const baseUrl = `http://127.0.0.1:${Option.getOrThrow(address).port}`;
+    await app.listen(0, "127.0.0.1");
+    const baseUrl = applicationBaseUrl(app.getHttpServer().address());
     const traceId = "0af7651916cd43dd8448eb211c80319c";
     const parentSpanId = "b7ad6b7169203331";
-
-    const sampled = await fetch(`${baseUrl}/traceparent/sampled`, {
-      headers: { traceparent: `00-${traceId}-${parentSpanId}-01` },
-    });
-    assert.strictEqual(sampled.status, 200);
-    assert.deepStrictEqual(await sampled.json(), { route: "sampled" });
-
-    const absent = await fetch(`${baseUrl}/traceparent/absent`);
-    assert.strictEqual(absent.status, 200);
-    assert.deepStrictEqual(await absent.json(), { route: "absent" });
-
     const malformedTraceparents = [
       `01-${traceId}-${parentSpanId}-01`,
       `00-${traceId}-${parentSpanId}`,
@@ -231,85 +538,166 @@ describe("nestjs TelemetryInterceptor", () => {
       `00-${"0".repeat(32)}-${parentSpanId}-01`,
       `00-${traceId}-${"0".repeat(16)}-01`,
     ];
-    for (const traceparent of malformedTraceparents) {
-      const malformed = await fetch(`${baseUrl}/traceparent/malformed`, {
-        headers: { traceparent },
+
+    try {
+      const sampled = await fetch(`${baseUrl}/traceparent/sampled`, {
+        headers: { traceparent: `00-${traceId}-${parentSpanId}-01` },
       });
-      assert.strictEqual(malformed.status, 200);
-      assert.deepStrictEqual(await malformed.json(), { route: "malformed" });
+      assert.strictEqual(sampled.status, 200);
+
+      const absent = await fetch(`${baseUrl}/traceparent/absent`);
+      assert.strictEqual(absent.status, 200);
+
+      for (const traceparent of malformedTraceparents) {
+        const malformed = await fetch(`${baseUrl}/traceparent/malformed`, {
+          headers: { traceparent },
+        });
+        assert.strictEqual(malformed.status, 200);
+      }
+
+      const unsampled = await fetch(`${baseUrl}/traceparent/unsampled`, {
+        headers: { traceparent: `00-${traceId}-${parentSpanId}-00` },
+      });
+      assert.strictEqual(unsampled.status, 200);
+    } finally {
+      await app.close();
+      await runtime.dispose();
     }
 
-    const unsampled = await fetch(`${baseUrl}/traceparent/unsampled`, {
-      headers: { traceparent: `00-${traceId}-${parentSpanId}-00` },
-    });
-    assert.strictEqual(unsampled.status, 200);
-    assert.deepStrictEqual(await unsampled.json(), { route: "unsampled" });
-
-    await app.close();
-    await runtime.dispose();
     const telemetry = await Effect.runPromise(capture.telemetry);
-
-    const sampledSpan = telemetry.spans.find(
-      (span) => span.name === "GET TraceparentController.sampled",
-    );
-    const sampledChild = telemetry.spans.find((span) => span.name === "sampled.child");
-    assert.isDefined(sampledSpan);
-    assert.isDefined(sampledChild);
+    const sampledSpan = findSpan(telemetry, "GET /traceparent/sampled");
+    const sampledChild = findSpan(telemetry, "sampled.child");
     assert.strictEqual(sampledSpan.traceId, traceId);
     assert.deepStrictEqual(sampledSpan.parentSpanId, Option.some(parentSpanId));
     assert.strictEqual(sampledChild.traceId, traceId);
     assert.deepStrictEqual(sampledChild.parentSpanId, Option.some(sampledSpan.spanId));
 
-    const absentSpan = telemetry.spans.find(
-      (span) => span.name === "GET TraceparentController.absent",
-    );
-    assert.isDefined(absentSpan);
+    const absentSpan = findSpan(telemetry, "GET /traceparent/absent");
     assert.isTrue(Option.isNone(absentSpan.parentSpanId));
 
     const malformedSpans = telemetry.spans.filter(
-      (span) => span.name === "GET TraceparentController.malformed",
+      (span) => span.name === "GET /traceparent/malformed",
     );
     assert.lengthOf(malformedSpans, malformedTraceparents.length);
     for (const malformedSpan of malformedSpans) {
       assert.isTrue(Option.isNone(malformedSpan.parentSpanId));
     }
 
-    assert.notInclude(
-      telemetry.spans.map((span) => span.name),
-      "GET TraceparentController.unsampled",
-    );
-    assert.notInclude(
-      telemetry.spans.map((span) => span.name),
-      "unsampled.child",
-    );
+    assert.isUndefined(telemetry.spans.find((span) => span.name === "GET /traceparent/unsampled"));
+    assert.isUndefined(telemetry.spans.find((span) => span.name === "unsampled.child"));
   }, 30_000);
 
-  it("ends the span as cancelled when the response observable unsubscribes", async () => {
-    const capture = await Effect.runPromise(Testing.makeCapture());
-    const runtime = ManagedRuntime.make(capture.layer);
-    const interceptor = new TelemetryInterceptor(runtime);
+  it("closes telemetry admission and interrupts every active request once", async () => {
+    const tracker = new TelemetryRequestTracker();
+    let interruptions = 0;
+    let releaseFirst = (): void => {};
+    let releaseSecond = (): void => {};
+    const first = tracker.register({
+      interrupt: () => {
+        interruptions++;
+        releaseFirst();
+      },
+    });
+    const second = tracker.register({
+      interrupt: () => {
+        interruptions++;
+        releaseSecond();
+      },
+    });
+    assert.isTrue(Option.isSome(first));
+    assert.isTrue(Option.isSome(second));
+    releaseFirst = Option.getOrThrow(first);
+    releaseSecond = Option.getOrThrow(second);
+    const idle = tracker.waitForIdle();
+    tracker.closeAdmission();
+    tracker.interruptActive();
+    await idle;
+    assert.strictEqual(interruptions, 2);
+    assert.isFalse(tracker.accepting);
+    assert.isTrue(Option.isNone(tracker.register({ interrupt: () => interruptions++ })));
+  });
 
-    class FakeController {
-      slow(this: void): void {}
+  it("bounds unknown methods and omits unsafe paths at the parsed boundary", () => {
+    const unknownMethod = inspectHttpServerRequest({
+      method: "brew",
+      route: { path: "/items/:id" },
+      originalUrl: "/items/private-value?token=query-secret",
+      socket: { remoteAddress: "127.0.0.1", remotePort: 42_000 },
+    });
+    assert.isTrue(Option.isSome(unknownMethod));
+    assert.strictEqual(Option.getOrThrow(unknownMethod).method, "_OTHER");
+    assert.deepStrictEqual(Option.getOrThrow(unknownMethod).methodOriginal, Option.some("BREW"));
+    assert.strictEqual(Option.getOrThrow(unknownMethod).spanName, "HTTP /items/:id");
+    assert.deepStrictEqual(
+      Option.getOrThrow(unknownMethod).urlPath,
+      Option.some("/items/REDACTED"),
+    );
+
+    const complexRoute = inspectHttpServerRequest({
+      method: "GET",
+      route: { path: "/items/:id(\\d+)" },
+      originalUrl: "/items/123",
+      socket: {},
+    });
+    assert.isTrue(Option.isSome(complexRoute));
+    assert.isTrue(Option.isNone(Option.getOrThrow(complexRoute).urlPath));
+
+    const absoluteTarget = inspectHttpServerRequest({
+      method: "GET",
+      route: { path: "/items/:id" },
+      originalUrl: "https://user:secret@example.test/items/123",
+      socket: {},
+    });
+    assert.isTrue(Option.isSome(absoluteTarget));
+    assert.isTrue(Option.isNone(Option.getOrThrow(absoluteTarget).urlPath));
+
+    const rootRoute = inspectHttpServerRequest({
+      method: "GET",
+      route: { path: "/" },
+      originalUrl: "/?token=query-secret",
+      socket: {},
+    });
+    assert.isTrue(Option.isSome(rootRoute));
+    assert.deepStrictEqual(Option.getOrThrow(rootRoute).urlPath, Option.some("/"));
+
+    const unsafeFrameworkHost = inspectHttpServerRequest(
+      {
+        method: "GET",
+        route: { path: "/proxy" },
+        originalUrl: "/proxy",
+        protocol: "https",
+        hostname: "user@spoofed.example",
+        ip: "198.51.100.7",
+        socket: {},
+      },
+      { proxyPolicy: "framework" },
+    );
+    assert.isTrue(Option.isSome(unsafeFrameworkHost));
+    assert.isTrue(Option.isNone(Option.getOrThrow(unsafeFrameworkHost).serverAddress));
+
+    const unavailableRoute = inspectHttpServerRequest({
+      method: "GET",
+      url: "/private",
+      socket: {},
+    });
+    assert.isTrue(Option.isSome(unavailableRoute));
+    assert.strictEqual(Option.getOrThrow(unavailableRoute).spanName, "GET");
+    assert.isTrue(Option.isNone(Option.getOrThrow(unavailableRoute).route));
+
+    for (const malformedTemplate of [
+      "health",
+      "https://example.test/health",
+      "/health?token=secret",
+      "/health#fragment",
+      "/health\\private",
+      "/health\nprivate",
+    ]) {
+      assert.throws(() =>
+        inspectHttpServerRequest(
+          { method: "GET", route: { path: "/safe" }, url: "/safe" },
+          { healthRouteTemplates: [malformedTemplate] },
+        ),
+      );
     }
-    const request = { method: "get" };
-    const response = { statusCode: 200 };
-    const context: ExecutionContext = new ExecutionContextHost(
-      [request, response],
-      FakeController,
-      FakeController.prototype.slow,
-    );
-    const next: CallHandler = {
-      handle: () => new Observable(() => {}),
-    };
-
-    const subscription = interceptor.intercept(context, next).subscribe();
-    subscription.unsubscribe();
-
-    await runtime.dispose();
-    const telemetry = await Effect.runPromise(capture.telemetry);
-    const span = telemetry.spans.find((candidate) => candidate.name === "GET FakeController.slow");
-    assert.isDefined(span);
-    expect(attributeOrUndefined(span.attributes, "http.request.cancelled")).toBe(true);
-  }, 30_000);
+  });
 });

--- a/packages/telemetry/test/nestjs.test.ts
+++ b/packages/telemetry/test/nestjs.test.ts
@@ -617,6 +617,19 @@ describe("nestjs TelemetryInterceptor", () => {
     assert.isTrue(Option.isNone(tracker.register({ interrupt: () => interruptions++ })));
   });
 
+  it("preserves lowercase known methods when normalization changes the emitted method", () => {
+    const lowercaseMethod = inspectHttpServerRequest({
+      method: "get",
+      route: { path: "/items" },
+      originalUrl: "/items",
+      socket: {},
+    });
+    assert.isTrue(Option.isSome(lowercaseMethod));
+    assert.strictEqual(Option.getOrThrow(lowercaseMethod).method, "GET");
+    assert.deepStrictEqual(Option.getOrThrow(lowercaseMethod).methodOriginal, Option.some("get"));
+    assert.strictEqual(Option.getOrThrow(lowercaseMethod).spanName, "GET /items");
+  });
+
   it("bounds unknown methods and omits unsafe paths at the parsed boundary", () => {
     const unknownMethod = inspectHttpServerRequest({
       method: "brew",
@@ -626,7 +639,7 @@ describe("nestjs TelemetryInterceptor", () => {
     });
     assert.isTrue(Option.isSome(unknownMethod));
     assert.strictEqual(Option.getOrThrow(unknownMethod).method, "_OTHER");
-    assert.deepStrictEqual(Option.getOrThrow(unknownMethod).methodOriginal, Option.some("BREW"));
+    assert.deepStrictEqual(Option.getOrThrow(unknownMethod).methodOriginal, Option.some("brew"));
     assert.strictEqual(Option.getOrThrow(unknownMethod).spanName, "HTTP /items/:id");
     assert.deepStrictEqual(
       Option.getOrThrow(unknownMethod).urlPath,


### PR DESCRIPTION
## Summary

- apply OpenTelemetry HTTP server semantic conventions v1.44.0 to NestJS spans
- use route templates, bounded methods, scrubbed paths, explicit proxy policy, exclusions, and final response status
- add a standards-aware OTLP tracer, active-request tracking, shared flushing, and real Nest/Express verification

## Verification

- `bunx vp test run packages/telemetry/test/nestjs.test.ts`
- `bun check`
- `bun run build`
- `bun run test`
- `bun run test:package`
- isolated Collector pipeline canary
- independent review panel at exact feature SHA

Linear: OBS-20
