### PR TITLE
fix(telemetry): redact browser events before transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ O pacote `@equipe-tech/observability` publica um subpath por runtime:
 | `./browser` | `BrowserTelemetry` (fila limitada, batch e flush de wide events para `/_telemetry/events`) com transporte `fetch` injetável  |
 | `./testing` | Captura em memória dos exports OTLP reais (`run`, `makeCapture`) para asserts de spans, logs e métricas em testes            |
 
-O contrato do endpoint `/_telemetry/events` vive em `BrowserEvents` no entrypoint raiz. O servidor faz o parse com `parseBrowserEventBatch` e re-emite os eventos como wide events com atributos de servidor (`event.source`, `browser.event.id`).
+O contrato do endpoint `/_telemetry/events` vive em `BrowserEvents` no entrypoint raiz. O servidor faz o parse com `parseBrowserEventBatch` e re-emite os eventos como wide events com atributos de servidor (`event.source`, `browser.event.id`). O cliente sanitiza nomes e campos antes da fila conforme a [política de dados da telemetria do browser](docs/browser-telemetry-data-policy.md).
 
 O adapter `./nestjs` publica o endpoint pronto: registre `createBrowserEventsController(runtime)` nos controllers do módulo. O controller responde `202 { accepted }` e rejeita batches inválidos com `400 { code, message, correlationId }`. O valor `correlationId` é um identificador seguro para suporte. O limite de corpo bruto pertence ao transporte HTTP; o Express responde `413` acima do limite configurado.
 

--- a/docs/browser-telemetry-data-policy.md
+++ b/docs/browser-telemetry-data-policy.md
@@ -1,0 +1,53 @@
+# Browser telemetry data policy
+
+`BrowserTelemetry.emit` accepts event names and scalar fields. Field values remain limited to strings, finite numbers, and booleans. The wire batch remains version 1 and uses the same scalar contract.
+
+## Sink boundary
+
+Sanitization runs before a `BrowserEvent` is constructed and before the event enters the in-memory queue. Recording transports, retry batches, periodic flushes, finalizers, and fetch transports therefore receive only the sanitized representation.
+
+`BrowserTelemetry` has no console sink. This policy does not cover application-owned console calls and does not add console interception.
+
+## Unsupported runtime values
+
+JavaScript callers can bypass TypeScript declarations. Objects, arrays, null, undefined, functions, symbols, big integers, non-finite numbers, deep values, wide values, and cycles are dropped as complete fields. They are not traversed, stringified, logged, or retained. Valid scalar siblings remain available.
+
+## Sensitive fields
+
+Sensitive key terms include authorization, proxy authorization, cookies, passwords, secrets, tokens, API keys, access keys, client secrets, private keys, email, phone, CPF, CNPJ, and document identifiers. Matching is case-insensitive, recognizes dot, underscore, hyphen, camel-case, digit, and end-of-key boundaries, and can start within a longer key. Negative words such as `tokenizer`, `documentation`, and `secretive` do not match.
+
+The original complete key is inspected before bounding. A scalar value under a sensitive key becomes `****`. A key containing credential text or a structured sensitive assignment is removed.
+
+## Sensitive text
+
+The following content becomes `[REDACTED]` within safe string values and event names:
+
+- Bearer authorization values
+- `sk_`, `sk-`, `rk_`, and `rk-` credentials
+- JSON Web Tokens
+- Email addresses
+- RSA, EC, OpenSSH, and generic private-key blocks
+- Sensitive `key=value` and `key:value` assignments, including quoted values
+
+Valid serialized JSON beginning with an object or array is parsed and sanitized iteratively. Values under sensitive property keys become `[REDACTED]`, credential-bearing keys disappear, credential patterns are replaced in string leaves, array order is retained, and compact valid JSON is emitted. Traversal is limited to 32 levels and 1,024 values. Inputs beyond either limit become `[REDACTED]`.
+
+Malformed JSON-like text containing a sensitive term becomes `[REDACTED]`. Browser structured-text handling is intentionally stricter than the Collector policy because the browser can parse a bounded JSON string before queue insertion.
+
+## Bounds and collisions
+
+Sanitization inspects complete original input before applying output bounds.
+
+| Data               | Original inspection bound |            Output bound |
+| ------------------ | ------------------------: | ----------------------: |
+| Field key          |   2,048 UTF-16 code units |   128 UTF-16 code units |
+| String field value |  16,384 UTF-16 code units | 1,024 UTF-16 code units |
+| Event name         |  16,384 UTF-16 code units |   128 UTF-16 code units |
+| Fields per event   |            Not applicable |  32 unique bounded keys |
+| Events per batch   |            Not applicable |                      64 |
+| Event identifier   |            Not applicable |    64 UTF-16 code units |
+
+Oversized original keys are dropped. Oversized original string values and event names become `[REDACTED]`. If different original keys produce the same bounded key, the first accepted field in JavaScript iteration order wins. Later fields do not replace or merge with it.
+
+## Collector parity
+
+The telemetry package owns the semantic key vocabulary and the five core credential patterns. A repository parity test checks both Collector assets against that vocabulary, processor coverage, and processor order. Browser JSON traversal is intentionally outside exact Collector parity because Collector OTTL does not expose the same recursive contract.

--- a/packages/telemetry/src/RedactionPolicy.ts
+++ b/packages/telemetry/src/RedactionPolicy.ts
@@ -1,0 +1,296 @@
+import { Option, Predicate, Schema } from "effect";
+import {
+  maxEventNameLength,
+  maxFieldKeyLength,
+  maxFieldsPerEvent,
+  maxFieldValueLength,
+  type BrowserEventFields,
+} from "./BrowserEvents.ts";
+import type { WideEventFields } from "./WideEvent.ts";
+
+export const sensitiveFieldReplacement = "****";
+export const sensitiveTextReplacement = "[REDACTED]";
+
+const sensitiveTermSources = [
+  "authorization",
+  "proxy[._-]?authorization",
+  "cookie",
+  "set[._-]?cookie",
+  "password",
+  "passwd",
+  "secret",
+  "token",
+  "api[._-]?key",
+  "apikey",
+  "access[._-]?key",
+  "client[._-]?secret",
+  "private[._-]?key",
+  "email",
+  "phone",
+  "cpf",
+  "cnpj",
+  "document",
+];
+
+export const collectorBlockedKeyPattern = `(?i:${sensitiveTermSources.join("|")})(?:[._-]|[A-Z0-9]|$)`;
+
+export const collectorBlockedValuePatterns = [
+  "(?i)Bearer[[:space:]]+[A-Za-z0-9._~+/=-]+",
+  "(?:sk|rk)[_-][A-Za-z0-9_*.-]{3,}",
+  "eyJ[A-Za-z0-9_-]+[.]eyJ[A-Za-z0-9_-]+[.][A-Za-z0-9_-]+",
+  "(?i)[A-Z0-9._%+-]+@[A-Z0-9.-]+[.][A-Z]{2,}",
+  "(?s)-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----.*?-----END (?:RSA |EC |OPENSSH )?PRIVATE KEY-----",
+];
+
+const maxOriginalFieldKeyLength = 2_048;
+const maxOriginalStringLength = 16_384;
+const maxJsonDepth = 32;
+const maxJsonValues = 1_024;
+
+const SensitiveScalar = Schema.Union([
+  Schema.String,
+  Schema.Number.check(Schema.isFinite()),
+  Schema.Boolean,
+]);
+const decodeSensitiveScalar = Schema.decodeUnknownOption(SensitiveScalar);
+const decodeJsonText = Schema.decodeOption(Schema.fromJsonString(Schema.Json));
+const decodeJsonObject = Schema.decodeUnknownOption(Schema.JsonObject);
+
+type SensitiveScalar = typeof SensitiveScalar.Type;
+type JsonValue = typeof Schema.Json.Type;
+type SanitizedJson = null | string | number | boolean | Array<SanitizedJson> | SanitizedJsonObject;
+interface SanitizedJsonObject {
+  [key: string]: SanitizedJson;
+}
+interface JsonTraversal {
+  readonly source: JsonValue;
+  readonly depth: number;
+  readonly sensitive: boolean;
+  readonly assign: (value: SanitizedJson) => void;
+}
+
+const asciiCaseInsensitive = (source: string): string =>
+  source.replace(/[A-Za-z]/g, (letter) => `[${letter.toLowerCase()}${letter.toUpperCase()}]`);
+
+const sensitiveTerms = sensitiveTermSources.map(asciiCaseInsensitive).join("|");
+const sensitiveKeyPattern = new RegExp(`(?:${sensitiveTerms})(?=[._-]|[A-Z0-9]|$)`);
+const sensitiveTextTermPattern = new RegExp(
+  `(?:${sensitiveTerms})(?=[._-]|[A-Z0-9]|[^A-Za-z0-9._-]|$)`,
+);
+
+const coreValuePatterns = [
+  /Bearer\s+[A-Za-z0-9._~+/=-]+/gi,
+  /(?:sk|rk)[_-][A-Za-z0-9_*.-]{3,}/g,
+  /eyJ[A-Za-z0-9_-]+[.]eyJ[A-Za-z0-9_-]+[.][A-Za-z0-9_-]+/g,
+  /[A-Z0-9._%+-]+@[A-Z0-9.-]+[.][A-Z]{2,}/gi,
+  /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/g,
+];
+
+const structuredAssignmentPattern =
+  /([A-Za-z0-9_.-]+)(\s*[=:]\s*)(?:"((?:\\.|[^"\\])*)"|'((?:\\.|[^'\\])*)'|([^,;\s]+))/g;
+
+export const isSensitiveFieldKey = (key: string): boolean => sensitiveKeyPattern.test(key);
+
+const replaceCoreValues = (value: string): string => {
+  let sanitized = value;
+  for (const pattern of coreValuePatterns) {
+    pattern.lastIndex = 0;
+    sanitized = sanitized.replace(pattern, sensitiveTextReplacement);
+  }
+  return sanitized;
+};
+
+const containsCoreValue = (value: string): boolean => {
+  for (const pattern of coreValuePatterns) {
+    pattern.lastIndex = 0;
+    if (pattern.test(value)) {
+      pattern.lastIndex = 0;
+      return true;
+    }
+  }
+  return false;
+};
+
+const replaceStructuredAssignments = (value: string): string => {
+  structuredAssignmentPattern.lastIndex = 0;
+  let sanitized = "";
+  let offset = 0;
+  for (const match of value.matchAll(structuredAssignmentPattern)) {
+    const index = match.index;
+    const full = match[0];
+    const key = match[1];
+    const separator = match[2];
+    if (!Predicate.isNumber(index) || !Predicate.isString(full) || !Predicate.isString(key)) {
+      continue;
+    }
+    sanitized += value.slice(offset, index);
+    if (!isSensitiveFieldKey(key) || !Predicate.isString(separator)) {
+      sanitized += full;
+      offset = index + full.length;
+      continue;
+    }
+    if (Predicate.isString(match[3])) {
+      sanitized += `${key}${separator}"${sensitiveTextReplacement}"`;
+    } else if (Predicate.isString(match[4])) {
+      sanitized += `${key}${separator}'${sensitiveTextReplacement}'`;
+    } else {
+      sanitized += `${key}${separator}${sensitiveTextReplacement}`;
+    }
+    offset = index + full.length;
+  }
+  return sanitized + value.slice(offset);
+};
+
+const containsStructuredAssignment = (value: string): boolean =>
+  replaceStructuredAssignments(value) !== value;
+
+const sanitizeJson = (source: JsonValue): Option.Option<string> => {
+  const root: { value: SanitizedJson } = { value: null };
+  const stack: Array<JsonTraversal> = [
+    {
+      source,
+      depth: 0,
+      sensitive: false,
+      assign: (value) => {
+        root.value = value;
+      },
+    },
+  ];
+  let visited = 0;
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!Predicate.isNotUndefined(current)) {
+      continue;
+    }
+    visited += 1;
+    if (visited > maxJsonValues || current.depth > maxJsonDepth) {
+      return Option.none();
+    }
+    if (current.sensitive) {
+      current.assign(sensitiveTextReplacement);
+      continue;
+    }
+    if (
+      current.source === null ||
+      Predicate.isNumber(current.source) ||
+      Predicate.isBoolean(current.source)
+    ) {
+      current.assign(current.source);
+      continue;
+    }
+    if (Predicate.isString(current.source)) {
+      current.assign(replaceCoreValues(current.source));
+      continue;
+    }
+    if (Array.isArray(current.source)) {
+      const output: Array<SanitizedJson> = current.source.map(() => null);
+      current.assign(output);
+      for (let index = current.source.length - 1; index >= 0; index -= 1) {
+        const child = current.source[index];
+        if (!Predicate.isNotUndefined(child)) {
+          continue;
+        }
+        stack.push({
+          source: child,
+          depth: current.depth + 1,
+          sensitive: false,
+          assign: (value) => {
+            output[index] = value;
+          },
+        });
+      }
+      continue;
+    }
+    const sourceObject = decodeJsonObject(current.source);
+    if (Option.isNone(sourceObject)) {
+      return Option.none();
+    }
+    const output: SanitizedJsonObject = {};
+    current.assign(output);
+    const keys = Object.keys(sourceObject.value);
+    for (const key of keys) {
+      if (
+        key.length > maxOriginalFieldKeyLength ||
+        containsCoreValue(key) ||
+        containsStructuredAssignment(key)
+      ) {
+        continue;
+      }
+      output[key] = null;
+    }
+    for (let index = keys.length - 1; index >= 0; index -= 1) {
+      const key = keys[index];
+      if (!Predicate.isString(key) || !(key in output)) {
+        continue;
+      }
+      const child = sourceObject.value[key];
+      if (!Predicate.isNotUndefined(child)) {
+        continue;
+      }
+      stack.push({
+        source: child,
+        depth: current.depth + 1,
+        sensitive: isSensitiveFieldKey(key),
+        assign: (value) => {
+          output[key] = value;
+        },
+      });
+    }
+  }
+  return Option.some(JSON.stringify(root.value));
+};
+
+const sanitizeString = (value: string, outputLimit: number): string => {
+  if (value.length > maxOriginalStringLength) {
+    return sensitiveTextReplacement;
+  }
+  const trimmed = value.trimStart();
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    const parsed = decodeJsonText(value);
+    if (Option.isSome(parsed)) {
+      const sanitizedJson = Option.getOrElse(
+        sanitizeJson(parsed.value),
+        () => sensitiveTextReplacement,
+      );
+      return sanitizedJson.length <= outputLimit ? sanitizedJson : sensitiveTextReplacement;
+    }
+    if (sensitiveTextTermPattern.test(value)) {
+      return sensitiveTextReplacement;
+    }
+  }
+  return replaceCoreValues(replaceStructuredAssignments(value));
+};
+
+const shouldDropKey = (key: string): boolean =>
+  key.length > maxOriginalFieldKeyLength ||
+  containsCoreValue(key) ||
+  containsStructuredAssignment(key);
+
+export const sanitizeBrowserFields = (fields: WideEventFields): BrowserEventFields => {
+  const sanitized: { [attribute: string]: SensitiveScalar } = {};
+  let count = 0;
+  for (const [key, runtimeValue] of Object.entries(fields)) {
+    const decoded = decodeSensitiveScalar(runtimeValue);
+    if (Option.isNone(decoded) || key === "" || shouldDropKey(key)) {
+      continue;
+    }
+    const boundedKey = key.slice(0, maxFieldKeyLength);
+    if (boundedKey in sanitized) {
+      continue;
+    }
+    const value = isSensitiveFieldKey(key)
+      ? sensitiveFieldReplacement
+      : Predicate.isString(decoded.value)
+        ? sanitizeString(decoded.value, maxFieldValueLength).slice(0, maxFieldValueLength)
+        : decoded.value;
+    sanitized[boundedKey] = value;
+    count += 1;
+    if (count >= maxFieldsPerEvent) {
+      break;
+    }
+  }
+  return sanitized;
+};
+
+export const sanitizeBrowserEventName = (name: string): string =>
+  sanitizeString(name, maxEventNameLength).slice(0, maxEventNameLength);

--- a/packages/telemetry/src/RedactionPolicy.ts
+++ b/packages/telemetry/src/RedactionPolicy.ts
@@ -57,6 +57,7 @@ const decodeJsonText = Schema.decodeOption(Schema.fromJsonString(Schema.Json));
 const decodeJsonObject = Schema.decodeUnknownOption(Schema.JsonObject);
 
 type SensitiveScalar = typeof SensitiveScalar.Type;
+type SanitizedFieldEntry = readonly [string, SensitiveScalar];
 type JsonValue = typeof Schema.Json.Type;
 type SanitizedJson = null | string | number | boolean | Array<SanitizedJson> | SanitizedJsonObject;
 interface SanitizedJsonObject {
@@ -205,7 +206,8 @@ const sanitizeJson = (source: JsonValue): Option.Option<string> => {
     if (Option.isNone(sourceObject)) {
       return Option.none();
     }
-    const output: SanitizedJsonObject = {};
+    const output: SanitizedJsonObject = Object.create(null);
+    const outputKeys = new Set<string>();
     current.assign(output);
     const keys = Object.keys(sourceObject.value);
     for (const key of keys) {
@@ -217,10 +219,11 @@ const sanitizeJson = (source: JsonValue): Option.Option<string> => {
         continue;
       }
       output[key] = null;
+      outputKeys.add(key);
     }
     for (let index = keys.length - 1; index >= 0; index -= 1) {
       const key = keys[index];
-      if (!Predicate.isString(key) || !(key in output)) {
+      if (!Predicate.isString(key) || !outputKeys.has(key)) {
         continue;
       }
       const child = sourceObject.value[key];
@@ -267,15 +270,15 @@ const shouldDropKey = (key: string): boolean =>
   containsStructuredAssignment(key);
 
 export const sanitizeBrowserFields = (fields: WideEventFields): BrowserEventFields => {
-  const sanitized: { [attribute: string]: SensitiveScalar } = {};
-  let count = 0;
+  const sanitized: Array<SanitizedFieldEntry> = [];
+  const boundedKeys = new Set<string>();
   for (const [key, runtimeValue] of Object.entries(fields)) {
     const decoded = decodeSensitiveScalar(runtimeValue);
     if (Option.isNone(decoded) || key === "" || shouldDropKey(key)) {
       continue;
     }
     const boundedKey = key.slice(0, maxFieldKeyLength);
-    if (boundedKey in sanitized) {
+    if (boundedKeys.has(boundedKey)) {
       continue;
     }
     const value = isSensitiveFieldKey(key)
@@ -283,13 +286,13 @@ export const sanitizeBrowserFields = (fields: WideEventFields): BrowserEventFiel
       : Predicate.isString(decoded.value)
         ? sanitizeString(decoded.value, maxFieldValueLength).slice(0, maxFieldValueLength)
         : decoded.value;
-    sanitized[boundedKey] = value;
-    count += 1;
-    if (count >= maxFieldsPerEvent) {
+    sanitized.push([boundedKey, value]);
+    boundedKeys.add(boundedKey);
+    if (boundedKeys.size >= maxFieldsPerEvent) {
       break;
     }
   }
-  return sanitized;
+  return Object.fromEntries(sanitized);
 };
 
 export const sanitizeBrowserEventName = (name: string): string =>

--- a/packages/telemetry/src/browser/index.ts
+++ b/packages/telemetry/src/browser/index.ts
@@ -1,15 +1,11 @@
-import { Clock, Context, Duration, Effect, Layer, Predicate, Ref, Schema } from "effect";
+import { Clock, Context, Duration, Effect, Layer, Ref, Schema } from "effect";
 import {
   BrowserEvent,
   BrowserEventBatch,
   encodeBrowserEventBatch,
-  maxEventNameLength,
   maxEventsPerBatch,
-  maxFieldKeyLength,
-  maxFieldsPerEvent,
-  maxFieldValueLength,
-  type BrowserEventFields,
 } from "../BrowserEvents.ts";
+import { sanitizeBrowserEventName, sanitizeBrowserFields } from "../RedactionPolicy.ts";
 import type { WideEventFields } from "../WideEvent.ts";
 
 export {
@@ -93,20 +89,6 @@ type EventQueue = {
   readonly dropped: number;
 };
 
-const clampFields = (fields: WideEventFields): BrowserEventFields => {
-  const clamped: { [attribute: string]: string | number | boolean } = {};
-  let count = 0;
-  for (const [key, value] of Object.entries(fields)) {
-    if (key === "" || count >= maxFieldsPerEvent) {
-      continue;
-    }
-    const boundedKey = key.slice(0, maxFieldKeyLength);
-    clamped[boundedKey] = Predicate.isString(value) ? value.slice(0, maxFieldValueLength) : value;
-    count += 1;
-  }
-  return clamped;
-};
-
 const makeBrowserTelemetry = Effect.fn("makeBrowserTelemetry")(function* (
   options?: BrowserTelemetryOptions,
 ) {
@@ -121,9 +103,9 @@ const makeBrowserTelemetry = Effect.fn("makeBrowserTelemetry")(function* (
       const occurredAt = yield* Clock.currentTimeMillis;
       const event = new BrowserEvent({
         id: crypto.randomUUID(),
-        name: name.slice(0, maxEventNameLength),
+        name: sanitizeBrowserEventName(name),
         occurredAt,
-        fields: clampFields(fields ?? {}),
+        fields: sanitizeBrowserFields(fields ?? {}),
       });
       yield* Ref.update(queue, (state) =>
         state.events.length >= maxQueueSize

--- a/packages/telemetry/test/browser.test.ts
+++ b/packages/telemetry/test/browser.test.ts
@@ -269,11 +269,15 @@ describe("BrowserEventTransport.layerFetch", () => {
       const secret = crypto.randomUUID().replaceAll("-", "");
       const bodies: Array<string> = [];
       const endpoint = yield* Effect.promise(() => startEndpoint(200, bodies));
-      const fields: WideEventFields = {
-        authorization: secret,
-        note: `before Bearer ${secret} after`,
-        control: "tokenizer",
-      };
+      const fields: WideEventFields = Object.fromEntries([
+        ["authorization", secret],
+        ["note", `before Bearer ${secret} after`],
+        ["control", "tokenizer"],
+        ["toString", "safe-to-string"],
+        ["constructor", "safe-constructor"],
+        ["hasOwnProperty", "safe-has-own-property"],
+        ["__proto__", "safe-proto"],
+      ]);
       Object.defineProperty(fields, "nested", { value: { token: secret }, enumerable: true });
       yield* Effect.gen(function* () {
         const telemetry = yield* BrowserTelemetry;
@@ -295,9 +299,18 @@ describe("BrowserEventTransport.layerFetch", () => {
       assert.include(body, sensitiveTextReplacement);
       assert.include(body, "tokenizer");
       assert.notInclude(body, "nested");
+      assert.include(body, '"toString":"safe-to-string"');
+      assert.include(body, '"constructor":"safe-constructor"');
+      assert.include(body, '"hasOwnProperty":"safe-has-own-property"');
+      assert.include(body, '"__proto__":"safe-proto"');
       const batch = decodeBrowserEventBatch(JSON.parse(body));
       assert.strictEqual(batch.version, 1);
       assert.strictEqual(batch.events.length, 1);
+      const event = batch.events[0];
+      assert.isDefined(event);
+      for (const key of ["toString", "constructor", "hasOwnProperty", "__proto__"]) {
+        assert.isTrue(Object.prototype.hasOwnProperty.call(event.fields, key));
+      }
     }),
   );
 

--- a/packages/telemetry/test/browser.test.ts
+++ b/packages/telemetry/test/browser.test.ts
@@ -8,9 +8,12 @@ import {
   BrowserTelemetry,
   maxFieldValueLength,
 } from "../src/browser/index.ts";
+import { sensitiveFieldReplacement, sensitiveTextReplacement } from "../src/RedactionPolicy.ts";
+import type { WideEventFields } from "../src/WideEvent.ts";
 
 const AddressInfo = Schema.Struct({ port: Schema.Number });
 const decodeAddressInfo = Schema.decodeUnknownOption(AddressInfo);
+const decodeBrowserEventBatch = Schema.decodeUnknownSync(BrowserEventBatch);
 
 type RecordedBatches = Array<BrowserEventBatch>;
 
@@ -125,6 +128,56 @@ describe("BrowserTelemetry", () => {
     }),
   );
 
+  it.live("redacts before queueing and preserves the sanitized batch across retry", () =>
+    Effect.gen(function* () {
+      const secret = crypto.randomUUID().replaceAll("-", "");
+      const attempts: RecordedBatches = [];
+      let sends = 0;
+      const flakyTransport = Layer.succeed(
+        BrowserEventTransport,
+        BrowserEventTransport.of({
+          send: (batch) =>
+            Effect.suspend(() => {
+              attempts.push(batch);
+              sends += 1;
+              if (sends === 1) {
+                return Effect.fail(
+                  new BrowserEventDeliveryError({
+                    code: "OBS_BROWSER_EVENTS_DELIVERY_FAILED",
+                    message: "The network failed and the sanitized batch remains queued.",
+                    retryable: true,
+                    cause: "network",
+                  }),
+                );
+              }
+              return Effect.void;
+            }),
+        }),
+      );
+      const fields: WideEventFields = {
+        authorization: secret,
+        note: `Bearer ${secret}`,
+        control: "tokenizer",
+      };
+      Object.defineProperty(fields, "nested", { value: { secret }, enumerable: true });
+      yield* Effect.gen(function* () {
+        const telemetry = yield* BrowserTelemetry;
+        yield* telemetry.emit(`checkout token=${secret}`, fields);
+        yield* telemetry.flush().pipe(Effect.flip);
+        assert.strictEqual(yield* telemetry.pending(), 1);
+        yield* telemetry.flush();
+      }).pipe(Effect.provide(BrowserTelemetry.layer().pipe(Layer.provide(flakyTransport))));
+      assert.strictEqual(attempts.length, 2);
+      assert.deepStrictEqual(attempts[0], attempts[1]);
+      const serialized = JSON.stringify(attempts);
+      assert.notInclude(serialized, secret);
+      assert.include(serialized, sensitiveFieldReplacement);
+      assert.include(serialized, sensitiveTextReplacement);
+      assert.notInclude(serialized, "nested");
+      assert.include(serialized, "tokenizer");
+    }),
+  );
+
   it.live("flushes pending events when the scope closes", () =>
     Effect.gen(function* () {
       const sent: RecordedBatches = [];
@@ -208,6 +261,43 @@ describe("BrowserEventTransport.layerFetch", () => {
       assert.isDefined(body);
       assert.include(body, "fetch.delivered");
       assert.include(body, '"version":1');
+    }),
+  );
+
+  it.live("sends only sanitized event data to a real loopback endpoint", () =>
+    Effect.gen(function* () {
+      const secret = crypto.randomUUID().replaceAll("-", "");
+      const bodies: Array<string> = [];
+      const endpoint = yield* Effect.promise(() => startEndpoint(200, bodies));
+      const fields: WideEventFields = {
+        authorization: secret,
+        note: `before Bearer ${secret} after`,
+        control: "tokenizer",
+      };
+      Object.defineProperty(fields, "nested", { value: { token: secret }, enumerable: true });
+      yield* Effect.gen(function* () {
+        const telemetry = yield* BrowserTelemetry;
+        yield* telemetry.emit(`checkout authorization=${secret}`, fields);
+        yield* telemetry.flush();
+      }).pipe(
+        Effect.provide(
+          BrowserTelemetry.layer().pipe(
+            Layer.provide(BrowserEventTransport.layerFetch({ endpoint: endpoint.url })),
+          ),
+        ),
+        Effect.ensuring(Effect.sync(() => endpoint.server.close())),
+      );
+      assert.strictEqual(bodies.length, 1);
+      const body = bodies[0];
+      assert.isDefined(body);
+      assert.notInclude(body, secret);
+      assert.include(body, sensitiveFieldReplacement);
+      assert.include(body, sensitiveTextReplacement);
+      assert.include(body, "tokenizer");
+      assert.notInclude(body, "nested");
+      const batch = decodeBrowserEventBatch(JSON.parse(body));
+      assert.strictEqual(batch.version, 1);
+      assert.strictEqual(batch.events.length, 1);
     }),
   );
 

--- a/packages/telemetry/test/redactionParity.test.ts
+++ b/packages/telemetry/test/redactionParity.test.ts
@@ -1,0 +1,55 @@
+import { assert, describe, it } from "vite-plus/test";
+import { readFileSync } from "node:fs";
+import {
+  collectorBlockedKeyPattern,
+  collectorBlockedValuePatterns,
+} from "../src/RedactionPolicy.ts";
+
+const assetPaths = [
+  "packages/cli/src/assets/local.yaml",
+  "packages/cli/src/assets/production.yaml",
+];
+
+const occurrences = (source: string, value: string): number => source.split(value).length - 1;
+
+describe("browser and Collector redaction parity", () => {
+  for (const assetPath of assetPaths) {
+    it(`keeps the canonical key and value vocabulary in ${assetPath}`, () => {
+      const asset = readFileSync(assetPath, "utf8");
+      assert.strictEqual(occurrences(asset, `- "${collectorBlockedKeyPattern}"`), 1);
+      let previousIndex = -1;
+      for (const pattern of collectorBlockedValuePatterns) {
+        const blockedValue = `- "${pattern}"`;
+        const index = asset.indexOf(blockedValue);
+        assert.isAbove(index, previousIndex);
+        previousIndex = index;
+        assert.strictEqual(occurrences(asset, pattern), 3);
+      }
+      const transform = asset.slice(
+        asset.indexOf("  transform/redact:"),
+        asset.indexOf("  redaction/sensitive:"),
+      );
+      const trace = transform.slice(
+        transform.indexOf("trace_statements:"),
+        transform.indexOf("log_statements:"),
+      );
+      const logs = transform.slice(transform.indexOf("log_statements:"));
+      const vocabulary = collectorBlockedKeyPattern.replace("(?:[._-]|[A-Z0-9]|$)", "");
+      assert.include(trace, vocabulary);
+      assert.include(logs, vocabulary);
+      for (const pattern of collectorBlockedValuePatterns) {
+        assert.include(trace, pattern);
+        assert.include(logs, pattern);
+      }
+      assert.match(
+        asset,
+        /traces:[\s\S]*?processors:[\s\S]*?transform\/redact, redaction\/sensitive[\s\S]*?logs:/,
+      );
+      assert.match(
+        asset,
+        /logs:[\s\S]*?processors:[\s\S]*?transform\/redact, redaction\/sensitive[\s\S]*?metrics:/,
+      );
+      assert.match(asset, /metrics:[\s\S]*?processors:.*redaction\/sensitive/);
+    });
+  }
+});

--- a/packages/telemetry/test/redactionPolicy.test.ts
+++ b/packages/telemetry/test/redactionPolicy.test.ts
@@ -1,0 +1,228 @@
+import { assert, describe, it } from "vite-plus/test";
+import { Schema } from "effect";
+import {
+  isSensitiveFieldKey,
+  sanitizeBrowserEventName,
+  sanitizeBrowserFields,
+  sensitiveFieldReplacement,
+  sensitiveTextReplacement,
+} from "../src/RedactionPolicy.ts";
+import type { WideEventFields } from "../src/WideEvent.ts";
+
+const SanitizedJson = Schema.fromJsonString(
+  Schema.Struct({
+    profile: Schema.Struct({
+      email: Schema.String,
+      display: Schema.String,
+      escaped: Schema.String,
+    }),
+    events: Schema.Array(Schema.Struct({ token: Schema.String, note: Schema.String })),
+  }),
+);
+const decodeSanitizedJson = Schema.decodeUnknownSync(SanitizedJson);
+
+const marker = (): string => crypto.randomUUID().replaceAll("-", "");
+
+interface RuntimeNode {
+  self?: RuntimeNode;
+  child?: RuntimeNode;
+}
+
+const runtimeFields = (): WideEventFields => {
+  const fields: WideEventFields = { valid: "kept" };
+  const cyclic: RuntimeNode = {};
+  cyclic.self = cyclic;
+  let deep: RuntimeNode = {};
+  for (let index = 0; index < 100; index += 1) {
+    deep = { child: deep };
+  }
+  const wide = Object.fromEntries(
+    Array.from({ length: 2_000 }, (_, index) => [`key${index}`, index]),
+  );
+  const invalid = {
+    object: { nested: true },
+    array: ["value"],
+    null: null,
+    undefined,
+    nan: Number.NaN,
+    positiveInfinity: Number.POSITIVE_INFINITY,
+    negativeInfinity: Number.NEGATIVE_INFINITY,
+    bigint: BigInt(1),
+    symbol: Symbol("value"),
+    function: () => "value",
+    deep,
+    wide,
+    cyclic,
+  };
+  for (const [key, value] of Object.entries(invalid)) {
+    Object.defineProperty(fields, key, { value, enumerable: true });
+  }
+  return fields;
+};
+
+describe("browser telemetry redaction policy", () => {
+  it("classifies the complete sensitive vocabulary and keeps negative controls", () => {
+    const terms = [
+      ["authorization"],
+      ["proxy", "authorization"],
+      ["cookie"],
+      ["set", "cookie"],
+      ["password"],
+      ["passwd"],
+      ["secret"],
+      ["token"],
+      ["api", "key"],
+      ["apikey"],
+      ["access", "key"],
+      ["client", "secret"],
+      ["private", "key"],
+      ["email"],
+      ["phone"],
+      ["cpf"],
+      ["cnpj"],
+      ["document"],
+    ];
+    for (const segments of terms) {
+      const compact = segments.join("");
+      const camel = segments
+        .map((segment, index) =>
+          index === 0 ? segment : `${segment[0]?.toUpperCase()}${segment.slice(1)}`,
+        )
+        .join("");
+      for (const key of [
+        compact,
+        compact.toUpperCase(),
+        segments.join("."),
+        segments.join("_"),
+        segments.join("-"),
+        camel,
+        `prefix.${compact}`,
+        `${compact}2`,
+      ]) {
+        assert.isTrue(isSensitiveFieldKey(key));
+      }
+    }
+    for (const key of ["tokenizer", "documentation", "secretive", "phoneme", "documentary"]) {
+      assert.isFalse(isSensitiveFieldKey(key));
+    }
+  });
+
+  it("masks sensitive scalar fields and embedded credential patterns", () => {
+    const secret = marker();
+    const fields = sanitizeBrowserFields({
+      authorization: secret,
+      phone2: 5511999999999,
+      "private-key": true,
+      bearer: `before Bearer ${secret} after`,
+      service: `sk_${secret}`,
+      jwt: `eyJ${secret}.eyJ${secret}.${secret}`,
+      contact: `${secret}@example.com`,
+      pem: `-----BEGIN PRIVATE KEY-----${secret}-----END PRIVATE KEY-----`,
+      control: "tokenizer documentation secretive phoneme documentary",
+    });
+    assert.strictEqual(fields.authorization, sensitiveFieldReplacement);
+    assert.strictEqual(fields.phone2, sensitiveFieldReplacement);
+    assert.strictEqual(fields["private-key"], sensitiveFieldReplacement);
+    assert.notInclude(JSON.stringify(fields), secret);
+    assert.include(String(fields.bearer), sensitiveTextReplacement);
+    assert.include(String(fields.service), sensitiveTextReplacement);
+    assert.include(String(fields.jwt), sensitiveTextReplacement);
+    assert.include(String(fields.contact), sensitiveTextReplacement);
+    assert.include(String(fields.pem), sensitiveTextReplacement);
+    assert.strictEqual(fields.control, "tokenizer documentation secretive phoneme documentary");
+  });
+
+  it("sanitizes structured JSON, assignments, escaped strings, and malformed JSON", () => {
+    const secret = marker();
+    const json = JSON.stringify({
+      profile: {
+        email: secret,
+        display: `Bearer ${secret}`,
+        escaped: `quoted "Bearer ${secret}"`,
+      },
+      events: [
+        { token: secret, note: `sk_${secret}` },
+        { token: secret, note: "ordinary value" },
+      ],
+    });
+    const fields = sanitizeBrowserFields({
+      json,
+      assignments: `authorization = "${secret}" other:value token:'${secret}'`,
+      malformed: `{"token":"${secret}"`,
+      escaped: `password="escaped\\"${secret}"`,
+    });
+    const decoded = decodeSanitizedJson(fields.json);
+    assert.strictEqual(decoded.profile.email, sensitiveTextReplacement);
+    assert.strictEqual(decoded.profile.escaped, `quoted "${sensitiveTextReplacement}"`);
+    assert.strictEqual(decoded.events[0]?.token, sensitiveTextReplacement);
+    assert.strictEqual(decoded.events[1]?.token, sensitiveTextReplacement);
+    assert.notInclude(JSON.stringify(fields), secret);
+    assert.strictEqual(fields.malformed, sensitiveTextReplacement);
+    assert.include(String(fields.assignments), `authorization = "${sensitiveTextReplacement}"`);
+    assert.include(String(fields.escaped), sensitiveTextReplacement);
+  });
+
+  it("fails closed for excessive JSON depth, value count, and original string size", () => {
+    let deep = '"safe"';
+    for (let index = 0; index < 34; index += 1) {
+      deep = `{"safe":${deep}}`;
+    }
+    const wide = JSON.stringify(Array.from({ length: 1_025 }, (_, index) => index));
+    const boundedJson = JSON.stringify({ safe: "x".repeat(2_000) });
+    const fields = sanitizeBrowserFields({
+      deep,
+      wide,
+      boundedJson,
+      oversized: "x".repeat(16_385),
+    });
+    assert.strictEqual(fields.deep, sensitiveTextReplacement);
+    assert.strictEqual(fields.wide, sensitiveTextReplacement);
+    assert.strictEqual(fields.boundedJson, sensitiveTextReplacement);
+    assert.strictEqual(fields.oversized, sensitiveTextReplacement);
+  });
+
+  it("drops every unsupported runtime value while retaining valid siblings", () => {
+    const fields = sanitizeBrowserFields(runtimeFields());
+    assert.deepStrictEqual(fields, { valid: "kept" });
+  });
+
+  it("inspects complete keys and values before applying output bounds", () => {
+    const secret = marker();
+    const dangerousKey = `${"x".repeat(140)}.authorization`;
+    const credentialKey = `header.Bearer ${secret}`;
+    const oversizedKey = "z".repeat(2_049);
+    const fields = sanitizeBrowserFields({
+      [dangerousKey]: secret,
+      [credentialKey]: "value",
+      [oversizedKey]: "value",
+      boundary: `${"x".repeat(1_020)} Bearer ${secret}`,
+    });
+    assert.strictEqual(fields[dangerousKey.slice(0, 128)], sensitiveFieldReplacement);
+    assert.isUndefined(fields[credentialKey.slice(0, 128)]);
+    assert.isUndefined(fields[oversizedKey.slice(0, 128)]);
+    assert.notInclude(JSON.stringify(fields), secret);
+    assert.strictEqual(String(fields.boundary).length, 1_024);
+  });
+
+  it("uses first bounded key wins for safe and sensitive collisions", () => {
+    const prefix = "x".repeat(128);
+    const safeFirst = sanitizeBrowserFields({
+      [`${prefix}.safe`]: "first",
+      [`${prefix}.token`]: "second",
+    });
+    const sensitiveFirst = sanitizeBrowserFields({
+      [`${prefix}.token`]: "first",
+      [`${prefix}.safe`]: "second",
+    });
+    assert.strictEqual(safeFirst[prefix], "first");
+    assert.strictEqual(sensitiveFirst[prefix], sensitiveFieldReplacement);
+  });
+
+  it("sanitizes event names before truncation", () => {
+    const secret = marker();
+    const eventName = sanitizeBrowserEventName(`checkout token=${secret} Bearer ${secret}`);
+    assert.notInclude(eventName, secret);
+    assert.include(eventName, sensitiveTextReplacement);
+    assert.strictEqual(sanitizeBrowserEventName("x".repeat(16_385)), sensitiveTextReplacement);
+  });
+});

--- a/packages/telemetry/test/redactionPolicy.test.ts
+++ b/packages/telemetry/test/redactionPolicy.test.ts
@@ -186,6 +186,29 @@ describe("browser telemetry redaction policy", () => {
     assert.deepStrictEqual(fields, { valid: "kept" });
   });
 
+  it("preserves inherited names and proto as safe own fields", () => {
+    const names = ["toString", "constructor", "hasOwnProperty", "__proto__"];
+    const input = Object.fromEntries(names.map((name) => [name, `value-${name}`]));
+    const fields = sanitizeBrowserFields(input);
+    assert.strictEqual(Object.getPrototypeOf(fields), Object.prototype);
+    assert.deepStrictEqual(Object.keys(fields), names);
+    for (const name of names) {
+      assert.isTrue(Object.prototype.hasOwnProperty.call(fields, name));
+      assert.strictEqual(fields[name], `value-${name}`);
+    }
+  });
+
+  it("preserves proto and inherited names in sanitized JSON text", () => {
+    const names = ["toString", "constructor", "hasOwnProperty", "__proto__"];
+    const source = Object.fromEntries(names.map((name) => [name, `value-${name}`]));
+    const fields = sanitizeBrowserFields({ json: JSON.stringify(source) });
+    const serialized = String(fields.json);
+    for (const name of names) {
+      assert.include(serialized, `"${name}":"value-${name}"`);
+    }
+    assert.strictEqual(serialized, JSON.stringify(source));
+  });
+
   it("inspects complete keys and values before applying output bounds", () => {
     const secret = marker();
     const dangerousKey = `${"x".repeat(140)}.authorization`;
@@ -216,6 +239,10 @@ describe("browser telemetry redaction policy", () => {
     });
     assert.strictEqual(safeFirst[prefix], "first");
     assert.strictEqual(sensitiveFirst[prefix], sensitiveFieldReplacement);
+    assert.deepStrictEqual(Object.keys(safeFirst), [prefix]);
+    assert.deepStrictEqual(Object.keys(sensitiveFirst), [prefix]);
+    assert.isTrue(Object.prototype.hasOwnProperty.call(safeFirst, prefix));
+    assert.isTrue(Object.prototype.hasOwnProperty.call(sensitiveFirst, prefix));
   });
 
   it("sanitizes event names before truncation", () => {


### PR DESCRIPTION
## Summary

- redact browser telemetry before event construction, queue insertion, retry, and transport
- preserve scalar contracts while dropping unsupported runtime values without traversal
- enforce shared key/value vocabulary, structured-text policy, fail-closed bounds, and Collector parity

## Verification

- pre-change real loopback leak reproduction
- browser, policy, parity, retry, and encoded loopback tests
- `bun check`
- `bun run build`
- `bun run test`
- `bun run test:package`
- independent exact-head review

Linear: OBS-5
