### PR TITLE
feat(cli): support provider-specific remote provisioning

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -56,7 +56,7 @@ A seleção é aditiva. Selecionar Axiom em um ambiente Sentry adiciona Axiom se
 
 Axiom cria três datasets e um token de ingestão por ambiente. Sentry usa um projeto para todos os ambientes da aplicação.
 
-`--rotate-token` exige Axiom em todos os ambientes solicitados. A CLI marca a mutação como pendente antes da chamada ao Axiom e salva o novo segredo após cada ambiente. Uma falha de transporte, resposta ilegível ou HTTP 5xx exige outra rotação explícita.
+`--rotate-token` exige Axiom em todos os ambientes solicitados. A CLI marca a mutação como pendente antes da chamada ao Axiom e salva o novo segredo após cada ambiente. Uma falha de transporte, resposta ilegível, HTTP 5xx ou status 2xx inesperado exige outra rotação explícita.
 
 `--force` afeta somente os assets locais. A flag não sobrescreve recursos remotos.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -41,15 +41,22 @@ observability provision \
   [--name <project>] \
   [--force] \
   [--environment <name>]... \
+  [--provider <axiom|sentry>]... \
   [--sentry-platform <platform>] \
   [--rotate-token]
 ```
 
-Sem `--environment`, o comando gera somente os assets locais. Esse comportamento mantém compatibilidade com versões anteriores.
+Sem `--environment`, o comando gera somente os assets locais. As flags remotas válidas não fazem chamadas externas nesse modo.
 
-Cada `--environment` cria três datasets Axiom e um token de ingestão. Todos os ambientes usam o mesmo projeto Sentry.
+Repita `--provider` para selecionar os dois providers. Valores duplicados produzem uma seleção única.
 
-`--rotate-token` regenera um token Axiom existente. A CLI salva o novo valor no arquivo local de credenciais.
+Sem `--provider`, um ambiente novo configura Axiom e Sentry. Um ambiente existente repete os providers salvos.
+
+A seleção é aditiva. Selecionar Axiom em um ambiente Sentry adiciona Axiom sem remover Sentry.
+
+Axiom cria três datasets e um token de ingestão por ambiente. Sentry usa um projeto para todos os ambientes da aplicação.
+
+`--rotate-token` exige Axiom em todos os ambientes solicitados. A CLI salva o novo segredo após cada ambiente.
 
 `--force` afeta somente os assets locais. A flag não sobrescreve recursos remotos.
 
@@ -69,18 +76,19 @@ observability env export \
   --environment <name>
 ```
 
-O comando imprime estas variáveis no formato dotenv:
+O comando sempre imprime `OTEL_SERVICE_NAME` e `OTEL_DEPLOYMENT_ENVIRONMENT`.
 
-- `OTEL_SERVICE_NAME`
-- `OTEL_DEPLOYMENT_ENVIRONMENT`
+Um ambiente Axiom também imprime:
+
 - `OTEL_EXPORTER_OTLP_ENDPOINT`
 - `AXIOM_TOKEN`
 - `AXIOM_DATASET_TRACES`
 - `AXIOM_DATASET_LOGS`
 - `AXIOM_DATASET_METRICS`
-- `SENTRY_DSN`
 
-A saída contém segredos. A CLI não mascara a saída desse comando.
+Um ambiente Sentry imprime `SENTRY_DSN`.
+
+Um ambiente combinado imprime a união dessas variáveis. A saída contém segredos e não aplica mascaramento.
 
 ## Arquivo de credenciais
 
@@ -88,7 +96,13 @@ O caminho padrão é `~/.local/state/observability/credentials.json`. `OBSERVABI
 
 A CLI cria o diretório com modo `0700`. A CLI cria o arquivo com modo `0600`.
 
-O arquivo contém tokens administrativos, tokens de ingestão, DSNs, e o estado dos ambientes. A CLI recusa um arquivo acessível por grupo ou outros usuários.
+O arquivo contém tokens administrativos, tokens de ingestão, DSNs e o estado dos ambientes. A CLI recusa um arquivo acessível por outros usuários.
+
+A CLI atual migra o formato de versão 1 para a versão 2 antes de uma chamada externa. A migração preserva os segredos e o modo `0600`.
+
+Não use uma versão antiga da CLI após a migração. Versões antigas não leem o formato de versão 2.
+
+A CLI serializa atualizações com um lock entre processos. Um comando espera no máximo 30 segundos por outra atualização.
 
 ## Convenção de nomes
 
@@ -108,15 +122,22 @@ O nome do token Axiom segue este formato:
 
 ## Erros remotos
 
-| Código                                 | Significado                                                            |
-| -------------------------------------- | ---------------------------------------------------------------------- |
-| `OBS_CLI_CREDENTIALS_INVALID`          | O arquivo ou a configuração de credenciais não passa no parse.         |
-| `OBS_CLI_CREDENTIALS_INSECURE`         | O arquivo de credenciais permite acesso para grupo ou outros usuários. |
-| `OBS_CLI_CREDENTIALS_FAILED`           | A CLI não consegue acessar o arquivo de credenciais.                   |
-| `OBS_CLI_REMOTE_CREDENTIALS_MISSING`   | O provisionamento remoto não encontra as duas credenciais.             |
-| `OBS_CLI_REMOTE_UNAUTHORIZED`          | O provider recusa a credencial ou o acesso à organização.              |
-| `OBS_CLI_REMOTE_FAILED`                | A requisição falha ou o provider retorna um status inesperado.         |
-| `OBS_CLI_REMOTE_INVALID_RESPONSE`      | A resposta do provider não passa no parse.                             |
-| `OBS_CLI_REMOTE_INVALID_ENVIRONMENT`   | O ambiente ou o nome derivado de um dataset é inválido.                |
-| `OBS_CLI_REMOTE_TOKEN_UNAVAILABLE`     | O token existe no Axiom, mas a CLI não possui o valor secreto.         |
-| `OBS_CLI_REMOTE_ENVIRONMENT_NOT_FOUND` | O arquivo local não contém o projeto e o ambiente solicitados.         |
+| Código                                        | Significado                                                    |
+| --------------------------------------------- | -------------------------------------------------------------- |
+| `OBS_CLI_CREDENTIALS_INVALID`                 | O arquivo ou a configuração de credenciais não passa no parse. |
+| `OBS_CLI_CREDENTIALS_INSECURE`                | O arquivo de credenciais permite acesso para outros usuários.  |
+| `OBS_CLI_CREDENTIALS_FAILED`                  | A CLI não consegue acessar o arquivo de credenciais.           |
+| `OBS_CLI_CREDENTIALS_VERSION_UNSUPPORTED`     | Uma CLI antiga não lê a versão do arquivo.                     |
+| `OBS_CLI_CREDENTIALS_BUSY`                    | Outro processo mantém o lock de atualização.                   |
+| `OBS_CLI_REMOTE_CREDENTIALS_MISSING`          | Uma seleção combinada não encontra as duas credenciais.        |
+| `OBS_CLI_REMOTE_PROVIDER_CREDENTIALS_MISSING` | Um provider selecionado não tem credenciais.                   |
+| `OBS_CLI_REMOTE_INVALID_PROVIDER`             | `--provider` não contém `axiom` ou `sentry`.                   |
+| `OBS_CLI_REMOTE_UNAUTHORIZED`                 | O provider recusa a credencial ou o acesso à organização.      |
+| `OBS_CLI_REMOTE_FAILED`                       | A requisição falha ou o provider retorna um status inesperado. |
+| `OBS_CLI_REMOTE_INVALID_RESPONSE`             | A resposta do provider não passa no parse.                     |
+| `OBS_CLI_REMOTE_INVALID_ENVIRONMENT`          | O ambiente ou o nome derivado de um dataset é inválido.        |
+| `OBS_CLI_REMOTE_ROTATION_NOT_SELECTED`        | Uma rotação inclui um ambiente sem Axiom.                      |
+| `OBS_CLI_REMOTE_TOKEN_UNAVAILABLE`            | O token existe no Axiom, mas a CLI não possui o valor secreto. |
+| `OBS_CLI_REMOTE_PARTIAL_FAILURE`              | Um ambiente falha após a CLI salvar ambientes anteriores.      |
+| `OBS_CLI_REMOTE_OUTCOME_UNKNOWN`              | Uma mutação do token Axiom não tem resultado local confirmado. |
+| `OBS_CLI_REMOTE_ENVIRONMENT_NOT_FOUND`        | O arquivo local não contém o projeto e o ambiente solicitados. |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -56,7 +56,7 @@ A seleção é aditiva. Selecionar Axiom em um ambiente Sentry adiciona Axiom se
 
 Axiom cria três datasets e um token de ingestão por ambiente. Sentry usa um projeto para todos os ambientes da aplicação.
 
-`--rotate-token` exige Axiom em todos os ambientes solicitados. A CLI salva o novo segredo após cada ambiente.
+`--rotate-token` exige Axiom em todos os ambientes solicitados. A CLI marca a mutação como pendente antes da chamada ao Axiom e salva o novo segredo após cada ambiente. Uma falha de transporte, resposta ilegível ou HTTP 5xx exige outra rotação explícita.
 
 `--force` afeta somente os assets locais. A flag não sobrescreve recursos remotos.
 

--- a/docs/environment-management.md
+++ b/docs/environment-management.md
@@ -86,7 +86,7 @@ Uma queda entre a resposta Axiom e a gravação local cria uma janela inevitáve
 
 Antes de criar ou regenerar o token, a CLI salva uma marca de mutação pendente. Se o processo cair, uma repetição comum e `observability env export` recusam o segredo local possivelmente inválido. Execute a rotação explícita do token Axiom.
 
-Se a resposta de mutação for ilegível, retornar HTTP 5xx ou falhar no transporte, a CLI informa `OBS_CLI_REMOTE_OUTCOME_UNKNOWN`. Não repita o comando sem rotação. Rode novamente com `--provider axiom --rotate-token`.
+Se a resposta de mutação for ilegível, retornar HTTP 5xx, usar um status 2xx inesperado ou falhar no transporte, a CLI informa `OBS_CLI_REMOTE_OUTCOME_UNKNOWN`. Não repita o comando sem rotação. Rode novamente com `--provider axiom --rotate-token`.
 
 A CLI preserva ambientes salvos antes de uma falha posterior. `OBS_CLI_REMOTE_PARTIAL_FAILURE` lista esses ambientes.
 

--- a/docs/environment-management.md
+++ b/docs/environment-management.md
@@ -58,19 +58,37 @@ A CLI cria um projeto Sentry por aplicação. O SDK Sentry envia o nome do ambie
 
 O Sentry cria a lista de ambientes observados após receber eventos. A CLI não cria ambientes Sentry separados.
 
+## Cada ambiente registra somente os providers configurados
+
+Use `--provider axiom` para configurar somente Axiom. Use `--provider sentry` para configurar somente Sentry.
+
+Repita a flag para configurar ambos. Sem a flag, um ambiente novo configura os dois providers.
+
+Um ambiente existente repete sua seleção salva quando a flag não existe. Uma seleção explícita adiciona providers e não remove estado anterior.
+
+Um ambiente Sentry não exporta variáveis Axiom. Ele também não exporta `OTEL_EXPORTER_OTLP_ENDPOINT`.
+
+Os assets gerados ainda configuram um Collector Axiom. Uma execução somente Sentry não configura as variáveis desses assets.
+
 ## A CLI separa credenciais administrativas de credenciais de runtime
 
 `observability auth login` salva os tokens administrativos no arquivo local de credenciais. O arquivo usa o modo `0600`.
 
-O provisionamento usa esses tokens para criar recursos remotos. A CLI cria um token Axiom com acesso somente para ingestão.
+O provisionamento exige credenciais somente para os providers efetivos. A CLI cria um token Axiom com acesso somente para ingestão.
 
-A CLI não grava segredos nos assets em `observability/`. `observability env export` imprime as variáveis para integração com Kamal ou outro gerenciador de segredos.
+A CLI não grava segredos nos assets em `observability/`. `observability env export` imprime as variáveis para integração com um gerenciador de segredos.
 
 ## O estado local preserva segredos que o provider não retorna
 
-O Axiom retorna o valor do token somente na criação ou na regeneração. A CLI salva esse valor no arquivo local de credenciais.
+O Axiom retorna o valor do token somente na criação ou na regeneração. A CLI salva cada ambiente logo após receber esse valor.
 
-Se esse estado local for perdido, a CLI encontra o token remoto sem acesso ao valor. Nesse caso, `--rotate-token` regenera o token e salva o novo valor.
+Uma queda entre a resposta Axiom e a gravação local cria uma janela inevitável. Uma gravação atômica não remove essa janela.
+
+Se o segredo local não existe, a CLI recusa uma repetição comum. Execute a rotação explícita do token Axiom.
+
+Se a CLI informa `OBS_CLI_REMOTE_OUTCOME_UNKNOWN`, não repita o comando sem rotação. Rode novamente com `--provider axiom --rotate-token`.
+
+A CLI preserva ambientes salvos antes de uma falha posterior. `OBS_CLI_REMOTE_PARTIAL_FAILURE` lista esses ambientes.
 
 ## Ambientes configurados e ambientes observados têm significados diferentes
 

--- a/docs/environment-management.md
+++ b/docs/environment-management.md
@@ -84,9 +84,9 @@ O Axiom retorna o valor do token somente na criação ou na regeneração. A CLI
 
 Uma queda entre a resposta Axiom e a gravação local cria uma janela inevitável. Uma gravação atômica não remove essa janela.
 
-Se o segredo local não existe, a CLI recusa uma repetição comum. Execute a rotação explícita do token Axiom.
+Antes de criar ou regenerar o token, a CLI salva uma marca de mutação pendente. Se o processo cair, uma repetição comum e `observability env export` recusam o segredo local possivelmente inválido. Execute a rotação explícita do token Axiom.
 
-Se a CLI informa `OBS_CLI_REMOTE_OUTCOME_UNKNOWN`, não repita o comando sem rotação. Rode novamente com `--provider axiom --rotate-token`.
+Se a resposta de mutação for ilegível, retornar HTTP 5xx ou falhar no transporte, a CLI informa `OBS_CLI_REMOTE_OUTCOME_UNKNOWN`. Não repita o comando sem rotação. Rode novamente com `--provider axiom --rotate-token`.
 
 A CLI preserva ambientes salvos antes de uma falha posterior. `OBS_CLI_REMOTE_PARTIAL_FAILURE` lista esses ambientes.
 

--- a/docs/setup-project-environments.md
+++ b/docs/setup-project-environments.md
@@ -4,11 +4,13 @@ Use este guia para configurar Axiom e Sentry para `development`, `staging`, e `p
 
 ## Preparar os tokens administrativos
 
+Prepare somente os tokens dos providers selecionados.
+
 1. Crie um personal access token no Axiom.
 2. Conceda ao token acesso para gerenciar datasets e API tokens.
 3. Copie o identificador da organização Axiom.
 4. Crie um organization auth token no Sentry.
-5. Conceda ao token os escopos `org:read`, `project:read`, e `project:write`.
+5. Conceda ao token os escopos `org:read`, `project:read` e `project:write`.
 6. Copie os slugs da organização e do time Sentry.
 
 Não use tokens administrativos no runtime da aplicação. Esses tokens podem alterar recursos da organização.
@@ -33,13 +35,13 @@ observability auth login sentry \
 
 Cole o organization auth token no prompt protegido.
 
-Valide as duas conexões:
+Valide as conexões salvas:
 
 ```sh
 observability auth status
 ```
 
-A saída mostra a identidade Axiom, a organização Sentry, e o caminho do arquivo de credenciais.
+A saída mostra cada identidade disponível e o caminho do arquivo de credenciais.
 
 ## Iniciar a observabilidade local
 
@@ -81,6 +83,20 @@ O comando cria estes recursos:
 
 O comando não imprime os tokens de runtime.
 
+Para configurar somente Axiom, adicione `--provider axiom`. Para configurar somente Sentry, adicione `--provider sentry`.
+
+Para selecionar ambos explicitamente, repita a flag:
+
+```sh
+observability provision \
+  --name livro-caixa \
+  --environment staging \
+  --provider axiom \
+  --provider sentry
+```
+
+Sem a flag, um ambiente novo usa ambos. Um ambiente existente repete seus providers salvos.
+
 ## Adicionar as variáveis ao deploy
 
 Exporte as variáveis de `staging`:
@@ -91,9 +107,9 @@ observability env export \
   --environment staging
 ```
 
-A saída contém `AXIOM_TOKEN` e `SENTRY_DSN`. Não salve essa saída em um arquivo versionado.
+A saída contém somente variáveis dos providers salvos. Não salve essa saída em um arquivo versionado.
 
-Adicione os valores ao gerenciador de segredos do ambiente. Adicione as variáveis `OTEL_*` e `AXIOM_DATASET_*` ao destino Kamal.
+Adicione os valores ao gerenciador de segredos do ambiente. Adicione variáveis Axiom ao destino Kamal somente quando o ambiente usa Axiom.
 
 Repita o processo para `production`:
 
@@ -123,7 +139,10 @@ Se o arquivo local de credenciais foi perdido, regenere o token do ambiente:
 observability provision \
   --name livro-caixa \
   --environment staging \
+  --provider axiom \
   --rotate-token
 ```
 
 Atualize o segredo `AXIOM_TOKEN` antes do próximo deploy. O token anterior deixa de funcionar imediatamente.
+
+Não execute uma repetição comum após `OBS_CLI_REMOTE_OUTCOME_UNKNOWN`. Use a rotação explícita para recuperar o estado.

--- a/packages/cli/src/Cli.ts
+++ b/packages/cli/src/Cli.ts
@@ -9,6 +9,7 @@ import {
   environmentSentry,
   parseProviderSelection,
   RemoteEnvironment,
+  validateRemoteProvisionRequest,
 } from "./RemoteEnvironment.ts";
 import { StackAssets } from "./StackAssets.ts";
 
@@ -181,12 +182,15 @@ const provision = Command.make(
     const selectedProviders = yield* parseProviderSelection(providers);
     const assets = yield* ProvisionAssets;
     const projectName = yield* assets.resolveName(dir, name);
+    const uniqueEnvironments = [...new Set(environments)];
+    if (uniqueEnvironments.length > 0) {
+      yield* validateRemoteProvisionRequest(projectName, uniqueEnvironments);
+    }
     const files = yield* assets.provision(dir, Option.some(projectName), force);
     for (const file of files) {
       yield* Console.log(`${file.action}  ${file.relativePath}`);
     }
 
-    const uniqueEnvironments = [...new Set(environments)];
     if (uniqueEnvironments.length === 0) {
       yield* Console.log(
         "Merge observability/kamal.accessory.yml into config/deploy.yml and set the AXIOM_TOKEN secret.",

--- a/packages/cli/src/Cli.ts
+++ b/packages/cli/src/Cli.ts
@@ -2,7 +2,14 @@ import { Console, Effect, Option, Path, Redacted } from "effect";
 import { Command, Flag, Prompt } from "effect/unstable/cli";
 import { DockerCompose } from "./DockerCompose.ts";
 import { ProvisionAssets } from "./ProvisionAssets.ts";
-import { Authentication, RemoteEnvironment } from "./RemoteEnvironment.ts";
+import {
+  Authentication,
+  environmentAxiom,
+  environmentProviderNames,
+  environmentSentry,
+  parseProviderSelection,
+  RemoteEnvironment,
+} from "./RemoteEnvironment.ts";
 import { StackAssets } from "./StackAssets.ts";
 
 const composeFile = Flag.string("file").pipe(
@@ -144,6 +151,11 @@ const provisionEnvironments = Flag.string("environment").pipe(
   Flag.atMost(10),
 );
 
+const provisionProviders = Flag.string("provider").pipe(
+  Flag.withDescription("Provider remoto. Use axiom ou sentry e repita para selecionar ambos"),
+  Flag.atMost(10),
+);
+
 const provisionPlatform = Flag.string("sentry-platform").pipe(
   Flag.withDescription("Plataforma do projeto Sentry"),
   Flag.withDefault("node"),
@@ -161,42 +173,69 @@ const provision = Command.make(
     name: provisionName,
     force: provisionForce,
     environments: provisionEnvironments,
+    providers: provisionProviders,
     platform: provisionPlatform,
     rotateToken: provisionRotateToken,
   },
-  Effect.fn(function* ({ dir, environments, force, name, platform, rotateToken }) {
+  Effect.fn(function* ({ dir, environments, force, name, platform, providers, rotateToken }) {
+    const selectedProviders = yield* parseProviderSelection(providers);
     const assets = yield* ProvisionAssets;
     const projectName = yield* assets.resolveName(dir, name);
     const files = yield* assets.provision(dir, Option.some(projectName), force);
     for (const file of files) {
       yield* Console.log(`${file.action}  ${file.relativePath}`);
     }
-    yield* Console.log(
-      "Merge observability/kamal.accessory.yml into config/deploy.yml and set the AXIOM_TOKEN secret.",
-    );
 
     const uniqueEnvironments = [...new Set(environments)];
-    if (uniqueEnvironments.length > 0) {
-      const remote = yield* RemoteEnvironment;
-      const configured = yield* remote.provision(
-        projectName,
-        uniqueEnvironments,
-        platform,
-        rotateToken,
+    if (uniqueEnvironments.length === 0) {
+      yield* Console.log(
+        "Merge observability/kamal.accessory.yml into config/deploy.yml and set the AXIOM_TOKEN secret.",
       );
-      for (const environment of configured) {
-        yield* Console.log(
-          `configured  ${environment.project}/${environment.environment} (${environment.tracesDataset}, ${environment.logsDataset}, ${environment.metricsDataset})`,
+      return;
+    }
+
+    const remote = yield* RemoteEnvironment;
+    const configured = yield* remote.provision(
+      projectName,
+      uniqueEnvironments,
+      selectedProviders,
+      platform,
+      rotateToken,
+    );
+    for (const environment of configured) {
+      const providerNames = environmentProviderNames(environment).join(",");
+      const parts = [
+        `configured  ${environment.project}/${environment.environment}`,
+        `providers=${providerNames}`,
+      ];
+      const axiom = environmentAxiom(environment);
+      if (Option.isSome(axiom)) {
+        parts.push(
+          `datasets=${axiom.value.tracesDataset},${axiom.value.logsDataset},${axiom.value.metricsDataset}`,
         );
       }
+      const sentry = environmentSentry(environment);
+      if (Option.isSome(sentry)) {
+        parts.push(`sentry-project=${sentry.value.project}`);
+      }
+      yield* Console.log(parts.join("  "));
+    }
+    if (configured.some((environment) => Option.isSome(environmentAxiom(environment)))) {
       yield* Console.log(
-        `Run observability env export --name ${projectName} --environment <environment> to print deploy variables.`,
+        "Merge observability/kamal.accessory.yml into config/deploy.yml and set the AXIOM_TOKEN secret.",
+      );
+    } else {
+      yield* Console.log(
+        "The generated Collector assets require Axiom variables and are not configured by this Sentry-only command.",
       );
     }
+    yield* Console.log(
+      `Run observability env export --name ${projectName} --environment <environment> to print deploy variables.`,
+    );
   }),
 ).pipe(
   Command.withDescription(
-    "Provisiona os assets locais e, com --environment, os recursos Axiom e Sentry",
+    "Provisiona os assets locais e, com --environment, os providers remotos selecionados",
   ),
 );
 
@@ -217,9 +256,18 @@ const environmentList = Command.make(
       return;
     }
     for (const environment of environments) {
-      yield* Console.log(
-        `${environment.project}/${environment.environment}  axiom=${environment.tracesDataset},${environment.logsDataset},${environment.metricsDataset}  sentry=${environment.sentryProject}`,
-      );
+      const parts = [`${environment.project}/${environment.environment}`];
+      const axiom = environmentAxiom(environment);
+      if (Option.isSome(axiom)) {
+        parts.push(
+          `axiom=${axiom.value.tracesDataset},${axiom.value.logsDataset},${axiom.value.metricsDataset}`,
+        );
+      }
+      const sentry = environmentSentry(environment);
+      if (Option.isSome(sentry)) {
+        parts.push(`sentry=${sentry.value.project}`);
+      }
+      yield* Console.log(parts.join("  "));
     }
   }),
 ).pipe(Command.withDescription("Lista os ambientes configurados por esta CLI"));

--- a/packages/cli/src/CredentialsStore.ts
+++ b/packages/cli/src/CredentialsStore.ts
@@ -69,6 +69,13 @@ export class ManagedEnvironment extends Schema.Class<ManagedEnvironment>(
   providers: EnvironmentProviders,
 }) {}
 
+export class PendingAxiomMutation extends Schema.Class<PendingAxiomMutation>(
+  "@equipe-tech/observability-cli/PendingAxiomMutation",
+)({
+  project: Schema.NonEmptyString,
+  environment: Schema.NonEmptyString,
+}) {}
+
 export class CredentialsFile extends Schema.Class<CredentialsFile>(
   "@equipe-tech/observability-cli/CredentialsFile",
 )({
@@ -76,6 +83,7 @@ export class CredentialsFile extends Schema.Class<CredentialsFile>(
   axiom: AxiomCredentials.pipe(Schema.optionalKey),
   sentry: SentryCredentials.pipe(Schema.optionalKey),
   environments: Schema.Array(ManagedEnvironment),
+  pendingAxiomMutations: Schema.Array(PendingAxiomMutation).pipe(Schema.optionalKey),
 }) {}
 
 const LegacyManagedEnvironment = Schema.Struct({
@@ -251,6 +259,8 @@ export class CredentialsStore extends Context.Service<
       const credentialsPath = path.join(root, "credentials.json");
       const lockPath = path.join(root, ".credentials.lock");
       const lockOwnerPath = path.join(lockPath, "owner.json");
+      const heartbeatPath = (nonce: string): string =>
+        path.join(root, `.credentials.heartbeat-${nonce}`);
 
       const prepareRoot = Effect.fn("CredentialsStore.prepareRoot")(function* () {
         yield* fs
@@ -260,29 +270,54 @@ export class CredentialsStore extends Context.Service<
       });
 
       const writeLockOwner = Effect.fn("CredentialsStore.writeLockOwner")(function* (
+        directory: string,
         nonce: string,
       ) {
         const heartbeat = yield* Clock.currentTimeMillis;
-        const temporaryPath = path.join(lockPath, `owner-${nonce}-${crypto.randomUUID()}.tmp`);
+        const ownerPath = path.join(directory, "owner.json");
         const content = `${JSON.stringify({ nonce, pid: process.pid, heartbeat })}\n`;
         yield* fs
-          .writeFileString(temporaryPath, content, { mode: 0o600 })
+          .writeFileString(ownerPath, content, { mode: 0o600 })
+          .pipe(Effect.mapError(credentialsFailure));
+        yield* fs.chmod(ownerPath, 0o600).pipe(Effect.mapError(credentialsFailure));
+      });
+
+      const writeHeartbeat = Effect.fn("CredentialsStore.writeHeartbeat")(function* (
+        nonce: string,
+      ) {
+        const heartbeat = yield* Clock.currentTimeMillis;
+        const target = heartbeatPath(nonce);
+        const temporaryPath = `${target}.${crypto.randomUUID()}.tmp`;
+        yield* fs
+          .writeFileString(temporaryPath, `${heartbeat}\n`, { mode: 0o600 })
           .pipe(Effect.mapError(credentialsFailure));
         yield* fs.chmod(temporaryPath, 0o600).pipe(Effect.mapError(credentialsFailure));
-        yield* fs.rename(temporaryPath, lockOwnerPath).pipe(Effect.mapError(credentialsFailure));
+        yield* fs.rename(temporaryPath, target).pipe(Effect.mapError(credentialsFailure));
+      });
+
+      const lockOwner = Effect.fn("CredentialsStore.lockOwner")(function* (ownerPath: string) {
+        const content = yield* fs.readFileString(ownerPath).pipe(Effect.option);
+        if (Option.isNone(content)) {
+          return Option.none<typeof LockOwner.Type>();
+        }
+        return yield* Effect.try((): unknown => JSON.parse(content.value)).pipe(
+          Effect.flatMap(decodeLockOwner),
+          Effect.option,
+        );
       });
 
       const lockAge = Effect.fn("CredentialsStore.lockAge")(function* () {
         const now = yield* Clock.currentTimeMillis;
-        const content = yield* fs.readFileString(lockOwnerPath).pipe(Effect.option);
-        if (Option.isSome(content)) {
-          const parsed = yield* Effect.try((): unknown => JSON.parse(content.value)).pipe(
-            Effect.flatMap(decodeLockOwner),
+        const owner = yield* lockOwner(lockOwnerPath);
+        if (Option.isSome(owner)) {
+          const heartbeat = yield* fs.readFileString(heartbeatPath(owner.value.nonce)).pipe(
+            Effect.flatMap((value) => Effect.try(() => Number(value.trim()))),
             Effect.option,
           );
-          if (Option.isSome(parsed)) {
-            return now - parsed.value.heartbeat;
+          if (Option.isSome(heartbeat) && Number.isFinite(heartbeat.value)) {
+            return now - heartbeat.value;
           }
+          return now - owner.value.heartbeat;
         }
         const info = yield* fs.stat(lockPath).pipe(Effect.option);
         if (Option.isSome(info) && Option.isSome(info.value.mtime)) {
@@ -296,6 +331,7 @@ export class CredentialsStore extends Context.Service<
         if (age <= 30_000) {
           return false;
         }
+        const owner = yield* lockOwner(lockOwnerPath);
         const tombstone = `${lockPath}.stale-${crypto.randomUUID()}`;
         const renamed = yield* fs.rename(lockPath, tombstone).pipe(
           Effect.as(true),
@@ -307,31 +343,47 @@ export class CredentialsStore extends Context.Service<
         yield* fs
           .remove(tombstone, { recursive: true, force: true })
           .pipe(Effect.mapError(credentialsFailure));
+        if (Option.isSome(owner)) {
+          yield* fs.remove(heartbeatPath(owner.value.nonce), { force: true }).pipe(Effect.ignore);
+        }
         return true;
       });
 
       const acquireLock = Effect.fn("CredentialsStore.acquireLock")(function* () {
         yield* prepareRoot();
         const nonce = crypto.randomUUID();
+        const candidatePath = `${lockPath}.candidate-${nonce}`;
         const started = yield* Clock.currentTimeMillis;
+        yield* fs
+          .makeDirectory(candidatePath, { mode: 0o700 })
+          .pipe(Effect.mapError(credentialsFailure));
+        yield* writeLockOwner(candidatePath, nonce).pipe(
+          Effect.andThen(writeHeartbeat(nonce)),
+          Effect.catch((error) =>
+            fs
+              .remove(candidatePath, { recursive: true, force: true })
+              .pipe(
+                Effect.ignore,
+                Effect.andThen(
+                  fs.remove(heartbeatPath(nonce), { force: true }).pipe(Effect.ignore),
+                ),
+                Effect.andThen(Effect.fail(error)),
+              ),
+          ),
+        );
         while (true) {
-          const acquired = yield* fs.makeDirectory(lockPath, { mode: 0o700 }).pipe(
+          const acquired = yield* fs.rename(candidatePath, lockPath).pipe(
             Effect.as(true),
             Effect.catch(() => Effect.succeed(false)),
           );
           if (acquired) {
-            return yield* writeLockOwner(nonce).pipe(
-              Effect.as(nonce),
-              Effect.catch((error) =>
-                fs
-                  .remove(lockPath, { recursive: true, force: true })
-                  .pipe(Effect.ignore, Effect.andThen(Effect.fail(error))),
-              ),
-            );
+            return nonce;
           }
           yield* reclaimStaleLock();
           const now = yield* Clock.currentTimeMillis;
           if (now - started >= 30_000) {
+            yield* fs.remove(candidatePath, { recursive: true, force: true }).pipe(Effect.ignore);
+            yield* fs.remove(heartbeatPath(nonce), { force: true }).pipe(Effect.ignore);
             return yield* new CredentialsError({
               code: "OBS_CLI_CREDENTIALS_BUSY",
               message:
@@ -346,24 +398,18 @@ export class CredentialsStore extends Context.Service<
       const heartbeat = Effect.fn("CredentialsStore.heartbeat")(function* (nonce: string) {
         while (true) {
           yield* Effect.sleep("1 second");
-          yield* writeLockOwner(nonce);
+          yield* writeHeartbeat(nonce);
         }
       });
 
       const releaseLock = Effect.fn("CredentialsStore.releaseLock")(function* (nonce: string) {
-        const content = yield* fs.readFileString(lockOwnerPath).pipe(Effect.option);
-        if (Option.isNone(content)) {
-          return;
-        }
-        const owner = yield* Effect.try((): unknown => JSON.parse(content.value)).pipe(
-          Effect.flatMap(decodeLockOwner),
-          Effect.option,
-        );
+        const owner = yield* lockOwner(lockOwnerPath);
         if (Option.isSome(owner) && owner.value.nonce === nonce) {
           yield* fs
             .remove(lockPath, { recursive: true, force: true })
             .pipe(Effect.mapError(credentialsFailure));
         }
+        yield* fs.remove(heartbeatPath(nonce), { force: true }).pipe(Effect.ignore);
       });
 
       const loadPersisted = Effect.fn("CredentialsStore.loadPersisted")(function* () {

--- a/packages/cli/src/CredentialsStore.ts
+++ b/packages/cli/src/CredentialsStore.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, FileSystem, Layer, Option, Path, Schema } from "effect";
+import { Clock, Context, Effect, Fiber, FileSystem, Layer, Option, Path, Schema } from "effect";
 import { homedir } from "node:os";
 
 const CredentialsEnvironment = Schema.Struct({
@@ -23,9 +23,62 @@ export class SentryCredentials extends Schema.Class<SentryCredentials>(
   baseUrl: Schema.URLFromString,
 }) {}
 
+export class AxiomEnvironment extends Schema.Class<AxiomEnvironment>(
+  "@equipe-tech/observability-cli/AxiomEnvironment",
+)({
+  tokenId: Schema.NonEmptyString,
+  token: Schema.NonEmptyString,
+  tracesDataset: Schema.NonEmptyString,
+  logsDataset: Schema.NonEmptyString,
+  metricsDataset: Schema.NonEmptyString,
+}) {}
+
+export class SentryEnvironment extends Schema.Class<SentryEnvironment>(
+  "@equipe-tech/observability-cli/SentryEnvironment",
+)({
+  project: Schema.NonEmptyString,
+  dsn: Schema.NonEmptyString,
+}) {}
+
+const AxiomProviders = Schema.Struct({
+  type: Schema.Literal("axiom"),
+  axiom: AxiomEnvironment,
+});
+const SentryProviders = Schema.Struct({
+  type: Schema.Literal("sentry"),
+  sentry: SentryEnvironment,
+});
+const CombinedProviders = Schema.Struct({
+  type: Schema.Literal("combined"),
+  axiom: AxiomEnvironment,
+  sentry: SentryEnvironment,
+});
+
+export const EnvironmentProviders = Schema.Union([
+  AxiomProviders,
+  SentryProviders,
+  CombinedProviders,
+]);
+export type EnvironmentProviders = typeof EnvironmentProviders.Type;
+
 export class ManagedEnvironment extends Schema.Class<ManagedEnvironment>(
   "@equipe-tech/observability-cli/ManagedEnvironment",
 )({
+  project: Schema.NonEmptyString,
+  environment: Schema.NonEmptyString,
+  providers: EnvironmentProviders,
+}) {}
+
+export class CredentialsFile extends Schema.Class<CredentialsFile>(
+  "@equipe-tech/observability-cli/CredentialsFile",
+)({
+  version: Schema.Literal(2),
+  axiom: AxiomCredentials.pipe(Schema.optionalKey),
+  sentry: SentryCredentials.pipe(Schema.optionalKey),
+  environments: Schema.Array(ManagedEnvironment),
+}) {}
+
+const LegacyManagedEnvironment = Schema.Struct({
   project: Schema.NonEmptyString,
   environment: Schema.NonEmptyString,
   axiomTokenId: Schema.NonEmptyString,
@@ -35,24 +88,41 @@ export class ManagedEnvironment extends Schema.Class<ManagedEnvironment>(
   metricsDataset: Schema.NonEmptyString,
   sentryProject: Schema.NonEmptyString,
   sentryDsn: Schema.NonEmptyString,
-}) {}
+});
 
-export class CredentialsFile extends Schema.Class<CredentialsFile>(
-  "@equipe-tech/observability-cli/CredentialsFile",
-)({
+const LegacyCredentialsFile = Schema.Struct({
   version: Schema.Literal(1),
   axiom: AxiomCredentials.pipe(Schema.optionalKey),
   sentry: SentryCredentials.pipe(Schema.optionalKey),
-  environments: Schema.Array(ManagedEnvironment),
-}) {}
+  environments: Schema.Array(LegacyManagedEnvironment),
+});
 
+type LegacyCredentialsFile = typeof LegacyCredentialsFile.Type;
+
+const CredentialsVersion = Schema.Struct({ version: Schema.Number });
+const decodeCredentialsVersion = Schema.decodeUnknownEffect(CredentialsVersion);
+const decodeLegacyCredentialsFile = Schema.decodeUnknownEffect(LegacyCredentialsFile);
 const decodeCredentialsFile = Schema.decodeUnknownEffect(CredentialsFile);
+
+const LockOwner = Schema.Struct({
+  nonce: Schema.NonEmptyString,
+  pid: Schema.Int,
+  heartbeat: Schema.Number,
+});
+
+const decodeLockOwner = Schema.decodeUnknownEffect(LockOwner);
+
+type PersistedCredentials =
+  | { readonly type: "legacy"; readonly credentials: LegacyCredentialsFile }
+  | { readonly type: "current"; readonly credentials: CredentialsFile };
 
 export class CredentialsError extends Schema.TaggedError<CredentialsError>()("CredentialsError", {
   code: Schema.Literals([
     "OBS_CLI_CREDENTIALS_INVALID",
     "OBS_CLI_CREDENTIALS_INSECURE",
     "OBS_CLI_CREDENTIALS_FAILED",
+    "OBS_CLI_CREDENTIALS_VERSION_UNSUPPORTED",
+    "OBS_CLI_CREDENTIALS_BUSY",
   ]),
   message: Schema.String,
   cause: Schema.Defect(),
@@ -66,35 +136,98 @@ const credentialsFailure = (cause: unknown): CredentialsError =>
     cause,
   });
 
-const parseCredentials = Effect.fn("parseCredentials")(function* (content: string) {
+const invalidCredentials = (cause: unknown): CredentialsError =>
+  new CredentialsError({
+    code: "OBS_CLI_CREDENTIALS_INVALID",
+    message:
+      "The credentials file is invalid. Restore a valid credentials file or run the authentication commands again.",
+    cause,
+  });
+
+const parseCredentials = Effect.fn("parseCredentials")(function* (
+  content: string,
+): Effect.fn.Return<PersistedCredentials, CredentialsError> {
   const value = yield* Effect.try({
     try: () => JSON.parse(content),
-    catch: (cause) =>
-      new CredentialsError({
-        code: "OBS_CLI_CREDENTIALS_INVALID",
-        message:
-          "The credentials file is invalid. Remove it and run the authentication commands again.",
-        cause,
-      }),
+    catch: invalidCredentials,
   });
-  return yield* decodeCredentialsFile(value).pipe(
-    Effect.mapError(
-      (cause) =>
-        new CredentialsError({
-          code: "OBS_CLI_CREDENTIALS_INVALID",
-          message:
-            "The credentials file is invalid. Remove it and run the authentication commands again.",
-          cause,
-        }),
-    ),
-  );
+  const version = yield* decodeCredentialsVersion(value).pipe(Effect.mapError(invalidCredentials));
+  if (version.version > 2) {
+    return yield* new CredentialsError({
+      code: "OBS_CLI_CREDENTIALS_VERSION_UNSUPPORTED",
+      message: "The credentials file was written by a newer CLI. Update the CLI and retry.",
+      cause: version.version,
+    });
+  }
+  if (version.version === 1) {
+    const credentials = yield* decodeLegacyCredentialsFile(value).pipe(
+      Effect.mapError(invalidCredentials),
+    );
+    return { type: "legacy", credentials };
+  }
+  if (version.version === 2) {
+    const credentials = yield* decodeCredentialsFile(value).pipe(
+      Effect.mapError(invalidCredentials),
+    );
+    return { type: "current", credentials };
+  }
+  return yield* invalidCredentials(version.version);
 });
+
+const migrateCredentials = (legacy: LegacyCredentialsFile): CredentialsFile => {
+  const environments = legacy.environments.map(
+    (environment) =>
+      new ManagedEnvironment({
+        project: environment.project,
+        environment: environment.environment,
+        providers: {
+          type: "combined",
+          axiom: new AxiomEnvironment({
+            tokenId: environment.axiomTokenId,
+            token: environment.axiomToken,
+            tracesDataset: environment.tracesDataset,
+            logsDataset: environment.logsDataset,
+            metricsDataset: environment.metricsDataset,
+          }),
+          sentry: new SentryEnvironment({
+            project: environment.sentryProject,
+            dsn: environment.sentryDsn,
+          }),
+        },
+      }),
+  );
+  if (legacy.axiom !== undefined && legacy.sentry !== undefined) {
+    return new CredentialsFile({
+      version: 2,
+      axiom: legacy.axiom,
+      sentry: legacy.sentry,
+      environments,
+    });
+  }
+  if (legacy.axiom !== undefined) {
+    return new CredentialsFile({ version: 2, axiom: legacy.axiom, environments });
+  }
+  if (legacy.sentry !== undefined) {
+    return new CredentialsFile({ version: 2, sentry: legacy.sentry, environments });
+  }
+  return new CredentialsFile({ version: 2, environments });
+};
+
+export type CredentialsAccess = {
+  load(): Effect.Effect<Option.Option<CredentialsFile>, CredentialsError>;
+  save(credentials: CredentialsFile): Effect.Effect<void, CredentialsError>;
+};
+
+type ExclusiveCredentials = <A, E, R>(
+  use: (access: CredentialsAccess) => Effect.Effect<A, E, R>,
+) => Effect.Effect<A, E | CredentialsError, R>;
 
 export class CredentialsStore extends Context.Service<
   CredentialsStore,
   {
     load(): Effect.Effect<Option.Option<CredentialsFile>, CredentialsError>;
     save(credentials: CredentialsFile): Effect.Effect<void, CredentialsError>;
+    exclusive: ExclusiveCredentials;
     path: string;
   }
 >()("@equipe-tech/observability-cli/CredentialsStore") {
@@ -116,11 +249,127 @@ export class CredentialsStore extends Context.Service<
       const root =
         environment.OBSERVABILITY_HOME ?? path.join(homedir(), ".local", "state", "observability");
       const credentialsPath = path.join(root, "credentials.json");
+      const lockPath = path.join(root, ".credentials.lock");
+      const lockOwnerPath = path.join(lockPath, "owner.json");
 
-      const load = Effect.fn("CredentialsStore.load")(function* () {
+      const prepareRoot = Effect.fn("CredentialsStore.prepareRoot")(function* () {
+        yield* fs
+          .makeDirectory(root, { recursive: true, mode: 0o700 })
+          .pipe(Effect.mapError(credentialsFailure));
+        yield* fs.chmod(root, 0o700).pipe(Effect.mapError(credentialsFailure));
+      });
+
+      const writeLockOwner = Effect.fn("CredentialsStore.writeLockOwner")(function* (
+        nonce: string,
+      ) {
+        const heartbeat = yield* Clock.currentTimeMillis;
+        const temporaryPath = path.join(lockPath, `owner-${nonce}-${crypto.randomUUID()}.tmp`);
+        const content = `${JSON.stringify({ nonce, pid: process.pid, heartbeat })}\n`;
+        yield* fs
+          .writeFileString(temporaryPath, content, { mode: 0o600 })
+          .pipe(Effect.mapError(credentialsFailure));
+        yield* fs.chmod(temporaryPath, 0o600).pipe(Effect.mapError(credentialsFailure));
+        yield* fs.rename(temporaryPath, lockOwnerPath).pipe(Effect.mapError(credentialsFailure));
+      });
+
+      const lockAge = Effect.fn("CredentialsStore.lockAge")(function* () {
+        const now = yield* Clock.currentTimeMillis;
+        const content = yield* fs.readFileString(lockOwnerPath).pipe(Effect.option);
+        if (Option.isSome(content)) {
+          const parsed = yield* Effect.try((): unknown => JSON.parse(content.value)).pipe(
+            Effect.flatMap(decodeLockOwner),
+            Effect.option,
+          );
+          if (Option.isSome(parsed)) {
+            return now - parsed.value.heartbeat;
+          }
+        }
+        const info = yield* fs.stat(lockPath).pipe(Effect.option);
+        if (Option.isSome(info) && Option.isSome(info.value.mtime)) {
+          return now - info.value.mtime.value.getTime();
+        }
+        return 0;
+      });
+
+      const reclaimStaleLock = Effect.fn("CredentialsStore.reclaimStaleLock")(function* () {
+        const age = yield* lockAge();
+        if (age <= 30_000) {
+          return false;
+        }
+        const tombstone = `${lockPath}.stale-${crypto.randomUUID()}`;
+        const renamed = yield* fs.rename(lockPath, tombstone).pipe(
+          Effect.as(true),
+          Effect.catch(() => Effect.succeed(false)),
+        );
+        if (!renamed) {
+          return false;
+        }
+        yield* fs
+          .remove(tombstone, { recursive: true, force: true })
+          .pipe(Effect.mapError(credentialsFailure));
+        return true;
+      });
+
+      const acquireLock = Effect.fn("CredentialsStore.acquireLock")(function* () {
+        yield* prepareRoot();
+        const nonce = crypto.randomUUID();
+        const started = yield* Clock.currentTimeMillis;
+        while (true) {
+          const acquired = yield* fs.makeDirectory(lockPath, { mode: 0o700 }).pipe(
+            Effect.as(true),
+            Effect.catch(() => Effect.succeed(false)),
+          );
+          if (acquired) {
+            return yield* writeLockOwner(nonce).pipe(
+              Effect.as(nonce),
+              Effect.catch((error) =>
+                fs
+                  .remove(lockPath, { recursive: true, force: true })
+                  .pipe(Effect.ignore, Effect.andThen(Effect.fail(error))),
+              ),
+            );
+          }
+          yield* reclaimStaleLock();
+          const now = yield* Clock.currentTimeMillis;
+          if (now - started >= 30_000) {
+            return yield* new CredentialsError({
+              code: "OBS_CLI_CREDENTIALS_BUSY",
+              message:
+                "Another observability command is updating credentials. Retry after it finishes.",
+              cause: "credentials-lock-timeout",
+            });
+          }
+          yield* Effect.sleep("100 millis");
+        }
+      });
+
+      const heartbeat = Effect.fn("CredentialsStore.heartbeat")(function* (nonce: string) {
+        while (true) {
+          yield* Effect.sleep("1 second");
+          yield* writeLockOwner(nonce);
+        }
+      });
+
+      const releaseLock = Effect.fn("CredentialsStore.releaseLock")(function* (nonce: string) {
+        const content = yield* fs.readFileString(lockOwnerPath).pipe(Effect.option);
+        if (Option.isNone(content)) {
+          return;
+        }
+        const owner = yield* Effect.try((): unknown => JSON.parse(content.value)).pipe(
+          Effect.flatMap(decodeLockOwner),
+          Effect.option,
+        );
+        if (Option.isSome(owner) && owner.value.nonce === nonce) {
+          yield* fs
+            .remove(lockPath, { recursive: true, force: true })
+            .pipe(Effect.mapError(credentialsFailure));
+        }
+      });
+
+      const loadPersisted = Effect.fn("CredentialsStore.loadPersisted")(function* () {
         const exists = yield* fs.exists(credentialsPath).pipe(Effect.mapError(credentialsFailure));
         if (!exists) {
-          return Option.none();
+          return Option.none<PersistedCredentials>();
         }
         const info = yield* fs.stat(credentialsPath).pipe(Effect.mapError(credentialsFailure));
         if ((info.mode & 0o077) !== 0) {
@@ -137,24 +386,90 @@ export class CredentialsStore extends Context.Service<
         return Option.some(yield* parseCredentials(content));
       });
 
-      const save = Effect.fn("CredentialsStore.save")(function* (credentials: CredentialsFile) {
-        yield* fs
-          .makeDirectory(root, { recursive: true })
-          .pipe(Effect.mapError(credentialsFailure));
-        yield* fs.chmod(root, 0o700).pipe(Effect.mapError(credentialsFailure));
-        const temporaryPath = `${credentialsPath}.tmp`;
-        const content = `${JSON.stringify(credentials, undefined, 2)}\n`;
-        yield* fs
-          .writeFileString(temporaryPath, content, { mode: 0o600 })
-          .pipe(Effect.mapError(credentialsFailure));
-        yield* fs.chmod(temporaryPath, 0o600).pipe(Effect.mapError(credentialsFailure));
-        yield* fs.rename(temporaryPath, credentialsPath).pipe(Effect.mapError(credentialsFailure));
+      const saveUnlocked = Effect.fn("CredentialsStore.saveUnlocked")(function* (
+        credentials: CredentialsFile,
+      ) {
+        yield* prepareRoot();
+        const temporaryPath = `${credentialsPath}.${process.pid}.${crypto.randomUUID()}.tmp`;
+        const content = new TextEncoder().encode(`${JSON.stringify(credentials, undefined, 2)}\n`);
+        const write = Effect.scoped(
+          Effect.gen(function* () {
+            const file = yield* fs
+              .open(temporaryPath, { flag: "wx", mode: 0o600 })
+              .pipe(Effect.mapError(credentialsFailure));
+            yield* file.writeAll(content).pipe(Effect.mapError(credentialsFailure));
+            yield* file.sync.pipe(Effect.mapError(credentialsFailure));
+          }),
+        );
+        yield* Effect.gen(function* () {
+          yield* write;
+          yield* fs.chmod(temporaryPath, 0o600).pipe(Effect.mapError(credentialsFailure));
+          yield* fs
+            .rename(temporaryPath, credentialsPath)
+            .pipe(Effect.mapError(credentialsFailure));
+          yield* fs.chmod(credentialsPath, 0o600).pipe(Effect.mapError(credentialsFailure));
+          yield* Effect.scoped(
+            Effect.gen(function* () {
+              const directory = yield* fs
+                .open(root, { flag: "r" })
+                .pipe(Effect.mapError(credentialsFailure));
+              yield* directory.sync.pipe(Effect.mapError(credentialsFailure));
+            }),
+          );
+          const info = yield* fs.stat(credentialsPath).pipe(Effect.mapError(credentialsFailure));
+          if ((info.mode & 0o777) !== 0o600) {
+            return yield* credentialsFailure(info.mode);
+          }
+        }).pipe(Effect.ensuring(fs.remove(temporaryPath, { force: true }).pipe(Effect.ignore)));
       });
 
-      return CredentialsStore.of({ load, save, path: credentialsPath });
+      const loadCurrentUnlocked = Effect.fn("CredentialsStore.loadCurrentUnlocked")(function* () {
+        const persisted = yield* loadPersisted();
+        if (Option.isNone(persisted)) {
+          return Option.none<CredentialsFile>();
+        }
+        if (persisted.value.type === "current") {
+          return Option.some(persisted.value.credentials);
+        }
+        const migrated = migrateCredentials(persisted.value.credentials);
+        yield* saveUnlocked(migrated);
+        return Option.some(migrated);
+      });
+
+      const access: CredentialsAccess = {
+        load: loadCurrentUnlocked,
+        save: saveUnlocked,
+      };
+
+      const exclusive: ExclusiveCredentials = (use) =>
+        Effect.acquireUseRelease(
+          Effect.gen(function* () {
+            const nonce = yield* acquireLock();
+            const fiber = yield* heartbeat(nonce).pipe(Effect.forkChild);
+            return { nonce, fiber };
+          }),
+          () => use(access),
+          ({ fiber, nonce }) => Fiber.interrupt(fiber).pipe(Effect.andThen(releaseLock(nonce))),
+        );
+
+      const load = Effect.fn("CredentialsStore.load")(function* () {
+        const persisted = yield* loadPersisted();
+        if (Option.isNone(persisted)) {
+          return Option.none<CredentialsFile>();
+        }
+        if (persisted.value.type === "current") {
+          return Option.some(persisted.value.credentials);
+        }
+        return yield* exclusive((locked) => locked.load());
+      });
+
+      const save = (credentials: CredentialsFile): Effect.Effect<void, CredentialsError> =>
+        exclusive((locked) => locked.save(credentials));
+
+      return CredentialsStore.of({ load, save, exclusive, path: credentialsPath });
     }),
   );
 }
 
 export const emptyCredentials = (): CredentialsFile =>
-  new CredentialsFile({ version: 1, environments: [] });
+  new CredentialsFile({ version: 2, environments: [] });

--- a/packages/cli/src/CredentialsStore.ts
+++ b/packages/cli/src/CredentialsStore.ts
@@ -1,4 +1,4 @@
-import { Clock, Context, Effect, Fiber, FileSystem, Layer, Option, Path, Schema } from "effect";
+import { Clock, Context, Effect, FileSystem, Layer, Option, Path, Schema } from "effect";
 import { homedir } from "node:os";
 
 const CredentialsEnvironment = Schema.Struct({
@@ -288,11 +288,13 @@ export class CredentialsStore extends Context.Service<
         const heartbeat = yield* Clock.currentTimeMillis;
         const target = heartbeatPath(nonce);
         const temporaryPath = `${target}.${crypto.randomUUID()}.tmp`;
-        yield* fs
-          .writeFileString(temporaryPath, `${heartbeat}\n`, { mode: 0o600 })
-          .pipe(Effect.mapError(credentialsFailure));
-        yield* fs.chmod(temporaryPath, 0o600).pipe(Effect.mapError(credentialsFailure));
-        yield* fs.rename(temporaryPath, target).pipe(Effect.mapError(credentialsFailure));
+        yield* Effect.gen(function* () {
+          yield* fs
+            .writeFileString(temporaryPath, `${heartbeat}\n`, { mode: 0o600 })
+            .pipe(Effect.mapError(credentialsFailure));
+          yield* fs.chmod(temporaryPath, 0o600).pipe(Effect.mapError(credentialsFailure));
+          yield* fs.rename(temporaryPath, target).pipe(Effect.mapError(credentialsFailure));
+        }).pipe(Effect.ensuring(fs.remove(temporaryPath, { force: true }).pipe(Effect.ignore)));
       });
 
       const lockOwner = Effect.fn("CredentialsStore.lockOwner")(function* (ownerPath: string) {
@@ -304,6 +306,15 @@ export class CredentialsStore extends Context.Service<
           Effect.flatMap(decodeLockOwner),
           Effect.option,
         );
+      });
+
+      const assertLockOwnership = Effect.fn("CredentialsStore.assertLockOwnership")(function* (
+        nonce: string,
+      ) {
+        const owner = yield* lockOwner(lockOwnerPath);
+        if (Option.isNone(owner) || owner.value.nonce !== nonce) {
+          return yield* credentialsFailure("credentials-lock-ownership-lost");
+        }
       });
 
       const lockAge = Effect.fn("CredentialsStore.lockAge")(function* () {
@@ -326,6 +337,48 @@ export class CredentialsStore extends Context.Service<
         return 0;
       });
 
+      const artifactAge = Effect.fn("CredentialsStore.artifactAge")(function* (
+        artifactPath: string,
+      ) {
+        const now = yield* Clock.currentTimeMillis;
+        const info = yield* fs.stat(artifactPath).pipe(Effect.option);
+        if (Option.isSome(info) && Option.isSome(info.value.mtime)) {
+          return Option.some(now - info.value.mtime.value.getTime());
+        }
+        return Option.none<number>();
+      });
+
+      const cleanupStaleLockArtifacts = Effect.fn("CredentialsStore.cleanupStaleLockArtifacts")(
+        function* () {
+          const owner = yield* lockOwner(lockOwnerPath);
+          const activeNonce = Option.map(owner, (current) => current.nonce);
+          const entries = yield* fs.readDirectory(root).pipe(Effect.mapError(credentialsFailure));
+          for (const entry of entries) {
+            const candidate = entry.startsWith(".credentials.lock.candidate-");
+            const heartbeat = entry.startsWith(".credentials.heartbeat-");
+            const tombstone =
+              entry.startsWith(".credentials.lock.released-") ||
+              entry.startsWith(".credentials.lock.stale-");
+            if (!candidate && !heartbeat && !tombstone) {
+              continue;
+            }
+            if (heartbeat) {
+              const nonce = entry.slice(".credentials.heartbeat-".length);
+              if (Option.contains(activeNonce, nonce)) {
+                continue;
+              }
+            }
+            const artifactPath = path.join(root, entry);
+            const age = yield* artifactAge(artifactPath);
+            if (Option.isSome(age) && age.value > 60_000) {
+              yield* fs
+                .remove(artifactPath, { recursive: candidate || tombstone, force: true })
+                .pipe(Effect.mapError(credentialsFailure));
+            }
+          }
+        },
+      );
+
       const reclaimStaleLock = Effect.fn("CredentialsStore.reclaimStaleLock")(function* () {
         const age = yield* lockAge();
         if (age <= 30_000) {
@@ -340,6 +393,22 @@ export class CredentialsStore extends Context.Service<
         if (!renamed) {
           return false;
         }
+        const reclaimedOwner = yield* lockOwner(path.join(tombstone, "owner.json"));
+        const sameGeneration = Option.match(owner, {
+          onNone: () => Option.isNone(reclaimedOwner),
+          onSome: (observed) =>
+            Option.isSome(reclaimedOwner) && reclaimedOwner.value.nonce === observed.nonce,
+        });
+        if (!sameGeneration) {
+          const restored = yield* fs.rename(tombstone, lockPath).pipe(
+            Effect.as(true),
+            Effect.catch(() => Effect.succeed(false)),
+          );
+          if (!restored) {
+            return yield* credentialsFailure("credentials-lock-reclaim-generation-changed");
+          }
+          return false;
+        }
         yield* fs
           .remove(tombstone, { recursive: true, force: true })
           .pipe(Effect.mapError(credentialsFailure));
@@ -351,6 +420,7 @@ export class CredentialsStore extends Context.Service<
 
       const acquireLock = Effect.fn("CredentialsStore.acquireLock")(function* () {
         yield* prepareRoot();
+        yield* cleanupStaleLockArtifacts();
         const nonce = crypto.randomUUID();
         const candidatePath = `${lockPath}.candidate-${nonce}`;
         const started = yield* Clock.currentTimeMillis;
@@ -398,6 +468,7 @@ export class CredentialsStore extends Context.Service<
       const heartbeat = Effect.fn("CredentialsStore.heartbeat")(function* (nonce: string) {
         while (true) {
           yield* Effect.sleep("1 second");
+          yield* assertLockOwnership(nonce);
           yield* writeHeartbeat(nonce);
         }
       });
@@ -405,9 +476,21 @@ export class CredentialsStore extends Context.Service<
       const releaseLock = Effect.fn("CredentialsStore.releaseLock")(function* (nonce: string) {
         const owner = yield* lockOwner(lockOwnerPath);
         if (Option.isSome(owner) && owner.value.nonce === nonce) {
-          yield* fs
-            .remove(lockPath, { recursive: true, force: true })
-            .pipe(Effect.mapError(credentialsFailure));
+          const tombstone = `${lockPath}.released-${nonce}-${crypto.randomUUID()}`;
+          const renamed = yield* fs.rename(lockPath, tombstone).pipe(
+            Effect.as(true),
+            Effect.catch(() => Effect.succeed(false)),
+          );
+          if (renamed) {
+            const releasedOwner = yield* lockOwner(path.join(tombstone, "owner.json"));
+            if (Option.isSome(releasedOwner) && releasedOwner.value.nonce === nonce) {
+              yield* fs
+                .remove(tombstone, { recursive: true, force: true })
+                .pipe(Effect.mapError(credentialsFailure));
+            } else {
+              return yield* credentialsFailure("credentials-lock-generation-changed");
+            }
+          }
         }
         yield* fs.remove(heartbeatPath(nonce), { force: true }).pipe(Effect.ignore);
       });
@@ -469,7 +552,9 @@ export class CredentialsStore extends Context.Service<
         }).pipe(Effect.ensuring(fs.remove(temporaryPath, { force: true }).pipe(Effect.ignore)));
       });
 
-      const loadCurrentUnlocked = Effect.fn("CredentialsStore.loadCurrentUnlocked")(function* () {
+      const loadCurrentUnlocked = Effect.fn("CredentialsStore.loadCurrentUnlocked")(function* (
+        save: CredentialsAccess["save"],
+      ) {
         const persisted = yield* loadPersisted();
         if (Option.isNone(persisted)) {
           return Option.none<CredentialsFile>();
@@ -478,24 +563,23 @@ export class CredentialsStore extends Context.Service<
           return Option.some(persisted.value.credentials);
         }
         const migrated = migrateCredentials(persisted.value.credentials);
-        yield* saveUnlocked(migrated);
+        yield* save(migrated);
         return Option.some(migrated);
       });
 
-      const access: CredentialsAccess = {
-        load: loadCurrentUnlocked,
-        save: saveUnlocked,
-      };
-
       const exclusive: ExclusiveCredentials = (use) =>
         Effect.acquireUseRelease(
-          Effect.gen(function* () {
-            const nonce = yield* acquireLock();
-            const fiber = yield* heartbeat(nonce).pipe(Effect.forkChild);
-            return { nonce, fiber };
-          }),
-          () => use(access),
-          ({ fiber, nonce }) => Fiber.interrupt(fiber).pipe(Effect.andThen(releaseLock(nonce))),
+          acquireLock(),
+          (nonce) => {
+            const save = (credentials: CredentialsFile): Effect.Effect<void, CredentialsError> =>
+              assertLockOwnership(nonce).pipe(Effect.andThen(saveUnlocked(credentials)));
+            const access: CredentialsAccess = {
+              load: () => loadCurrentUnlocked(save),
+              save,
+            };
+            return use(access).pipe(Effect.raceFirst(heartbeat(nonce)));
+          },
+          releaseLock,
         );
 
       const load = Effect.fn("CredentialsStore.load")(function* () {

--- a/packages/cli/src/ProviderApis.ts
+++ b/packages/cli/src/ProviderApis.ts
@@ -109,24 +109,13 @@ const remoteRequest = Effect.fn("remoteRequest")(function* (
   init: RequestInit,
 ): Effect.fn.Return<RemoteResponse, RemoteApiError> {
   const response = yield* Effect.tryPromise({
-    try: (signal) => fetch(url, { ...init, signal }),
+    try: (signal) => fetch(url, { ...init, redirect: "error", signal }),
     catch: (cause) =>
       new RemoteApiError({
         code: "OBS_CLI_REMOTE_FAILED",
         message: `${provider} could not be reached. Check the network connection and retry.`,
         provider,
         status: 0,
-        cause,
-      }),
-  });
-  const content = yield* Effect.tryPromise({
-    try: () => response.text(),
-    catch: (cause) =>
-      new RemoteApiError({
-        code: "OBS_CLI_REMOTE_FAILED",
-        message: `${provider} returned an unreadable response. Retry the command.`,
-        provider,
-        status: response.status,
         cause,
       }),
   });
@@ -139,6 +128,17 @@ const remoteRequest = Effect.fn("remoteRequest")(function* (
       cause: response.status,
     });
   }
+  const content = yield* Effect.tryPromise({
+    try: () => response.text(),
+    catch: (cause) =>
+      new RemoteApiError({
+        code: "OBS_CLI_REMOTE_FAILED",
+        message: `${provider} returned an unreadable response. Retry the command.`,
+        provider,
+        status: response.status,
+        cause,
+      }),
+  });
   return { status: response.status, content };
 });
 

--- a/packages/cli/src/ProviderApis.ts
+++ b/packages/cli/src/ProviderApis.ts
@@ -35,6 +35,12 @@ const decodeAxiomTokenSecret = Schema.decodeUnknownEffect(AxiomTokenSecret);
 const decodeSentryOrganization = Schema.decodeUnknownEffect(SentryOrganization);
 const decodeSentryProject = Schema.decodeUnknownEffect(SentryProject);
 const decodeSentryClientKeys = Schema.decodeUnknownEffect(SentryClientKeys);
+const AxiomTestEnvironment = Schema.Struct({
+  NODE_ENV: Schema.NonEmptyString.pipe(Schema.optionalKey),
+  OBSERVABILITY_CLI_TEST_AXIOM_BASE_URL: Schema.NonEmptyString.pipe(Schema.optionalKey),
+});
+const decodeAxiomTestEnvironment = Schema.decodeUnknownEffect(AxiomTestEnvironment);
+const decodeAxiomTestUrl = Schema.decodeUnknownEffect(Schema.URLFromString);
 
 export class RemoteApiError extends Schema.TaggedError<RemoteApiError>()("RemoteApiError", {
   code: Schema.Literals([
@@ -49,6 +55,48 @@ export class RemoteApiError extends Schema.TaggedError<RemoteApiError>()("Remote
 }) {}
 
 type Provider = "Axiom" | "Sentry";
+
+const invalidAxiomTestEndpoint = (cause: unknown): RemoteApiError =>
+  new RemoteApiError({
+    code: "OBS_CLI_REMOTE_FAILED",
+    message: "The internal Axiom test endpoint is invalid.",
+    provider: "Axiom",
+    status: 0,
+    cause,
+  });
+
+const resolveAxiomBaseUrl = Effect.fn("resolveAxiomBaseUrl")(function* () {
+  const environment = yield* decodeAxiomTestEnvironment(process.env).pipe(
+    Effect.mapError(invalidAxiomTestEndpoint),
+  );
+  const configured = environment.OBSERVABILITY_CLI_TEST_AXIOM_BASE_URL;
+  if (configured === undefined) {
+    return new URL("https://api.axiom.co");
+  }
+  if (environment.NODE_ENV !== "test") {
+    return yield* invalidAxiomTestEndpoint("NODE_ENV");
+  }
+  const endpoint = yield* decodeAxiomTestUrl(configured).pipe(
+    Effect.mapError(invalidAxiomTestEndpoint),
+  );
+  const host = endpoint.hostname;
+  const ipv4Loopback = /^127(?:[.]\d{1,3}){3}$/.test(host);
+  const ipv6Loopback = host === "[::1]";
+  const hasCredentials = endpoint.username !== "" || endpoint.password !== "";
+  if (endpoint.protocol !== "http:" || (!ipv4Loopback && !ipv6Loopback) || hasCredentials) {
+    return yield* invalidAxiomTestEndpoint(configured);
+  }
+  if (ipv4Loopback) {
+    const octets = host.split(".").map(Number);
+    if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) {
+      return yield* invalidAxiomTestEndpoint(configured);
+    }
+  }
+  return endpoint;
+});
+
+const axiomUrl = (baseUrl: URL, remotePath: string): string =>
+  new URL(remotePath, `${baseUrl.toString().replace(/\/$/, "")}/`).toString();
 
 type RemoteResponse = {
   readonly status: number;
@@ -163,82 +211,85 @@ export class AxiomApi extends Context.Service<
     ): Effect.Effect<{ readonly id: string; readonly token: string }, RemoteApiError>;
   }
 >()("@equipe-tech/observability-cli/AxiomApi") {
-  static readonly layer = Layer.succeed(
+  static readonly layer = Layer.effect(
     AxiomApi,
-    AxiomApi.of({
-      identity: Effect.fn("AxiomApi.identity")(function* (credentials) {
-        const response = yield* remoteRequest("Axiom", "https://api.axiom.co/v2/user", {
-          headers: axiomHeaders(credentials),
-        });
-        yield* expectStatus("Axiom", response, [200]);
-        const value = yield* parseRemoteJson("Axiom", response);
-        const user = yield* decodeAxiomUser(value).pipe(
-          Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
-        );
-        return user.email;
-      }),
-      datasets: Effect.fn("AxiomApi.datasets")(function* (credentials) {
-        const response = yield* remoteRequest("Axiom", "https://api.axiom.co/v2/datasets", {
-          headers: axiomHeaders(credentials),
-        });
-        yield* expectStatus("Axiom", response, [200]);
-        const value = yield* parseRemoteJson("Axiom", response);
-        const datasets = yield* decodeAxiomDatasets(value).pipe(
-          Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
-        );
-        return datasets.map((dataset) => dataset.name);
-      }),
-      createDataset: Effect.fn("AxiomApi.createDataset")(function* (credentials, name) {
-        const response = yield* remoteRequest("Axiom", "https://api.axiom.co/v2/datasets", {
-          method: "POST",
-          headers: axiomHeaders(credentials),
-          body: JSON.stringify({ name, description: `OpenTelemetry data for ${name}` }),
-        });
-        yield* expectStatus("Axiom", response, [200, 201, 409]);
-      }),
-      tokens: Effect.fn("AxiomApi.tokens")(function* (credentials) {
-        const response = yield* remoteRequest("Axiom", "https://api.axiom.co/v2/tokens", {
-          headers: axiomHeaders(credentials),
-        });
-        yield* expectStatus("Axiom", response, [200]);
-        const value = yield* parseRemoteJson("Axiom", response);
-        return yield* decodeAxiomTokens(value).pipe(
-          Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
-        );
-      }),
-      createToken: Effect.fn("AxiomApi.createToken")(function* (credentials, name, datasets) {
-        const datasetCapabilities = Object.fromEntries(
-          datasets.map((dataset) => [dataset, { ingest: ["create"] }]),
-        );
-        const response = yield* remoteRequest("Axiom", "https://api.axiom.co/v2/tokens", {
-          method: "POST",
-          headers: axiomHeaders(credentials),
-          body: JSON.stringify({
-            name,
-            description: `Collector ingest token for ${name}`,
-            datasetCapabilities,
-            orgCapabilities: {},
-            viewCapabilities: {},
-          }),
-        });
-        yield* expectStatus("Axiom", response, [200, 201]);
-        const value = yield* parseRemoteJson("Axiom", response);
-        return yield* decodeAxiomTokenSecret(value).pipe(
-          Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
-        );
-      }),
-      regenerateToken: Effect.fn("AxiomApi.regenerateToken")(function* (credentials, id) {
-        const response = yield* remoteRequest(
-          "Axiom",
-          `https://api.axiom.co/v2/tokens/${encodeURIComponent(id)}/regenerate`,
-          { method: "POST", headers: axiomHeaders(credentials) },
-        );
-        yield* expectStatus("Axiom", response, [200]);
-        const value = yield* parseRemoteJson("Axiom", response);
-        return yield* decodeAxiomTokenSecret(value).pipe(
-          Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
-        );
-      }),
+    Effect.gen(function* () {
+      const baseUrl = yield* resolveAxiomBaseUrl();
+      return AxiomApi.of({
+        identity: Effect.fn("AxiomApi.identity")(function* (credentials) {
+          const response = yield* remoteRequest("Axiom", axiomUrl(baseUrl, "/v2/user"), {
+            headers: axiomHeaders(credentials),
+          });
+          yield* expectStatus("Axiom", response, [200]);
+          const value = yield* parseRemoteJson("Axiom", response);
+          const user = yield* decodeAxiomUser(value).pipe(
+            Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
+          );
+          return user.email;
+        }),
+        datasets: Effect.fn("AxiomApi.datasets")(function* (credentials) {
+          const response = yield* remoteRequest("Axiom", axiomUrl(baseUrl, "/v2/datasets"), {
+            headers: axiomHeaders(credentials),
+          });
+          yield* expectStatus("Axiom", response, [200]);
+          const value = yield* parseRemoteJson("Axiom", response);
+          const datasets = yield* decodeAxiomDatasets(value).pipe(
+            Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
+          );
+          return datasets.map((dataset) => dataset.name);
+        }),
+        createDataset: Effect.fn("AxiomApi.createDataset")(function* (credentials, name) {
+          const response = yield* remoteRequest("Axiom", axiomUrl(baseUrl, "/v2/datasets"), {
+            method: "POST",
+            headers: axiomHeaders(credentials),
+            body: JSON.stringify({ name, description: `OpenTelemetry data for ${name}` }),
+          });
+          yield* expectStatus("Axiom", response, [200, 201, 409]);
+        }),
+        tokens: Effect.fn("AxiomApi.tokens")(function* (credentials) {
+          const response = yield* remoteRequest("Axiom", axiomUrl(baseUrl, "/v2/tokens"), {
+            headers: axiomHeaders(credentials),
+          });
+          yield* expectStatus("Axiom", response, [200]);
+          const value = yield* parseRemoteJson("Axiom", response);
+          return yield* decodeAxiomTokens(value).pipe(
+            Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
+          );
+        }),
+        createToken: Effect.fn("AxiomApi.createToken")(function* (credentials, name, datasets) {
+          const datasetCapabilities = Object.fromEntries(
+            datasets.map((dataset) => [dataset, { ingest: ["create"] }]),
+          );
+          const response = yield* remoteRequest("Axiom", axiomUrl(baseUrl, "/v2/tokens"), {
+            method: "POST",
+            headers: axiomHeaders(credentials),
+            body: JSON.stringify({
+              name,
+              description: `Collector ingest token for ${name}`,
+              datasetCapabilities,
+              orgCapabilities: {},
+              viewCapabilities: {},
+            }),
+          });
+          yield* expectStatus("Axiom", response, [200, 201]);
+          const value = yield* parseRemoteJson("Axiom", response);
+          return yield* decodeAxiomTokenSecret(value).pipe(
+            Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
+          );
+        }),
+        regenerateToken: Effect.fn("AxiomApi.regenerateToken")(function* (credentials, id) {
+          const response = yield* remoteRequest(
+            "Axiom",
+            axiomUrl(baseUrl, `/v2/tokens/${encodeURIComponent(id)}/regenerate`),
+            { method: "POST", headers: axiomHeaders(credentials) },
+          );
+          yield* expectStatus("Axiom", response, [200]);
+          const value = yield* parseRemoteJson("Axiom", response);
+          return yield* decodeAxiomTokenSecret(value).pipe(
+            Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
+          );
+        }),
+      });
     }),
   );
 }

--- a/packages/cli/src/RemoteEnvironment.ts
+++ b/packages/cli/src/RemoteEnvironment.ts
@@ -371,7 +371,11 @@ const mutationOutcomeUnknown = (
   error: RemoteApiError,
   completed: ReadonlyArray<string>,
 ): RemoteApiError | RemoteEnvironmentError => {
-  if (error.status > 0 && error.status < 500 && error.code !== "OBS_CLI_REMOTE_INVALID_RESPONSE") {
+  if (
+    error.status >= 400 &&
+    error.status < 500 &&
+    error.code !== "OBS_CLI_REMOTE_INVALID_RESPONSE"
+  ) {
     return partialFailure(error, completed);
   }
   const completedText = completed.length === 0 ? "none" : completed.join(", ");

--- a/packages/cli/src/RemoteEnvironment.ts
+++ b/packages/cli/src/RemoteEnvironment.ts
@@ -1,12 +1,15 @@
 import { Context, Effect, Layer, Option, Schema } from "effect";
 import {
   AxiomCredentials,
+  AxiomEnvironment,
+  CredentialsAccess,
   CredentialsError,
   CredentialsFile,
   CredentialsStore,
   emptyCredentials,
   ManagedEnvironment,
   SentryCredentials,
+  SentryEnvironment,
 } from "./CredentialsStore.ts";
 import { AxiomApi, RemoteApiError, SentryApi } from "./ProviderApis.ts";
 
@@ -17,16 +20,25 @@ const EnvironmentName = Schema.NonEmptyString.check(
   }),
 );
 const DatasetName = Schema.NonEmptyString.check(Schema.isMaxLength(128));
+const ProviderName = Schema.Literals(["axiom", "sentry"]);
 const decodeEnvironmentName = Schema.decodeUnknownEffect(EnvironmentName);
 const decodeDatasetName = Schema.decodeUnknownEffect(DatasetName);
+const decodeProviderName = Schema.decodeUnknownEffect(ProviderName);
+
+export type ProviderName = typeof ProviderName.Type;
 
 export class RemoteEnvironmentError extends Schema.TaggedError<RemoteEnvironmentError>()(
   "RemoteEnvironmentError",
   {
     code: Schema.Literals([
       "OBS_CLI_REMOTE_CREDENTIALS_MISSING",
+      "OBS_CLI_REMOTE_PROVIDER_CREDENTIALS_MISSING",
+      "OBS_CLI_REMOTE_INVALID_PROVIDER",
       "OBS_CLI_REMOTE_INVALID_ENVIRONMENT",
+      "OBS_CLI_REMOTE_ROTATION_NOT_SELECTED",
       "OBS_CLI_REMOTE_TOKEN_UNAVAILABLE",
+      "OBS_CLI_REMOTE_PARTIAL_FAILURE",
+      "OBS_CLI_REMOTE_OUTCOME_UNKNOWN",
       "OBS_CLI_REMOTE_ENVIRONMENT_NOT_FOUND",
     ]),
     message: Schema.String,
@@ -56,6 +68,27 @@ export const parseEnvironmentName = Effect.fn("parseEnvironmentName")(function* 
   );
 });
 
+export const parseProviderSelection = Effect.fn("parseProviderSelection")(function* (
+  providers: ReadonlyArray<string>,
+): Effect.fn.Return<ReadonlyArray<ProviderName>, RemoteEnvironmentError> {
+  const selected = new Set<ProviderName>();
+  for (const provider of providers) {
+    const parsed = yield* decodeProviderName(provider).pipe(
+      Effect.mapError(
+        (cause) =>
+          new RemoteEnvironmentError({
+            code: "OBS_CLI_REMOTE_INVALID_PROVIDER",
+            message: `Provider ${provider} is invalid. Use axiom or sentry.`,
+            cause,
+          }),
+      ),
+    );
+    selected.add(parsed);
+  }
+  const canonicalProviders: ReadonlyArray<ProviderName> = ["axiom", "sentry"];
+  return canonicalProviders.filter((provider) => selected.has(provider));
+});
+
 export const environmentDatasets = Effect.fn("environmentDatasets")(function* (
   project: string,
   environment: string,
@@ -81,31 +114,57 @@ export const environmentDatasets = Effect.fn("environmentDatasets")(function* (
   return names;
 });
 
-const requiredCredentials = (
-  credentials: CredentialsFile,
-): Effect.Effect<
-  { readonly axiom: AxiomCredentials; readonly sentry: SentryCredentials },
-  RemoteEnvironmentError
-> => {
-  if (credentials.axiom === undefined || credentials.sentry === undefined) {
-    return Effect.fail(
-      new RemoteEnvironmentError({
-        code: "OBS_CLI_REMOTE_CREDENTIALS_MISSING",
-        message:
-          "Remote provisioning requires Axiom and Sentry credentials. Run observability auth login for both providers.",
-        cause: "credentials",
-      }),
-    );
+export const environmentAxiom = (
+  environment: ManagedEnvironment,
+): Option.Option<AxiomEnvironment> => {
+  if (environment.providers.type === "sentry") {
+    return Option.none();
   }
-  return Effect.succeed({ axiom: credentials.axiom, sentry: credentials.sentry });
+  return Option.some(environment.providers.axiom);
 };
 
-const currentCredentials = Effect.fn("currentCredentials")(function* (
-  store: CredentialsStore["Service"],
-): Effect.fn.Return<CredentialsFile, CredentialsError> {
-  const current = yield* store.load();
-  return Option.getOrElse(current, emptyCredentials);
-});
+export const environmentSentry = (
+  environment: ManagedEnvironment,
+): Option.Option<SentryEnvironment> => {
+  if (environment.providers.type === "axiom") {
+    return Option.none();
+  }
+  return Option.some(environment.providers.sentry);
+};
+
+export const environmentProviderNames = (
+  environment: ManagedEnvironment,
+): ReadonlyArray<ProviderName> => {
+  if (environment.providers.type === "axiom") {
+    return ["axiom"];
+  }
+  if (environment.providers.type === "sentry") {
+    return ["sentry"];
+  }
+  return ["axiom", "sentry"];
+};
+
+const makeProviders = (
+  axiom: Option.Option<AxiomEnvironment>,
+  sentry: Option.Option<SentryEnvironment>,
+): Effect.Effect<ManagedEnvironment["providers"], CredentialsError> => {
+  if (Option.isSome(axiom) && Option.isSome(sentry)) {
+    return Effect.succeed({ type: "combined", axiom: axiom.value, sentry: sentry.value });
+  }
+  if (Option.isSome(axiom)) {
+    return Effect.succeed({ type: "axiom", axiom: axiom.value });
+  }
+  if (Option.isSome(sentry)) {
+    return Effect.succeed({ type: "sentry", sentry: sentry.value });
+  }
+  return Effect.fail(
+    new CredentialsError({
+      code: "OBS_CLI_CREDENTIALS_INVALID",
+      message: "The credentials file contains an environment without a provider.",
+      cause: "empty-environment-providers",
+    }),
+  );
+};
 
 const makeCredentialsFile = (
   axiom: AxiomCredentials | undefined,
@@ -113,15 +172,15 @@ const makeCredentialsFile = (
   environments: ReadonlyArray<ManagedEnvironment>,
 ): CredentialsFile => {
   if (axiom !== undefined && sentry !== undefined) {
-    return new CredentialsFile({ version: 1, axiom, sentry, environments });
+    return new CredentialsFile({ version: 2, axiom, sentry, environments });
   }
   if (axiom !== undefined) {
-    return new CredentialsFile({ version: 1, axiom, environments });
+    return new CredentialsFile({ version: 2, axiom, environments });
   }
   if (sentry !== undefined) {
-    return new CredentialsFile({ version: 1, sentry, environments });
+    return new CredentialsFile({ version: 2, sentry, environments });
   }
-  return new CredentialsFile({ version: 1, environments });
+  return new CredentialsFile({ version: 2, environments });
 };
 
 const replaceEnvironment = (
@@ -136,6 +195,121 @@ const replaceEnvironment = (
     ),
     environment,
   ]);
+
+const currentCredentials = Effect.fn("currentCredentials")(function* (
+  access: CredentialsAccess,
+): Effect.fn.Return<CredentialsFile, CredentialsError> {
+  const current = yield* access.load();
+  return Option.getOrElse(current, emptyCredentials);
+});
+
+const existingEnvironment = (
+  credentials: CredentialsFile,
+  project: string,
+  environment: string,
+): Option.Option<ManagedEnvironment> =>
+  Option.fromNullishOr(
+    credentials.environments.find(
+      (candidate) => candidate.project === project && candidate.environment === environment,
+    ),
+  );
+
+const effectiveProviders = (
+  explicit: ReadonlyArray<ProviderName>,
+  existing: Option.Option<ManagedEnvironment>,
+): ReadonlyArray<ProviderName> => {
+  if (explicit.length > 0) {
+    return explicit;
+  }
+  if (Option.isSome(existing)) {
+    return environmentProviderNames(existing.value);
+  }
+  return ["axiom", "sentry"];
+};
+
+type RequestedEnvironment = {
+  readonly name: string;
+  readonly datasets: EnvironmentDatasets;
+  readonly existing: Option.Option<ManagedEnvironment>;
+  readonly providers: ReadonlyArray<ProviderName>;
+};
+
+const requireCredentials = Effect.fn("requireCredentials")(function* (
+  credentials: CredentialsFile,
+  providers: ReadonlySet<ProviderName>,
+): Effect.fn.Return<
+  {
+    readonly axiom: Option.Option<AxiomCredentials>;
+    readonly sentry: Option.Option<SentryCredentials>;
+  },
+  RemoteEnvironmentError
+> {
+  const axiom = Option.fromNullishOr(credentials.axiom);
+  const sentry = Option.fromNullishOr(credentials.sentry);
+  if (
+    providers.has("axiom") &&
+    providers.has("sentry") &&
+    Option.isNone(axiom) &&
+    Option.isNone(sentry)
+  ) {
+    return yield* new RemoteEnvironmentError({
+      code: "OBS_CLI_REMOTE_CREDENTIALS_MISSING",
+      message:
+        "Remote provisioning requires Axiom and Sentry credentials. Run observability auth login for both providers.",
+      cause: "axiom,sentry",
+    });
+  }
+  if (providers.has("axiom") && Option.isNone(axiom)) {
+    return yield* new RemoteEnvironmentError({
+      code: "OBS_CLI_REMOTE_PROVIDER_CREDENTIALS_MISSING",
+      message:
+        "Axiom credentials are required. Run observability auth login axiom --organization-id <organization-id>.",
+      cause: "axiom",
+    });
+  }
+  if (providers.has("sentry") && Option.isNone(sentry)) {
+    return yield* new RemoteEnvironmentError({
+      code: "OBS_CLI_REMOTE_PROVIDER_CREDENTIALS_MISSING",
+      message:
+        "Sentry credentials are required. Run observability auth login sentry --organization <organization> --team <team>.",
+      cause: "sentry",
+    });
+  }
+  return { axiom, sentry };
+});
+
+const partialFailure = (
+  error: RemoteApiError,
+  completed: ReadonlyArray<string>,
+): RemoteApiError | RemoteEnvironmentError => {
+  if (completed.length === 0) {
+    return error;
+  }
+  return new RemoteEnvironmentError({
+    code: "OBS_CLI_REMOTE_PARTIAL_FAILURE",
+    message: `${error.provider} failed after these environments were saved: ${completed.join(", ")}. Retry the command.`,
+    cause: error,
+  });
+};
+
+const mutationOutcomeUnknown = (
+  error: RemoteApiError,
+  completed: ReadonlyArray<string>,
+): RemoteApiError | RemoteEnvironmentError => {
+  if (
+    error.status !== 0 &&
+    error.code !== "OBS_CLI_REMOTE_INVALID_RESPONSE" &&
+    (error.status < 200 || error.status >= 300)
+  ) {
+    return partialFailure(error, completed);
+  }
+  const completedText = completed.length === 0 ? "none" : completed.join(", ");
+  return new RemoteEnvironmentError({
+    code: "OBS_CLI_REMOTE_OUTCOME_UNKNOWN",
+    message: `The Axiom token outcome is unknown. Rotate the token before retrying. Saved environments: ${completedText}.`,
+    cause: error,
+  });
+};
 
 export type AuthenticationStatus = {
   readonly axiom: string;
@@ -170,23 +344,33 @@ export class Authentication extends Context.Service<
         loginAxiom: Effect.fn("Authentication.loginAxiom")(function* (token, organizationId) {
           const credentials = new AxiomCredentials({ token, organizationId });
           const identity = yield* axiomApi.identity(credentials);
-          const current = yield* currentCredentials(store);
-          yield* store.save(makeCredentialsFile(credentials, current.sentry, current.environments));
+          yield* store.exclusive((access) =>
+            Effect.gen(function* () {
+              const current = yield* currentCredentials(access);
+              yield* access.save(
+                makeCredentialsFile(credentials, current.sentry, current.environments),
+              );
+            }),
+          );
           return identity;
         }),
         loginSentry: Effect.fn("Authentication.loginSentry")(
           function* (token, organization, team, baseUrl) {
             const credentials = new SentryCredentials({ token, organization, team, baseUrl });
             const identity = yield* sentryApi.identity(credentials);
-            const current = yield* currentCredentials(store);
-            yield* store.save(
-              makeCredentialsFile(current.axiom, credentials, current.environments),
+            yield* store.exclusive((access) =>
+              Effect.gen(function* () {
+                const current = yield* currentCredentials(access);
+                yield* access.save(
+                  makeCredentialsFile(current.axiom, credentials, current.environments),
+                );
+              }),
             );
             return identity;
           },
         ),
         status: Effect.fn("Authentication.status")(function* () {
-          const current = yield* currentCredentials(store);
+          const current = Option.getOrElse(yield* store.load(), emptyCredentials);
           const axiom =
             current.axiom === undefined
               ? "not authenticated"
@@ -208,6 +392,7 @@ export class RemoteEnvironment extends Context.Service<
     provision(
       project: string,
       environments: ReadonlyArray<string>,
+      providers: ReadonlyArray<ProviderName>,
       platform: string,
       rotateToken: boolean,
     ): Effect.Effect<
@@ -231,7 +416,7 @@ export class RemoteEnvironment extends Context.Service<
       const sentryApi = yield* SentryApi;
 
       const list = Effect.fn("RemoteEnvironment.list")(function* (project: Option.Option<string>) {
-        const credentials = yield* currentCredentials(store);
+        const credentials = Option.getOrElse(yield* store.load(), emptyCredentials);
         return Option.match(project, {
           onNone: () => credentials.environments,
           onSome: (name) =>
@@ -241,75 +426,194 @@ export class RemoteEnvironment extends Context.Service<
 
       return RemoteEnvironment.of({
         provision: Effect.fn("RemoteEnvironment.provision")(
-          function* (project, environments, platform, rotateToken) {
-            let credentials = yield* currentCredentials(store);
-            const providers = yield* requiredCredentials(credentials);
-            const existingDatasets = [...(yield* axiomApi.datasets(providers.axiom))];
-            const existingTokens = [...(yield* axiomApi.tokens(providers.axiom))];
-            const sentryProject = yield* sentryApi.ensureProject(
-              providers.sentry,
-              project,
-              platform,
-            );
-            const sentryDsn = yield* sentryApi.dsn(providers.sentry, sentryProject);
-            const provisioned: Array<ManagedEnvironment> = [];
-
-            for (const rawEnvironment of environments) {
-              const environment = yield* parseEnvironmentName(rawEnvironment);
-              const datasets = yield* environmentDatasets(project, environment);
-              const datasetNames = [datasets.traces, datasets.logs, datasets.metrics];
-              for (const dataset of datasetNames) {
-                if (!existingDatasets.includes(dataset)) {
-                  yield* axiomApi.createDataset(providers.axiom, dataset);
-                  existingDatasets.push(dataset);
-                }
-              }
-
-              const tokenName = `${project}-${environment}-collector`;
-              const remoteToken = existingTokens.find((token) => token.name === tokenName);
-              const managed = credentials.environments.find(
-                (candidate) =>
-                  candidate.project === project && candidate.environment === environment,
-              );
-              let token: { readonly id: string; readonly token: string };
-              if (rotateToken && remoteToken !== undefined) {
-                token = yield* axiomApi.regenerateToken(providers.axiom, remoteToken.id);
-              } else if (managed !== undefined && !rotateToken) {
-                if (remoteToken === undefined || remoteToken.id !== managed.axiomTokenId) {
-                  return yield* new RemoteEnvironmentError({
-                    code: "OBS_CLI_REMOTE_TOKEN_UNAVAILABLE",
-                    message: `The stored token for ${project}/${environment} does not match Axiom. Rerun with --rotate-token.`,
-                    cause: tokenName,
+          function* (
+            project,
+            environments,
+            explicitProviders,
+            platform,
+            rotateToken,
+          ): Effect.fn.Return<
+            ReadonlyArray<ManagedEnvironment>,
+            CredentialsError | RemoteApiError | RemoteEnvironmentError
+          > {
+            return yield* store.exclusive((access) =>
+              Effect.gen(function* () {
+                let credentials = yield* currentCredentials(access);
+                const requested: Array<RequestedEnvironment> = [];
+                for (const rawEnvironment of environments) {
+                  const name = yield* parseEnvironmentName(rawEnvironment);
+                  const datasets = yield* environmentDatasets(project, name);
+                  const existing = existingEnvironment(credentials, project, name);
+                  requested.push({
+                    name,
+                    datasets,
+                    existing,
+                    providers: effectiveProviders(explicitProviders, existing),
                   });
                 }
-                token = { id: managed.axiomTokenId, token: managed.axiomToken };
-              } else if (remoteToken !== undefined) {
-                return yield* new RemoteEnvironmentError({
-                  code: "OBS_CLI_REMOTE_TOKEN_UNAVAILABLE",
-                  message: `Axiom already contains token ${tokenName}, but its secret is unavailable. Rerun with --rotate-token.`,
-                  cause: tokenName,
-                });
-              } else {
-                token = yield* axiomApi.createToken(providers.axiom, tokenName, datasetNames);
-                existingTokens.push({ id: token.id, name: tokenName });
-              }
+                if (
+                  rotateToken &&
+                  requested.some((environment) => !environment.providers.includes("axiom"))
+                ) {
+                  return yield* new RemoteEnvironmentError({
+                    code: "OBS_CLI_REMOTE_ROTATION_NOT_SELECTED",
+                    message:
+                      "Token rotation requires Axiom for every requested environment. Select --provider axiom or remove --rotate-token.",
+                    cause: "rotate-token",
+                  });
+                }
 
-              const result = new ManagedEnvironment({
-                project,
-                environment,
-                axiomTokenId: token.id,
-                axiomToken: token.token,
-                tracesDataset: datasets.traces,
-                logsDataset: datasets.logs,
-                metricsDataset: datasets.metrics,
-                sentryProject,
-                sentryDsn,
-              });
-              credentials = replaceEnvironment(credentials, result);
-              yield* store.save(credentials);
-              provisioned.push(result);
-            }
-            return provisioned;
+                const selected = new Set(requested.flatMap((environment) => environment.providers));
+                const providerCredentials = yield* requireCredentials(credentials, selected);
+                const axiomCredentials = providerCredentials.axiom;
+                const sentryCredentials = providerCredentials.sentry;
+
+                let sentry = Option.none<SentryEnvironment>();
+                if (selected.has("sentry") && Option.isSome(sentryCredentials)) {
+                  const sentryProject = yield* sentryApi.ensureProject(
+                    sentryCredentials.value,
+                    project,
+                    platform,
+                  );
+                  const sentryDsn = yield* sentryApi.dsn(sentryCredentials.value, sentryProject);
+                  sentry = Option.some(
+                    new SentryEnvironment({ project: sentryProject, dsn: sentryDsn }),
+                  );
+                }
+
+                const existingDatasets =
+                  selected.has("axiom") && Option.isSome(axiomCredentials)
+                    ? [...(yield* axiomApi.datasets(axiomCredentials.value))]
+                    : [];
+                const existingTokens =
+                  selected.has("axiom") && Option.isSome(axiomCredentials)
+                    ? [...(yield* axiomApi.tokens(axiomCredentials.value))]
+                    : [];
+                const completed: Array<string> = [];
+                const provisioned: Array<ManagedEnvironment> = [];
+
+                for (const request of requested) {
+                  const checkpoint: Effect.Effect<
+                    ManagedEnvironment,
+                    CredentialsError | RemoteApiError | RemoteEnvironmentError
+                  > = Effect.gen(function* () {
+                    let axiom = Option.isSome(request.existing)
+                      ? environmentAxiom(request.existing.value)
+                      : Option.none<AxiomEnvironment>();
+                    let selectedSentry = Option.isSome(request.existing)
+                      ? environmentSentry(request.existing.value)
+                      : Option.none<SentryEnvironment>();
+                    if (request.providers.includes("sentry")) {
+                      selectedSentry = sentry;
+                    }
+
+                    let tokenMutated = false;
+                    if (request.providers.includes("axiom") && Option.isSome(axiomCredentials)) {
+                      const datasetNames = [
+                        request.datasets.traces,
+                        request.datasets.logs,
+                        request.datasets.metrics,
+                      ];
+                      for (const dataset of datasetNames) {
+                        if (!existingDatasets.includes(dataset)) {
+                          yield* axiomApi.createDataset(axiomCredentials.value, dataset);
+                          existingDatasets.push(dataset);
+                        }
+                      }
+
+                      const tokenName = `${project}-${request.name}-collector`;
+                      const remoteToken = existingTokens.find((token) => token.name === tokenName);
+                      const localAxiom = Option.isSome(request.existing)
+                        ? environmentAxiom(request.existing.value)
+                        : Option.none<AxiomEnvironment>();
+                      let token: { readonly id: string; readonly token: string };
+                      if (rotateToken) {
+                        tokenMutated = true;
+                        token = yield* (
+                          remoteToken === undefined
+                            ? axiomApi.createToken(axiomCredentials.value, tokenName, datasetNames)
+                            : axiomApi.regenerateToken(axiomCredentials.value, remoteToken.id)
+                        ).pipe(
+                          Effect.catchTag("RemoteApiError", (error) =>
+                            Effect.fail(mutationOutcomeUnknown(error, completed)),
+                          ),
+                        );
+                        if (remoteToken === undefined) {
+                          existingTokens.push({ id: token.id, name: tokenName });
+                        }
+                      } else if (Option.isSome(localAxiom)) {
+                        if (
+                          remoteToken === undefined ||
+                          remoteToken.id !== localAxiom.value.tokenId
+                        ) {
+                          return yield* new RemoteEnvironmentError({
+                            code: "OBS_CLI_REMOTE_TOKEN_UNAVAILABLE",
+                            message: `The stored token for ${project}/${request.name} does not match Axiom. Rerun with --rotate-token.`,
+                            cause: tokenName,
+                          });
+                        }
+                        token = { id: localAxiom.value.tokenId, token: localAxiom.value.token };
+                      } else if (remoteToken !== undefined) {
+                        return yield* new RemoteEnvironmentError({
+                          code: "OBS_CLI_REMOTE_TOKEN_UNAVAILABLE",
+                          message: `Axiom already contains token ${tokenName}, but its secret is unavailable. Rerun with --rotate-token.`,
+                          cause: tokenName,
+                        });
+                      } else {
+                        tokenMutated = true;
+                        token = yield* axiomApi
+                          .createToken(axiomCredentials.value, tokenName, datasetNames)
+                          .pipe(
+                            Effect.catchTag("RemoteApiError", (error) =>
+                              Effect.fail(mutationOutcomeUnknown(error, completed)),
+                            ),
+                          );
+                        existingTokens.push({ id: token.id, name: tokenName });
+                      }
+                      axiom = Option.some(
+                        new AxiomEnvironment({
+                          tokenId: token.id,
+                          token: token.token,
+                          tracesDataset: request.datasets.traces,
+                          logsDataset: request.datasets.logs,
+                          metricsDataset: request.datasets.metrics,
+                        }),
+                      );
+                    }
+
+                    const environment = new ManagedEnvironment({
+                      project,
+                      environment: request.name,
+                      providers: yield* makeProviders(axiom, selectedSentry),
+                    });
+                    credentials = replaceEnvironment(credentials, environment);
+                    if (tokenMutated) {
+                      yield* access.save(credentials).pipe(
+                        Effect.mapError(
+                          (error) =>
+                            new RemoteEnvironmentError({
+                              code: "OBS_CLI_REMOTE_OUTCOME_UNKNOWN",
+                              message: `The Axiom token changed, but local state could not be saved. Rotate the token before retrying. Saved environments: ${completed.length === 0 ? "none" : completed.join(", ")}.`,
+                              cause: error,
+                            }),
+                        ),
+                      );
+                    } else {
+                      yield* access.save(credentials);
+                    }
+                    completed.push(`${project}/${request.name}`);
+                    return environment;
+                  });
+                  const result = yield* checkpoint.pipe(
+                    Effect.catchTag("RemoteApiError", (error) =>
+                      Effect.fail(partialFailure(error, completed)),
+                    ),
+                  );
+                  provisioned.push(result);
+                }
+                return provisioned;
+              }),
+            );
           },
         ),
         list,
@@ -324,16 +628,24 @@ export class RemoteEnvironment extends Context.Service<
               cause: `${project}/${environment}`,
             });
           }
-          const variables = [
+          const variables: Array<readonly [string, string]> = [
             ["OTEL_SERVICE_NAME", managed.project],
             ["OTEL_DEPLOYMENT_ENVIRONMENT", managed.environment],
-            ["OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector:4318"],
-            ["AXIOM_TOKEN", managed.axiomToken],
-            ["AXIOM_DATASET_TRACES", managed.tracesDataset],
-            ["AXIOM_DATASET_LOGS", managed.logsDataset],
-            ["AXIOM_DATASET_METRICS", managed.metricsDataset],
-            ["SENTRY_DSN", managed.sentryDsn],
           ];
+          const axiom = environmentAxiom(managed);
+          if (Option.isSome(axiom)) {
+            variables.push(
+              ["OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector:4318"],
+              ["AXIOM_TOKEN", axiom.value.token],
+              ["AXIOM_DATASET_TRACES", axiom.value.tracesDataset],
+              ["AXIOM_DATASET_LOGS", axiom.value.logsDataset],
+              ["AXIOM_DATASET_METRICS", axiom.value.metricsDataset],
+            );
+          }
+          const sentry = environmentSentry(managed);
+          if (Option.isSome(sentry)) {
+            variables.push(["SENTRY_DSN", sentry.value.dsn]);
+          }
           return variables.map(([name, value]) => `${name}=${JSON.stringify(value)}`).join("\n");
         }),
       });

--- a/packages/cli/src/RemoteEnvironment.ts
+++ b/packages/cli/src/RemoteEnvironment.ts
@@ -8,6 +8,7 @@ import {
   CredentialsStore,
   emptyCredentials,
   ManagedEnvironment,
+  PendingAxiomMutation,
   SentryCredentials,
   SentryEnvironment,
 } from "./CredentialsStore.ts";
@@ -114,6 +115,18 @@ export const environmentDatasets = Effect.fn("environmentDatasets")(function* (
   return names;
 });
 
+export const validateRemoteProvisionRequest = Effect.fn("validateRemoteProvisionRequest")(
+  function* (
+    project: string,
+    environments: ReadonlyArray<string>,
+  ): Effect.fn.Return<void, RemoteEnvironmentError> {
+    for (const rawEnvironment of environments) {
+      const environment = yield* parseEnvironmentName(rawEnvironment);
+      yield* environmentDatasets(project, environment);
+    }
+  },
+);
+
 export const environmentAxiom = (
   environment: ManagedEnvironment,
 ): Option.Option<AxiomEnvironment> => {
@@ -170,7 +183,26 @@ const makeCredentialsFile = (
   axiom: AxiomCredentials | undefined,
   sentry: SentryCredentials | undefined,
   environments: ReadonlyArray<ManagedEnvironment>,
+  pendingAxiomMutations: ReadonlyArray<PendingAxiomMutation> = [],
 ): CredentialsFile => {
+  if (pendingAxiomMutations.length > 0) {
+    if (axiom !== undefined && sentry !== undefined) {
+      return new CredentialsFile({
+        version: 2,
+        axiom,
+        sentry,
+        environments,
+        pendingAxiomMutations,
+      });
+    }
+    if (axiom !== undefined) {
+      return new CredentialsFile({ version: 2, axiom, environments, pendingAxiomMutations });
+    }
+    if (sentry !== undefined) {
+      return new CredentialsFile({ version: 2, sentry, environments, pendingAxiomMutations });
+    }
+    return new CredentialsFile({ version: 2, environments, pendingAxiomMutations });
+  }
   if (axiom !== undefined && sentry !== undefined) {
     return new CredentialsFile({ version: 2, axiom, sentry, environments });
   }
@@ -183,18 +215,61 @@ const makeCredentialsFile = (
   return new CredentialsFile({ version: 2, environments });
 };
 
+const pendingAxiomMutations = (credentials: CredentialsFile): ReadonlyArray<PendingAxiomMutation> =>
+  credentials.pendingAxiomMutations ?? [];
+
+const hasPendingAxiomMutation = (
+  credentials: CredentialsFile,
+  project: string,
+  environment: string,
+): boolean =>
+  pendingAxiomMutations(credentials).some(
+    (pending) => pending.project === project && pending.environment === environment,
+  );
+
+const markAxiomMutationPending = (
+  credentials: CredentialsFile,
+  project: string,
+  environment: string,
+): CredentialsFile =>
+  makeCredentialsFile(credentials.axiom, credentials.sentry, credentials.environments, [
+    ...pendingAxiomMutations(credentials).filter(
+      (pending) => pending.project !== project || pending.environment !== environment,
+    ),
+    new PendingAxiomMutation({ project, environment }),
+  ]);
+
+const clearPendingAxiomMutation = (
+  credentials: CredentialsFile,
+  project: string,
+  environment: string,
+): CredentialsFile =>
+  makeCredentialsFile(
+    credentials.axiom,
+    credentials.sentry,
+    credentials.environments,
+    pendingAxiomMutations(credentials).filter(
+      (pending) => pending.project !== project || pending.environment !== environment,
+    ),
+  );
+
 const replaceEnvironment = (
   credentials: CredentialsFile,
   environment: ManagedEnvironment,
 ): CredentialsFile =>
-  makeCredentialsFile(credentials.axiom, credentials.sentry, [
-    ...credentials.environments.filter(
-      (candidate) =>
-        candidate.project !== environment.project ||
-        candidate.environment !== environment.environment,
-    ),
-    environment,
-  ]);
+  makeCredentialsFile(
+    credentials.axiom,
+    credentials.sentry,
+    [
+      ...credentials.environments.filter(
+        (candidate) =>
+          candidate.project !== environment.project ||
+          candidate.environment !== environment.environment,
+      ),
+      environment,
+    ],
+    pendingAxiomMutations(credentials),
+  );
 
 const currentCredentials = Effect.fn("currentCredentials")(function* (
   access: CredentialsAccess,
@@ -296,11 +371,7 @@ const mutationOutcomeUnknown = (
   error: RemoteApiError,
   completed: ReadonlyArray<string>,
 ): RemoteApiError | RemoteEnvironmentError => {
-  if (
-    error.status !== 0 &&
-    error.code !== "OBS_CLI_REMOTE_INVALID_RESPONSE" &&
-    (error.status < 200 || error.status >= 300)
-  ) {
+  if (error.status > 0 && error.status < 500 && error.code !== "OBS_CLI_REMOTE_INVALID_RESPONSE") {
     return partialFailure(error, completed);
   }
   const completedText = completed.length === 0 ? "none" : completed.join(", ");
@@ -348,7 +419,12 @@ export class Authentication extends Context.Service<
             Effect.gen(function* () {
               const current = yield* currentCredentials(access);
               yield* access.save(
-                makeCredentialsFile(credentials, current.sentry, current.environments),
+                makeCredentialsFile(
+                  credentials,
+                  current.sentry,
+                  current.environments,
+                  pendingAxiomMutations(current),
+                ),
               );
             }),
           );
@@ -362,7 +438,12 @@ export class Authentication extends Context.Service<
               Effect.gen(function* () {
                 const current = yield* currentCredentials(access);
                 yield* access.save(
-                  makeCredentialsFile(current.axiom, credentials, current.environments),
+                  makeCredentialsFile(
+                    current.axiom,
+                    credentials,
+                    current.environments,
+                    pendingAxiomMutations(current),
+                  ),
                 );
               }),
             );
@@ -436,17 +517,23 @@ export class RemoteEnvironment extends Context.Service<
             ReadonlyArray<ManagedEnvironment>,
             CredentialsError | RemoteApiError | RemoteEnvironmentError
           > {
+            const validated: Array<{
+              readonly name: string;
+              readonly datasets: EnvironmentDatasets;
+            }> = [];
+            for (const rawEnvironment of environments) {
+              const name = yield* parseEnvironmentName(rawEnvironment);
+              validated.push({ name, datasets: yield* environmentDatasets(project, name) });
+            }
             return yield* store.exclusive((access) =>
               Effect.gen(function* () {
                 let credentials = yield* currentCredentials(access);
                 const requested: Array<RequestedEnvironment> = [];
-                for (const rawEnvironment of environments) {
-                  const name = yield* parseEnvironmentName(rawEnvironment);
-                  const datasets = yield* environmentDatasets(project, name);
-                  const existing = existingEnvironment(credentials, project, name);
+                for (const environment of validated) {
+                  const existing = existingEnvironment(credentials, project, environment.name);
                   requested.push({
-                    name,
-                    datasets,
+                    name: environment.name,
+                    datasets: environment.datasets,
                     existing,
                     providers: effectiveProviders(explicitProviders, existing),
                   });
@@ -460,6 +547,21 @@ export class RemoteEnvironment extends Context.Service<
                     message:
                       "Token rotation requires Axiom for every requested environment. Select --provider axiom or remove --rotate-token.",
                     cause: "rotate-token",
+                  });
+                }
+                if (
+                  !rotateToken &&
+                  requested.some(
+                    (environment) =>
+                      environment.providers.includes("axiom") &&
+                      hasPendingAxiomMutation(credentials, project, environment.name),
+                  )
+                ) {
+                  return yield* new RemoteEnvironmentError({
+                    code: "OBS_CLI_REMOTE_TOKEN_UNAVAILABLE",
+                    message:
+                      "A previous Axiom token mutation did not reach a durable checkpoint. Rerun with --rotate-token.",
+                    cause: "pending-axiom-mutation",
                   });
                 }
 
@@ -529,14 +631,30 @@ export class RemoteEnvironment extends Context.Service<
                       let token: { readonly id: string; readonly token: string };
                       if (rotateToken) {
                         tokenMutated = true;
+                        credentials = markAxiomMutationPending(credentials, project, request.name);
+                        yield* access.save(credentials);
                         token = yield* (
                           remoteToken === undefined
                             ? axiomApi.createToken(axiomCredentials.value, tokenName, datasetNames)
                             : axiomApi.regenerateToken(axiomCredentials.value, remoteToken.id)
                         ).pipe(
-                          Effect.catchTag("RemoteApiError", (error) =>
-                            Effect.fail(mutationOutcomeUnknown(error, completed)),
-                          ),
+                          Effect.catchTag("RemoteApiError", (error) => {
+                            const classified = mutationOutcomeUnknown(error, completed);
+                            if (
+                              classified._tag === "RemoteEnvironmentError" &&
+                              classified.code === "OBS_CLI_REMOTE_OUTCOME_UNKNOWN"
+                            ) {
+                              return Effect.fail(classified);
+                            }
+                            credentials = clearPendingAxiomMutation(
+                              credentials,
+                              project,
+                              request.name,
+                            );
+                            return access
+                              .save(credentials)
+                              .pipe(Effect.andThen(Effect.fail(classified)));
+                          }),
                         );
                         if (remoteToken === undefined) {
                           existingTokens.push({ id: token.id, name: tokenName });
@@ -561,12 +679,28 @@ export class RemoteEnvironment extends Context.Service<
                         });
                       } else {
                         tokenMutated = true;
+                        credentials = markAxiomMutationPending(credentials, project, request.name);
+                        yield* access.save(credentials);
                         token = yield* axiomApi
                           .createToken(axiomCredentials.value, tokenName, datasetNames)
                           .pipe(
-                            Effect.catchTag("RemoteApiError", (error) =>
-                              Effect.fail(mutationOutcomeUnknown(error, completed)),
-                            ),
+                            Effect.catchTag("RemoteApiError", (error) => {
+                              const classified = mutationOutcomeUnknown(error, completed);
+                              if (
+                                classified._tag === "RemoteEnvironmentError" &&
+                                classified.code === "OBS_CLI_REMOTE_OUTCOME_UNKNOWN"
+                              ) {
+                                return Effect.fail(classified);
+                              }
+                              credentials = clearPendingAxiomMutation(
+                                credentials,
+                                project,
+                                request.name,
+                              );
+                              return access
+                                .save(credentials)
+                                .pipe(Effect.andThen(Effect.fail(classified)));
+                            }),
                           );
                         existingTokens.push({ id: token.id, name: tokenName });
                       }
@@ -588,6 +722,7 @@ export class RemoteEnvironment extends Context.Service<
                     });
                     credentials = replaceEnvironment(credentials, environment);
                     if (tokenMutated) {
+                      credentials = clearPendingAxiomMutation(credentials, project, request.name);
                       yield* access.save(credentials).pipe(
                         Effect.mapError(
                           (error) =>
@@ -619,12 +754,24 @@ export class RemoteEnvironment extends Context.Service<
         list,
         export: Effect.fn("RemoteEnvironment.export")(function* (project, rawEnvironment) {
           const environment = yield* parseEnvironmentName(rawEnvironment);
-          const environments = yield* list(Option.some(project));
-          const managed = environments.find((candidate) => candidate.environment === environment);
+          const credentials = Option.getOrElse(yield* store.load(), emptyCredentials);
+          const managed = credentials.environments.find(
+            (candidate) => candidate.project === project && candidate.environment === environment,
+          );
           if (managed === undefined) {
             return yield* new RemoteEnvironmentError({
               code: "OBS_CLI_REMOTE_ENVIRONMENT_NOT_FOUND",
               message: `Environment ${project}/${environment} is not configured. Run observability provision with --environment ${environment}.`,
+              cause: `${project}/${environment}`,
+            });
+          }
+          if (
+            hasPendingAxiomMutation(credentials, project, environment) &&
+            Option.isSome(environmentAxiom(managed))
+          ) {
+            return yield* new RemoteEnvironmentError({
+              code: "OBS_CLI_REMOTE_TOKEN_UNAVAILABLE",
+              message: `The stored token for ${project}/${environment} may be stale after an unresolved mutation. Rerun provisioning with --provider axiom --rotate-token before exporting it.`,
               cause: `${project}/${environment}`,
             });
           }

--- a/packages/cli/test/CredentialsStore.bun.test.ts
+++ b/packages/cli/test/CredentialsStore.bun.test.ts
@@ -1,7 +1,7 @@
 import { BunServices } from "@effect/platform-bun";
 import { describe, expect, test } from "bun:test";
 import { Clock, Effect, FileSystem, Option, Schema } from "effect";
-import { chmod, mkdir } from "node:fs/promises";
+import { chmod, mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import {
   AxiomCredentials,
@@ -11,7 +11,13 @@ import {
 } from "../src/CredentialsStore.ts";
 
 const PersistedVersion = Schema.Struct({ version: Schema.Number });
+const PersistedLockOwner = Schema.Struct({
+  nonce: Schema.NonEmptyString,
+  pid: Schema.Int,
+  heartbeat: Schema.Number,
+});
 const decodePersistedVersion = Schema.decodeUnknownSync(PersistedVersion);
+const decodePersistedLockOwner = Schema.decodeUnknownSync(PersistedLockOwner);
 
 const makeAdvancingClock = (): Clock.Clock => {
   let current = 0;
@@ -184,6 +190,69 @@ describe("CredentialsStore", () => {
       );
 
       expect(error.code).toBe("OBS_CLI_CREDENTIALS_BUSY");
+    }),
+  );
+
+  test.serial("binds delayed heartbeats to one lock generation", () =>
+    withCredentialsHome("observability-lock-generation-", async (root) => {
+      const lockPath = join(root, ".credentials.lock");
+      const ownerPath = join(lockPath, "owner.json");
+      const staleNonce = "stale-owner";
+      await mkdir(lockPath, { recursive: true, mode: 0o700 });
+      await Bun.write(
+        ownerPath,
+        `${JSON.stringify({ nonce: staleNonce, pid: 1, heartbeat: Date.now() - 60_000 })}\n`,
+      );
+      await chmod(ownerPath, 0o600);
+
+      let signalAcquired = (): void => {};
+      let signalRelease = (): void => {};
+      const acquired = new Promise<void>((resolve) => {
+        signalAcquired = resolve;
+      });
+      const release = new Promise<void>((resolve) => {
+        signalRelease = resolve;
+      });
+      const owner = Effect.runPromise(
+        Effect.gen(function* () {
+          const store = yield* CredentialsStore;
+          yield* store.exclusive(() =>
+            Effect.gen(function* () {
+              yield* Effect.sync(signalAcquired);
+              yield* Effect.promise(() => release);
+            }),
+          );
+        }).pipe(Effect.provide(CredentialsStore.layer), Effect.provide(BunServices.layer)),
+      );
+      await acquired;
+
+      const currentOwner = decodePersistedLockOwner(JSON.parse(await Bun.file(ownerPath).text()));
+      expect(currentOwner.nonce).not.toBe(staleNonce);
+      expect(
+        await Bun.file(join(root, `.credentials.heartbeat-${currentOwner.nonce}`)).exists(),
+      ).toBeTrue();
+      await Bun.write(join(root, `.credentials.heartbeat-${staleNonce}`), `${Date.now()}\n`);
+      const ownerAfterDelayedHeartbeat = decodePersistedLockOwner(
+        JSON.parse(await Bun.file(ownerPath).text()),
+      );
+      expect(ownerAfterDelayedHeartbeat.nonce).toBe(currentOwner.nonce);
+
+      let contenderFinished = false;
+      const contender = Effect.runPromise(
+        Effect.gen(function* () {
+          const store = yield* CredentialsStore;
+          yield* store.save(new CredentialsFile({ version: 2, environments: [] }));
+        }).pipe(Effect.provide(CredentialsStore.layer), Effect.provide(BunServices.layer)),
+      ).then(() => {
+        contenderFinished = true;
+      });
+      await Bun.sleep(150);
+      expect(contenderFinished).toBeFalse();
+      signalRelease();
+      await owner;
+      await contender;
+      expect(contenderFinished).toBeTrue();
+      await rm(join(root, `.credentials.heartbeat-${staleNonce}`), { force: true });
     }),
   );
 

--- a/packages/cli/test/CredentialsStore.bun.test.ts
+++ b/packages/cli/test/CredentialsStore.bun.test.ts
@@ -1,6 +1,8 @@
 import { BunServices } from "@effect/platform-bun";
 import { describe, expect, test } from "bun:test";
-import { Effect, FileSystem, Option } from "effect";
+import { Clock, Effect, FileSystem, Option, Schema } from "effect";
+import { chmod, mkdir } from "node:fs/promises";
+import { join } from "node:path";
 import {
   AxiomCredentials,
   CredentialsFile,
@@ -8,77 +10,190 @@ import {
   SentryCredentials,
 } from "../src/CredentialsStore.ts";
 
-describe("CredentialsStore", () => {
-  test.serial("writes credentials with owner-only permissions and reads them back", async () => {
-    const previousHome = process.env.OBSERVABILITY_HOME;
-    const root = await Effect.runPromise(
-      Effect.gen(function* () {
-        const fs = yield* FileSystem.FileSystem;
-        return yield* fs.makeTempDirectory({ prefix: "observability-credentials-" });
-      }).pipe(Effect.provide(BunServices.layer)),
-    );
-    process.env.OBSERVABILITY_HOME = root;
+const PersistedVersion = Schema.Struct({ version: Schema.Number });
+const decodePersistedVersion = Schema.decodeUnknownSync(PersistedVersion);
 
-    try {
+const makeAdvancingClock = (): Clock.Clock => {
+  let current = 0;
+  const nextMillis = (): number => {
+    current += 1_000;
+    return current;
+  };
+  const nextNanos = (): bigint => BigInt(nextMillis()) * 1_000_000n;
+  return {
+    currentTimeMillisUnsafe: nextMillis,
+    currentTimeMillis: Effect.sync(nextMillis),
+    currentTimeNanosUnsafe: nextNanos,
+    currentTimeNanos: Effect.sync(nextNanos),
+    monotonicTimeNanosUnsafe: nextNanos,
+    monotonicTimeNanos: Effect.sync(nextNanos),
+    sleep: () => Effect.void,
+  };
+};
+
+const withCredentialsHome = async <A>(
+  prefix: string,
+  use: (root: string) => Promise<A>,
+): Promise<A> => {
+  const previousHome = process.env.OBSERVABILITY_HOME;
+  const root = await Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      return yield* fs.makeTempDirectory({ prefix });
+    }).pipe(Effect.provide(BunServices.layer)),
+  );
+  process.env.OBSERVABILITY_HOME = root;
+  try {
+    return await use(root);
+  } finally {
+    if (previousHome === undefined) {
+      delete process.env.OBSERVABILITY_HOME;
+    } else {
+      process.env.OBSERVABILITY_HOME = previousHome;
+    }
+  }
+};
+
+const administrativeCredentials = () => ({
+  axiom: new AxiomCredentials({ token: "xapt-secret", organizationId: "org-id" }),
+  sentry: new SentryCredentials({
+    token: "sentry-secret",
+    organization: "maxxi-cash",
+    team: "backend",
+    baseUrl: new URL("https://sentry.io"),
+  }),
+});
+
+describe("CredentialsStore", () => {
+  test.serial("writes version 2 credentials durably with owner-only permissions", () =>
+    withCredentialsHome("observability-credentials-", async (root) => {
+      const credentials = administrativeCredentials();
       const result = await Effect.runPromise(
         Effect.gen(function* () {
           const store = yield* CredentialsStore;
           const fs = yield* FileSystem.FileSystem;
-          yield* store.save(
-            new CredentialsFile({
-              version: 1,
-              axiom: new AxiomCredentials({
-                token: "xapt-secret",
-                organizationId: "org-id",
-              }),
-              sentry: new SentryCredentials({
-                token: "sentry-secret",
-                organization: "maxxi-cash",
-                team: "backend",
-                baseUrl: new URL("https://sentry.io"),
-              }),
-              environments: [],
-            }),
-          );
+          yield* store.save(new CredentialsFile({ version: 2, ...credentials, environments: [] }));
           const loaded = yield* store.load();
           const info = yield* fs.stat(store.path);
-          return { loaded, mode: info.mode & 0o777 };
+          const lockExists = yield* fs.exists(`${root}/.credentials.lock`);
+          return { loaded, lockExists, mode: info.mode & 0o777 };
         }).pipe(Effect.provide(CredentialsStore.layer), Effect.provide(BunServices.layer)),
       );
 
       expect(result.mode).toBe(0o600);
+      expect(result.lockExists).toBeFalse();
       expect(Option.isSome(result.loaded)).toBeTrue();
       if (Option.isSome(result.loaded)) {
-        expect(result.loaded.value.axiom?.organizationId).toBe("org-id");
+        expect(result.loaded.value.version).toBe(2);
         expect(result.loaded.value.axiom?.token).toBe("xapt-secret");
-        expect(result.loaded.value.sentry?.organization).toBe("maxxi-cash");
         expect(result.loaded.value.sentry?.baseUrl.toString()).toBe("https://sentry.io/");
       }
-    } finally {
-      if (previousHome === undefined) {
-        delete process.env.OBSERVABILITY_HOME;
-      } else {
-        process.env.OBSERVABILITY_HOME = previousHome;
+    }),
+  );
+
+  test.serial("migrates version 1 immediately without changing secrets or permissions", () =>
+    withCredentialsHome("observability-migration-", async (root) => {
+      const legacy = {
+        version: 1,
+        axiom: { token: "legacy-axiom-secret", organizationId: "legacy-org" },
+        sentry: {
+          token: "legacy-sentry-secret",
+          organization: "legacy-team",
+          team: "backend",
+          baseUrl: "https://sentry.io/",
+        },
+        environments: [
+          {
+            project: "livro-caixa",
+            environment: "staging",
+            axiomTokenId: "legacy-token-id",
+            axiomToken: "legacy-ingest-secret",
+            tracesDataset: "livro-caixa-staging-traces",
+            logsDataset: "livro-caixa-staging-logs",
+            metricsDataset: "livro-caixa-staging-metrics",
+            sentryProject: "livro-caixa",
+            sentryDsn: "https://public@sentry.example/1",
+          },
+        ],
+      };
+      await Bun.write(`${root}/credentials.json`, `${JSON.stringify(legacy)}\n`);
+      await chmod(`${root}/credentials.json`, 0o600);
+
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const store = yield* CredentialsStore;
+          const fs = yield* FileSystem.FileSystem;
+          const loaded = yield* store.load();
+          const content = yield* fs.readFileString(store.path);
+          const info = yield* fs.stat(store.path);
+          return { loaded, content, mode: info.mode & 0o777 };
+        }).pipe(Effect.provide(CredentialsStore.layer), Effect.provide(BunServices.layer)),
+      );
+
+      expect(decodePersistedVersion(JSON.parse(result.content)).version).toBe(2);
+      expect(result.content).toContain("legacy-axiom-secret");
+      expect(result.content).toContain("legacy-sentry-secret");
+      expect(result.content).toContain("legacy-ingest-secret");
+      expect(result.mode).toBe(0o600);
+      expect(Option.isSome(result.loaded)).toBeTrue();
+      if (Option.isSome(result.loaded)) {
+        expect(result.loaded.value.environments[0]?.providers.type).toBe("combined");
       }
-    }
-  });
+    }),
+  );
 
-  test.serial("rejects a credentials file that other users can read", async () => {
-    const previousHome = process.env.OBSERVABILITY_HOME;
-    const root = await Effect.runPromise(
-      Effect.gen(function* () {
-        const fs = yield* FileSystem.FileSystem;
-        return yield* fs.makeTempDirectory({ prefix: "observability-insecure-" });
-      }).pipe(Effect.provide(BunServices.layer)),
-    );
-    process.env.OBSERVABILITY_HOME = root;
+  test.serial("rejects unsupported versions without replacing the file", () =>
+    withCredentialsHome("observability-version-", async (root) => {
+      const original = '{"version":3,"environments":[]}\n';
+      await Bun.write(`${root}/credentials.json`, original);
+      await chmod(`${root}/credentials.json`, 0o600);
 
-    try {
+      const error = await Effect.runPromise(
+        Effect.gen(function* () {
+          const store = yield* CredentialsStore;
+          return yield* Effect.flip(store.load());
+        }).pipe(Effect.provide(CredentialsStore.layer), Effect.provide(BunServices.layer)),
+      );
+
+      expect(error.code).toBe("OBS_CLI_CREDENTIALS_VERSION_UNSUPPORTED");
+      expect(error.message).toContain("Update the CLI");
+      expect(await Bun.file(`${root}/credentials.json`).text()).toBe(original);
+    }),
+  );
+
+  test.serial("fails after waiting 30 seconds for an active credentials lock", () =>
+    withCredentialsHome("observability-busy-", async (root) => {
+      await mkdir(join(root, ".credentials.lock"), { recursive: true, mode: 0o700 });
+      await Bun.write(
+        join(root, ".credentials.lock", "owner.json"),
+        `${JSON.stringify({ nonce: "active-owner", pid: 1, heartbeat: 1_000_000 })}\n`,
+      );
+      await chmod(join(root, ".credentials.lock", "owner.json"), 0o600);
+
+      const error = await Effect.runPromise(
+        Effect.gen(function* () {
+          const store = yield* CredentialsStore;
+          return yield* Effect.flip(
+            store.save(new CredentialsFile({ version: 2, environments: [] })),
+          );
+        }).pipe(
+          Effect.provide(CredentialsStore.layer),
+          Effect.provideService(Clock.Clock, makeAdvancingClock()),
+          Effect.provide(BunServices.layer),
+        ),
+      );
+
+      expect(error.code).toBe("OBS_CLI_CREDENTIALS_BUSY");
+    }),
+  );
+
+  test.serial("rejects a credentials file that other users can read", () =>
+    withCredentialsHome("observability-insecure-", async () => {
       const error = await Effect.runPromise(
         Effect.gen(function* () {
           const store = yield* CredentialsStore;
           const fs = yield* FileSystem.FileSystem;
-          yield* store.save(new CredentialsFile({ version: 1, environments: [] }));
+          yield* store.save(new CredentialsFile({ version: 2, environments: [] }));
           yield* fs.chmod(store.path, 0o644);
           return yield* Effect.flip(store.load());
         }).pipe(Effect.provide(CredentialsStore.layer), Effect.provide(BunServices.layer)),
@@ -86,12 +201,6 @@ describe("CredentialsStore", () => {
 
       expect(error.code).toBe("OBS_CLI_CREDENTIALS_INSECURE");
       expect(error.message).toContain("chmod 600");
-    } finally {
-      if (previousHome === undefined) {
-        delete process.env.OBSERVABILITY_HOME;
-      } else {
-        process.env.OBSERVABILITY_HOME = previousHome;
-      }
-    }
-  });
+    }),
+  );
 });

--- a/packages/cli/test/CredentialsStore.bun.test.ts
+++ b/packages/cli/test/CredentialsStore.bun.test.ts
@@ -1,7 +1,7 @@
 import { BunServices } from "@effect/platform-bun";
 import { describe, expect, test } from "bun:test";
-import { Clock, Effect, FileSystem, Option, Schema } from "effect";
-import { chmod, mkdir, rm } from "node:fs/promises";
+import { Clock, Effect, FileSystem, Layer, Option, Schema } from "effect";
+import { access, chmod, mkdir, rename, rm, utimes } from "node:fs/promises";
 import { join } from "node:path";
 import {
   AxiomCredentials,
@@ -59,6 +59,18 @@ const withCredentialsHome = async <A>(
     }
   }
 };
+
+const exists = (path: string): Promise<boolean> =>
+  access(path).then(
+    () => true,
+    () => false,
+  );
+
+const within = <A>(promise: Promise<A>, operation: string): Promise<A> =>
+  Promise.race([
+    promise,
+    Bun.sleep(5_000).then(() => Promise.reject(new Error(`${operation} timed out`))),
+  ]);
 
 const administrativeCredentials = () => ({
   axiom: new AxiomCredentials({ token: "xapt-secret", organizationId: "org-id" }),
@@ -253,6 +265,216 @@ describe("CredentialsStore", () => {
       await contender;
       expect(contenderFinished).toBeTrue();
       await rm(join(root, `.credentials.heartbeat-${staleNonce}`), { force: true });
+    }),
+  );
+
+  test.serial("releases one generation before a contender acquires", () =>
+    withCredentialsHome("observability-release-race-", async (root) => {
+      const realFileSystem = await Effect.runPromise(
+        Effect.gen(function* () {
+          return yield* FileSystem.FileSystem;
+        }).pipe(Effect.provide(BunServices.layer)),
+      );
+      let signalRemovalStarted = (): void => {};
+      let signalAllowRemoval = (): void => {};
+      const removalStarted = new Promise<void>((resolve) => {
+        signalRemovalStarted = resolve;
+      });
+      const allowRemoval = new Promise<void>((resolve) => {
+        signalAllowRemoval = resolve;
+      });
+      let interceptRelease = true;
+      let releaseTombstone = "";
+      const controlledFileSystem = FileSystem.FileSystem.of({
+        ...realFileSystem,
+        remove: (target, options) => {
+          if (interceptRelease && target.includes(".credentials.lock.released-")) {
+            interceptRelease = false;
+            releaseTombstone = target;
+            signalRemovalStarted();
+            return Effect.promise(() => allowRemoval).pipe(
+              Effect.andThen(realFileSystem.remove(target, options)),
+            );
+          }
+          return realFileSystem.remove(target, options);
+        },
+      });
+      const storeLayer = CredentialsStore.layer.pipe(
+        Layer.provide(Layer.succeed(FileSystem.FileSystem, controlledFileSystem)),
+      );
+      let signalOwnerAcquired = (): void => {};
+      let signalOwnerRelease = (): void => {};
+      let signalContenderAcquired = (): void => {};
+      let signalContenderRelease = (): void => {};
+      const ownerAcquired = new Promise<void>((resolve) => {
+        signalOwnerAcquired = resolve;
+      });
+      const ownerRelease = new Promise<void>((resolve) => {
+        signalOwnerRelease = resolve;
+      });
+      const contenderAcquired = new Promise<void>((resolve) => {
+        signalContenderAcquired = resolve;
+      });
+      const contenderRelease = new Promise<void>((resolve) => {
+        signalContenderRelease = resolve;
+      });
+      const owner = Effect.runPromise(
+        Effect.gen(function* () {
+          const store = yield* CredentialsStore;
+          yield* store.exclusive(() =>
+            Effect.gen(function* () {
+              yield* Effect.sync(signalOwnerAcquired);
+              yield* Effect.promise(() => ownerRelease);
+            }),
+          );
+        }).pipe(Effect.provide(storeLayer), Effect.provide(BunServices.layer)),
+      );
+      await within(ownerAcquired, "owner acquisition");
+      const ownerBeforeRelease = decodePersistedLockOwner(
+        JSON.parse(await Bun.file(join(root, ".credentials.lock", "owner.json")).text()),
+      );
+      const contender = Effect.runPromise(
+        Effect.gen(function* () {
+          const store = yield* CredentialsStore;
+          yield* store.exclusive(() =>
+            Effect.gen(function* () {
+              yield* Effect.sync(signalContenderAcquired);
+              yield* Effect.promise(() => contenderRelease);
+            }),
+          );
+        }).pipe(Effect.provide(storeLayer), Effect.provide(BunServices.layer)),
+      );
+
+      signalOwnerRelease();
+      await within(removalStarted, "release tombstone rename");
+      expect(releaseTombstone).toContain(ownerBeforeRelease.nonce);
+      await within(contenderAcquired, "contender acquisition");
+      const contenderOwner = decodePersistedLockOwner(
+        JSON.parse(await Bun.file(join(root, ".credentials.lock", "owner.json")).text()),
+      );
+      expect(contenderOwner.nonce).not.toBe(ownerBeforeRelease.nonce);
+      signalAllowRemoval();
+      await within(owner, "owner release");
+      const ownerAfterRemoval = decodePersistedLockOwner(
+        JSON.parse(await Bun.file(join(root, ".credentials.lock", "owner.json")).text()),
+      );
+      expect(ownerAfterRemoval.nonce).toBe(contenderOwner.nonce);
+      signalContenderRelease();
+      await within(contender, "contender release");
+      expect(await exists(join(root, ".credentials.lock"))).toBeFalse();
+    }),
+  );
+
+  test.serial("interrupts the owner when its heartbeat cannot be persisted", () =>
+    withCredentialsHome("observability-heartbeat-failure-", async (root) => {
+      const backup = `${root}.backup`;
+      let signalAcquired = (): void => {};
+      const acquired = new Promise<void>((resolve) => {
+        signalAcquired = resolve;
+      });
+      const failed = Effect.runPromise(
+        Effect.flip(
+          Effect.gen(function* () {
+            const store = yield* CredentialsStore;
+            yield* store.exclusive(() =>
+              Effect.gen(function* () {
+                yield* Effect.sync(signalAcquired);
+                yield* Effect.never;
+              }),
+            );
+          }).pipe(Effect.provide(CredentialsStore.layer), Effect.provide(BunServices.layer)),
+        ),
+      );
+      await within(acquired, "heartbeat owner acquisition");
+      await rename(root, backup);
+      await Bun.write(root, "blocked");
+      try {
+        const error = await within(failed, "heartbeat failure");
+        expect(error.code).toBe("OBS_CLI_CREDENTIALS_FAILED");
+      } finally {
+        await rm(root, { force: true });
+        await rename(backup, root);
+      }
+    }),
+  );
+
+  test.serial("interrupts an owner after its lock generation is replaced", () =>
+    withCredentialsHome("observability-generation-loss-", async (root) => {
+      const lockPath = join(root, ".credentials.lock");
+      const displacedPath = join(root, ".credentials.lock.displaced");
+      const replacementNonce = "replacement-owner";
+      let signalAcquired = (): void => {};
+      const acquired = new Promise<void>((resolve) => {
+        signalAcquired = resolve;
+      });
+      const failed = Effect.runPromise(
+        Effect.flip(
+          Effect.gen(function* () {
+            const store = yield* CredentialsStore;
+            yield* store.exclusive(() =>
+              Effect.gen(function* () {
+                yield* Effect.sync(signalAcquired);
+                yield* Effect.never;
+              }),
+            );
+          }).pipe(Effect.provide(CredentialsStore.layer), Effect.provide(BunServices.layer)),
+        ),
+      );
+      await within(acquired, "generation owner acquisition");
+      const displacedOwner = decodePersistedLockOwner(
+        JSON.parse(await Bun.file(join(lockPath, "owner.json")).text()),
+      );
+      await rename(lockPath, displacedPath);
+      await mkdir(lockPath, { mode: 0o700 });
+      await Bun.write(
+        join(lockPath, "owner.json"),
+        `${JSON.stringify({ nonce: replacementNonce, pid: process.pid, heartbeat: Date.now() })}\n`,
+      );
+      await chmod(join(lockPath, "owner.json"), 0o600);
+      await Bun.write(join(root, `.credentials.heartbeat-${replacementNonce}`), `${Date.now()}\n`);
+
+      const error = await within(failed, "generation ownership failure");
+      expect(error.code).toBe("OBS_CLI_CREDENTIALS_FAILED");
+      const replacementOwner = decodePersistedLockOwner(
+        JSON.parse(await Bun.file(join(lockPath, "owner.json")).text()),
+      );
+      expect(replacementOwner.nonce).toBe(replacementNonce);
+      expect(replacementOwner.nonce).not.toBe(displacedOwner.nonce);
+      await rm(lockPath, { recursive: true, force: true });
+      await rm(displacedPath, { recursive: true, force: true });
+      await rm(join(root, `.credentials.heartbeat-${replacementNonce}`), { force: true });
+    }),
+  );
+
+  test.serial("removes only stale lock candidates and orphan heartbeats", () =>
+    withCredentialsHome("observability-lock-cleanup-", async (root) => {
+      const staleNonce = "stale-candidate";
+      const freshNonce = "fresh-candidate";
+      const staleCandidate = join(root, `.credentials.lock.candidate-${staleNonce}`);
+      const staleHeartbeat = join(root, `.credentials.heartbeat-${staleNonce}`);
+      const freshCandidate = join(root, `.credentials.lock.candidate-${freshNonce}`);
+      const freshHeartbeat = join(root, `.credentials.heartbeat-${freshNonce}`);
+      await mkdir(staleCandidate, { mode: 0o700 });
+      await Bun.write(staleHeartbeat, `${Date.now() - 120_000}\n`);
+      await mkdir(freshCandidate, { mode: 0o700 });
+      await Bun.write(freshHeartbeat, `${Date.now()}\n`);
+      const old = new Date(Date.now() - 120_000);
+      await utimes(staleCandidate, old, old);
+      await utimes(staleHeartbeat, old, old);
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const store = yield* CredentialsStore;
+          yield* store.save(new CredentialsFile({ version: 2, environments: [] }));
+        }).pipe(Effect.provide(CredentialsStore.layer), Effect.provide(BunServices.layer)),
+      );
+
+      expect(await exists(staleCandidate)).toBeFalse();
+      expect(await exists(staleHeartbeat)).toBeFalse();
+      expect(await exists(freshCandidate)).toBeTrue();
+      expect(await exists(freshHeartbeat)).toBeTrue();
+      await rm(freshCandidate, { recursive: true, force: true });
+      await rm(freshHeartbeat, { force: true });
     }),
   );
 

--- a/packages/cli/test/ProviderApis.bun.test.ts
+++ b/packages/cli/test/ProviderApis.bun.test.ts
@@ -36,30 +36,93 @@ const identityError = (url: string) =>
     ),
   );
 
-describe("provider HTTP boundary", () => {
-  test.serial("classifies unauthorized before consuming an unreadable body", async () => {
-    let responded = false;
-    const listener = Bun.listen({
-      hostname: "127.0.0.1",
-      port: 0,
-      socket: {
-        data(socket) {
-          if (responded) {
-            return;
-          }
-          responded = true;
-          socket.end(
-            "HTTP/1.1 401 Unauthorized\r\nContent-Type: application/json\r\nContent-Length: 100\r\nConnection: close\r\n\r\n{",
-          );
-        },
+const tokenError = (url: string) =>
+  withAxiomEndpoint(url, () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const api = yield* AxiomApi;
+        return yield* Effect.flip(api.createToken(credentials, "test-token", ["test-dataset"]));
+      }).pipe(Effect.provide(AxiomApi.layer)),
+    ),
+  );
+
+const startTruncatedResponseServer = (status: number, statusText: string) => {
+  const responded = new WeakSet<object>();
+  let responses = 0;
+  const listener = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      data(socket) {
+        if (responded.has(socket)) {
+          return;
+        }
+        responded.add(socket);
+        responses += 1;
+        socket.end(
+          `HTTP/1.1 ${status} ${statusText}\r\nContent-Type: application/json\r\nContent-Length: 100\r\nConnection: close\r\n\r\n{`,
+        );
       },
-    });
+    },
+  });
+  return { listener, responses: () => responses };
+};
+
+describe("provider HTTP boundary", () => {
+  test.serial("classifies unauthorized before consuming a body proven unreadable", async () => {
+    const server = startTruncatedResponseServer(401, "Unauthorized");
+    const url = `http://127.0.0.1:${server.listener.port}`;
     try {
-      const error = await identityError(`http://127.0.0.1:${listener.port}`);
+      const response = await fetch(`${url}/v2/user`);
+      expect(response.status).toBe(401);
+      const bodyOutcome = await Promise.race([
+        response.text().then(
+          () => "read",
+          () => "failed",
+        ),
+        Bun.sleep(500).then(() => "blocked"),
+      ]);
+      expect(["failed", "blocked"]).toContain(bodyOutcome);
+
+      const error = await identityError(url);
       expect(error.code).toBe("OBS_CLI_REMOTE_UNAUTHORIZED");
       expect(error.status).toBe(401);
+      expect(server.responses()).toBe(2);
     } finally {
-      listener.stop(true);
+      server.listener.stop(true);
+    }
+  });
+
+  test.serial("preserves successful status on unreadable token response bodies", async () => {
+    for (const status of [200, 201]) {
+      const server = startTruncatedResponseServer(status, "Success");
+      try {
+        const error = await tokenError(`http://127.0.0.1:${server.listener.port}`);
+        expect(error.code).toBe("OBS_CLI_REMOTE_FAILED");
+        expect(error.status).toBe(status);
+      } finally {
+        server.listener.stop(true);
+      }
+    }
+  });
+
+  test.serial("reports unexpected successful token statuses", async () => {
+    for (const status of [202, 204]) {
+      const server = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        fetch: () =>
+          status === 204
+            ? new Response(undefined, { status })
+            : Response.json({ id: "token", token: "secret" }, { status }),
+      });
+      try {
+        const error = await tokenError(`http://127.0.0.1:${server.port}`);
+        expect(error.code).toBe("OBS_CLI_REMOTE_FAILED");
+        expect(error.status).toBe(status);
+      } finally {
+        await server.stop(true);
+      }
     }
   });
 

--- a/packages/cli/test/ProviderApis.bun.test.ts
+++ b/packages/cli/test/ProviderApis.bun.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { AxiomCredentials } from "../src/CredentialsStore.ts";
+import { AxiomApi } from "../src/ProviderApis.ts";
+
+const credentials = new AxiomCredentials({ token: "test-token", organizationId: "test-org" });
+
+const withAxiomEndpoint = async <A>(url: string, use: () => Promise<A>): Promise<A> => {
+  const previousNodeEnvironment = process.env.NODE_ENV;
+  const previousEndpoint = process.env.OBSERVABILITY_CLI_TEST_AXIOM_BASE_URL;
+  process.env.NODE_ENV = "test";
+  process.env.OBSERVABILITY_CLI_TEST_AXIOM_BASE_URL = url;
+  try {
+    return await use();
+  } finally {
+    if (previousNodeEnvironment === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previousNodeEnvironment;
+    }
+    if (previousEndpoint === undefined) {
+      delete process.env.OBSERVABILITY_CLI_TEST_AXIOM_BASE_URL;
+    } else {
+      process.env.OBSERVABILITY_CLI_TEST_AXIOM_BASE_URL = previousEndpoint;
+    }
+  }
+};
+
+const identityError = (url: string) =>
+  withAxiomEndpoint(url, () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const api = yield* AxiomApi;
+        return yield* Effect.flip(api.identity(credentials));
+      }).pipe(Effect.provide(AxiomApi.layer)),
+    ),
+  );
+
+describe("provider HTTP boundary", () => {
+  test.serial("classifies unauthorized before consuming an unreadable body", async () => {
+    let responded = false;
+    const listener = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        data(socket) {
+          if (responded) {
+            return;
+          }
+          responded = true;
+          socket.end(
+            "HTTP/1.1 401 Unauthorized\r\nContent-Type: application/json\r\nContent-Length: 100\r\nConnection: close\r\n\r\n{",
+          );
+        },
+      },
+    });
+    try {
+      const error = await identityError(`http://127.0.0.1:${listener.port}`);
+      expect(error.code).toBe("OBS_CLI_REMOTE_UNAUTHORIZED");
+      expect(error.status).toBe(401);
+    } finally {
+      listener.stop(true);
+    }
+  });
+
+  test.serial("rejects redirects from the loopback-only Axiom test endpoint", async () => {
+    let redirectedRequests = 0;
+    const destination = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () => {
+        redirectedRequests += 1;
+        return Response.json({ id: "owner", email: "owner@example.com" });
+      },
+    });
+    const origin = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () =>
+        new Response(undefined, {
+          status: 302,
+          headers: { location: `http://127.0.0.1:${destination.port}/v2/user` },
+        }),
+    });
+    try {
+      const error = await identityError(`http://127.0.0.1:${origin.port}`);
+      expect(error.code).toBe("OBS_CLI_REMOTE_FAILED");
+      expect(error.status).toBe(0);
+      expect(redirectedRequests).toBe(0);
+    } finally {
+      await origin.stop(true);
+      await destination.stop(true);
+    }
+  });
+});

--- a/packages/cli/test/ProviderSelection.bun.test.ts
+++ b/packages/cli/test/ProviderSelection.bun.test.ts
@@ -525,6 +525,22 @@ describe("built CLI provider selection", () => {
         ).toBeFalse();
         expect(server.requests).toHaveLength(0);
 
+        const invalidEnvironmentTarget = join(root, "invalid-environment-target");
+        const invalidEnvironment = await runCli(
+          provisionArgs(invalidEnvironmentTarget, "Production US", ["sentry"]),
+          stateRoot,
+          invalidEnvironmentTarget,
+          server,
+        );
+        expect(invalidEnvironment.exitCode).toBe(1);
+        expect(invalidEnvironment.stderr).toContain("OBS_CLI_REMOTE_INVALID_ENVIRONMENT");
+        expect(
+          await Bun.file(
+            join(invalidEnvironmentTarget, "observability", "collector.yaml"),
+          ).exists(),
+        ).toBeFalse();
+        expect(server.requests).toHaveLength(0);
+
         const missing = await runCli(
           provisionArgs(target, "staging", ["axiom"]),
           stateRoot,
@@ -624,6 +640,44 @@ describe("built CLI provider selection", () => {
         ).toHaveLength(1);
         assertNoSecretOutput(rotated);
 
+        const rotatedDocument = JSON.parse(await Bun.file(migrationPath).text());
+        rotatedDocument.pendingAxiomMutations = [{ project: "livro-caixa", environment: "legacy" }];
+        await Bun.write(migrationPath, `${JSON.stringify(rotatedDocument, undefined, 2)}\n`);
+        await chmod(migrationPath, 0o600);
+        const requestsBeforeUnresolvedRetry = server.requests.length;
+        const unresolvedExport = await runCli(
+          ["env", "export", "--name", "livro-caixa", "--environment", "legacy"],
+          migrationRoot,
+          migrationTarget,
+          server,
+        );
+        expect(unresolvedExport.exitCode).toBe(1);
+        expect(unresolvedExport.stderr).toContain("OBS_CLI_REMOTE_TOKEN_UNAVAILABLE");
+        expect(server.requests).toHaveLength(requestsBeforeUnresolvedRetry);
+        const unresolvedRetry = await runCli(
+          provisionArgs(migrationTarget, "legacy", ["axiom"]),
+          migrationRoot,
+          migrationTarget,
+          server,
+        );
+        expect(unresolvedRetry.exitCode).toBe(1);
+        expect(unresolvedRetry.stderr).toContain("OBS_CLI_REMOTE_TOKEN_UNAVAILABLE");
+        expect(unresolvedRetry.stderr).toContain("--rotate-token");
+        expect(server.requests).toHaveLength(requestsBeforeUnresolvedRetry);
+        const recoveredRotation = await runCli(
+          [...provisionArgs(migrationTarget, "legacy", ["axiom"]), "--rotate-token"],
+          migrationRoot,
+          migrationTarget,
+          server,
+        );
+        expect(recoveredRotation.exitCode).toBe(0);
+        expect(
+          JSON.parse(await Bun.file(migrationPath).text()).pendingAxiomMutations,
+        ).toBeUndefined();
+        assertNoSecretOutput(unresolvedExport);
+        assertNoSecretOutput(unresolvedRetry);
+        assertNoSecretOutput(recoveredRotation);
+
         const sentryFailureRoot = join(root, "sentry-failure-state");
         const sentryFailureTarget = join(root, "sentry-failure-target");
         await writeCredentials(sentryFailureRoot, server.url, ["axiom", "sentry"]);
@@ -688,7 +742,35 @@ describe("built CLI provider selection", () => {
         expect(unknown.exitCode).toBe(1);
         expect(unknown.stderr).toContain("OBS_CLI_REMOTE_OUTCOME_UNKNOWN");
         expect((await readPersisted(unknownRoot)).environments).toHaveLength(0);
+        expect(
+          JSON.parse(await Bun.file(join(unknownRoot, "credentials.json")).text()),
+        ).toMatchObject({
+          pendingAxiomMutations: [{ project: "livro-caixa", environment: "unknown" }],
+        });
+        const requestsBeforeUnknownRetry = server.requests.length;
+        const unknownRetry = await runCli(
+          provisionArgs(unknownTarget, "unknown", ["axiom"]),
+          unknownRoot,
+          unknownTarget,
+          server,
+        );
+        expect(unknownRetry.exitCode).toBe(1);
+        expect(unknownRetry.stderr).toContain("OBS_CLI_REMOTE_TOKEN_UNAVAILABLE");
+        expect(server.requests).toHaveLength(requestsBeforeUnknownRetry);
+        const unknownRecovery = await runCli(
+          [...provisionArgs(unknownTarget, "unknown", ["axiom"]), "--rotate-token"],
+          unknownRoot,
+          unknownTarget,
+          server,
+        );
+        expect(unknownRecovery.exitCode).toBe(0);
+        expect(
+          JSON.parse(await Bun.file(join(unknownRoot, "credentials.json")).text())
+            .pendingAxiomMutations,
+        ).toBeUndefined();
         assertNoSecretOutput(unknown);
+        assertNoSecretOutput(unknownRetry);
+        assertNoSecretOutput(unknownRecovery);
 
         const concurrentRoot = join(root, "concurrent-state");
         const concurrentTarget = join(root, "concurrent-target");

--- a/packages/cli/test/ProviderSelection.bun.test.ts
+++ b/packages/cli/test/ProviderSelection.bun.test.ts
@@ -1,0 +1,734 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { Schema } from "effect";
+import { chmod, mkdtemp, mkdir, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repository = fileURLToPath(new URL("../../..", import.meta.url));
+const cli = fileURLToPath(new URL("../dist/main.js", import.meta.url));
+
+const PersistedCredentials = Schema.Struct({
+  version: Schema.Literal(2),
+  axiom: Schema.Struct({ token: Schema.NonEmptyString }).pipe(Schema.optionalKey),
+  sentry: Schema.Struct({ token: Schema.NonEmptyString }).pipe(Schema.optionalKey),
+  environments: Schema.Array(
+    Schema.Struct({
+      project: Schema.String,
+      environment: Schema.String,
+      providers: Schema.Struct({ type: Schema.Literals(["axiom", "sentry", "combined"]) }),
+    }),
+  ),
+});
+const decodePersistedCredentials = Schema.decodeUnknownSync(PersistedCredentials);
+
+type ProviderRequest = {
+  readonly method: string;
+  readonly path: string;
+  readonly body: string;
+};
+
+type ProviderServer = {
+  readonly url: string;
+  readonly requests: Array<ProviderRequest>;
+  readonly datasets: Set<string>;
+  readonly tokens: Array<{ id: string; name: string; token: string }>;
+  failDataset(name: string): void;
+  failNextSentryProject(): void;
+  failNextTokenResponse(): void;
+  stop(): void;
+};
+
+type CliResult = {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+};
+
+type ProviderResponsePayload = typeof Schema.Json.Type;
+
+const json = (value: ProviderResponsePayload, status = 200): Response =>
+  Response.json(value, { status, headers: { "content-type": "application/json" } });
+
+const startProviderServer = (): ProviderServer => {
+  const requests: Array<ProviderRequest> = [];
+  const datasets = new Set<string>();
+  const tokens: Array<{ id: string; name: string; token: string }> = [];
+  let sentryProject = false;
+  let tokenSequence = 0;
+  let failSentryProject = false;
+  let failTokenResponse = false;
+  const failedDatasets = new Set<string>();
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: async (request) => {
+      const url = new URL(request.url);
+      const body = await request.text();
+      requests.push({ method: request.method, path: url.pathname, body });
+
+      if (request.method === "GET" && url.pathname === "/v2/user") {
+        return json({ id: "owner", email: "owner@example.com" });
+      }
+      if (request.method === "GET" && url.pathname === "/v2/datasets") {
+        return json([...datasets].map((name) => ({ name })));
+      }
+      if (request.method === "POST" && url.pathname === "/v2/datasets") {
+        const value = Schema.decodeUnknownSync(Schema.Struct({ name: Schema.NonEmptyString }))(
+          JSON.parse(body),
+        );
+        if (failedDatasets.has(value.name)) {
+          return json({ error: "selected failure" }, 500);
+        }
+        datasets.add(value.name);
+        return json({ name: value.name }, 201);
+      }
+      if (request.method === "GET" && url.pathname === "/v2/tokens") {
+        return json(tokens.map(({ id, name }) => ({ id, name })));
+      }
+      if (request.method === "POST" && url.pathname === "/v2/tokens") {
+        const value = Schema.decodeUnknownSync(Schema.Struct({ name: Schema.NonEmptyString }))(
+          JSON.parse(body),
+        );
+        tokenSequence += 1;
+        const token = {
+          id: `token-${tokenSequence}`,
+          name: value.name,
+          token: `ingest-secret-${tokenSequence}`,
+        };
+        tokens.push(token);
+        if (failTokenResponse) {
+          failTokenResponse = false;
+          return new Response("{", { status: 201 });
+        }
+        return json({ id: token.id, token: token.token }, 201);
+      }
+      const regenerate = url.pathname.match(/^\/v2\/tokens\/([^/]+)\/regenerate$/);
+      if (request.method === "POST" && regenerate !== null) {
+        const id = decodeURIComponent(regenerate[1] ?? "");
+        const token = tokens.find((candidate) => candidate.id === id);
+        if (token === undefined) {
+          return json({ error: "missing" }, 404);
+        }
+        tokenSequence += 1;
+        token.token = `ingest-secret-${tokenSequence}`;
+        return json({ id: token.id, token: token.token });
+      }
+      if (
+        request.method === "GET" &&
+        /^\/api\/0\/projects\/maxxi-cash\/[^/]+\/$/.test(url.pathname)
+      ) {
+        if (failSentryProject) {
+          failSentryProject = false;
+          return json({ error: "selected failure" }, 500);
+        }
+        const slug = url.pathname.split("/").at(-2) ?? "";
+        return sentryProject ? json({ slug, name: slug }) : json({ detail: "missing" }, 404);
+      }
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/0/teams/maxxi-cash/backend/projects/"
+      ) {
+        const value = Schema.decodeUnknownSync(Schema.Struct({ slug: Schema.NonEmptyString }))(
+          JSON.parse(body),
+        );
+        sentryProject = true;
+        return json({ slug: value.slug, name: value.slug }, 201);
+      }
+      if (
+        request.method === "GET" &&
+        /^\/api\/0\/projects\/maxxi-cash\/[^/]+\/keys\/$/.test(url.pathname)
+      ) {
+        return json([{ dsn: { public: "https://public@sentry.example/1" } }]);
+      }
+      return json({ error: "unexpected request" }, 500);
+    },
+  });
+  return {
+    url: `http://127.0.0.1:${server.port}`,
+    requests,
+    datasets,
+    tokens,
+    failDataset: (name) => {
+      failedDatasets.add(name);
+    },
+    failNextSentryProject: () => {
+      failSentryProject = true;
+    },
+    failNextTokenResponse: () => {
+      failTokenResponse = true;
+    },
+    stop: () => server.stop(true),
+  };
+};
+
+const credentialsDocument = (
+  sentryBaseUrl: string,
+  providers: ReadonlyArray<"axiom" | "sentry">,
+): string => {
+  const axiom = { token: "axiom-admin-secret", organizationId: "org-id" };
+  const sentry = {
+    token: "sentry-admin-secret",
+    organization: "maxxi-cash",
+    team: "backend",
+    baseUrl: sentryBaseUrl,
+  };
+  const document = providers.includes("axiom")
+    ? providers.includes("sentry")
+      ? { version: 2, axiom, sentry, environments: [] }
+      : { version: 2, axiom, environments: [] }
+    : { version: 2, sentry, environments: [] };
+  return `${JSON.stringify(document, undefined, 2)}\n`;
+};
+
+const writeCredentials = async (
+  root: string,
+  sentryBaseUrl: string,
+  providers: ReadonlyArray<"axiom" | "sentry">,
+): Promise<void> => {
+  await mkdir(root, { recursive: true, mode: 0o700 });
+  const path = join(root, "credentials.json");
+  await Bun.write(path, credentialsDocument(sentryBaseUrl, providers));
+  await chmod(path, 0o600);
+};
+
+const runCli = (
+  args: ReadonlyArray<string>,
+  stateRoot: string,
+  target: string,
+  server: ProviderServer,
+): Promise<CliResult> => {
+  const child = Bun.spawn(["bun", cli, ...args], {
+    cwd: repository,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      NODE_ENV: "test",
+      NO_COLOR: "1",
+      OBSERVABILITY_HOME: stateRoot,
+      OBSERVABILITY_CLI_TEST_AXIOM_BASE_URL: server.url,
+    },
+  });
+  return Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]).then(([exitCode, stdout, stderr]) => ({ exitCode, stdout, stderr }));
+};
+
+const provisionArgs = (
+  target: string,
+  environment: string,
+  providers: ReadonlyArray<"axiom" | "sentry">,
+): ReadonlyArray<string> => [
+  "provision",
+  "--dir",
+  target,
+  "--name",
+  "livro-caixa",
+  "--environment",
+  environment,
+  ...providers.flatMap((provider) => ["--provider", provider]),
+];
+
+const assertNoSecretOutput = (result: CliResult): void => {
+  for (const secret of [
+    "axiom-admin-secret",
+    "sentry-admin-secret",
+    "ingest-secret-",
+    "https://public@sentry.example/1",
+  ]) {
+    expect(result.stdout).not.toContain(secret);
+    expect(result.stderr).not.toContain(secret);
+  }
+};
+
+const readPersisted = async (root: string) => {
+  const content = await Bun.file(join(root, "credentials.json")).text();
+  return decodePersistedCredentials(JSON.parse(content));
+};
+
+beforeAll(async () => {
+  const child = Bun.spawn(["bun", "run", "build"], {
+    cwd: repository,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const exitCode = await child.exited;
+  expect(exitCode).toBe(0);
+});
+
+describe("built CLI provider selection", () => {
+  test.serial(
+    "drives Axiom-only, Sentry-only and combined state through loopback providers",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "observability-provider-cli-"));
+      const server = startProviderServer();
+      try {
+        const axiomRoot = join(root, "axiom-state");
+        const axiomTarget = join(root, "axiom-target");
+        await writeCredentials(axiomRoot, server.url, ["axiom"]);
+        const axiomFirst = await runCli(
+          provisionArgs(axiomTarget, "staging", ["axiom"]),
+          axiomRoot,
+          axiomTarget,
+          server,
+        );
+        const axiomRepeat = await runCli(
+          provisionArgs(axiomTarget, "staging", []),
+          axiomRoot,
+          axiomTarget,
+          server,
+        );
+        const axiomExport = await runCli(
+          ["env", "export", "--name", "livro-caixa", "--environment", "staging"],
+          axiomRoot,
+          axiomTarget,
+          server,
+        );
+        expect(axiomFirst.exitCode).toBe(0);
+        expect(axiomRepeat.exitCode).toBe(0);
+        expect(axiomExport.stdout.trim().split("\n")).toEqual([
+          'OTEL_SERVICE_NAME="livro-caixa"',
+          'OTEL_DEPLOYMENT_ENVIRONMENT="staging"',
+          'OTEL_EXPORTER_OTLP_ENDPOINT="http://otel-collector:4318"',
+          'AXIOM_TOKEN="ingest-secret-1"',
+          'AXIOM_DATASET_TRACES="livro-caixa-staging-traces"',
+          'AXIOM_DATASET_LOGS="livro-caixa-staging-logs"',
+          'AXIOM_DATASET_METRICS="livro-caixa-staging-metrics"',
+        ]);
+        expect(
+          server.requests.filter((request) => request.path.startsWith("/api/0/")),
+        ).toHaveLength(0);
+        expect(
+          server.requests.filter(
+            (request) => request.method === "POST" && request.path === "/v2/tokens",
+          ),
+        ).toHaveLength(1);
+        expect(server.requests.map((request) => `${request.method} ${request.path}`)).toEqual([
+          "GET /v2/datasets",
+          "GET /v2/tokens",
+          "POST /v2/datasets",
+          "POST /v2/datasets",
+          "POST /v2/datasets",
+          "POST /v2/tokens",
+          "GET /v2/datasets",
+          "GET /v2/tokens",
+        ]);
+        expect(
+          server.requests
+            .filter((request) => request.path === "/v2/datasets" && request.method === "POST")
+            .map((request) => JSON.parse(request.body)),
+        ).toEqual([
+          {
+            name: "livro-caixa-staging-traces",
+            description: "OpenTelemetry data for livro-caixa-staging-traces",
+          },
+          {
+            name: "livro-caixa-staging-logs",
+            description: "OpenTelemetry data for livro-caixa-staging-logs",
+          },
+          {
+            name: "livro-caixa-staging-metrics",
+            description: "OpenTelemetry data for livro-caixa-staging-metrics",
+          },
+        ]);
+        const axiomTokenRequest = server.requests.find(
+          (request) => request.path === "/v2/tokens" && request.method === "POST",
+        );
+        expect(axiomTokenRequest).toBeDefined();
+        if (axiomTokenRequest !== undefined) {
+          expect(JSON.parse(axiomTokenRequest.body)).toEqual({
+            name: "livro-caixa-staging-collector",
+            description: "Collector ingest token for livro-caixa-staging-collector",
+            datasetCapabilities: {
+              "livro-caixa-staging-traces": { ingest: ["create"] },
+              "livro-caixa-staging-logs": { ingest: ["create"] },
+              "livro-caixa-staging-metrics": { ingest: ["create"] },
+            },
+            orgCapabilities: {},
+            viewCapabilities: {},
+          });
+        }
+        assertNoSecretOutput(axiomFirst);
+        assertNoSecretOutput(axiomRepeat);
+
+        const sentryRequestStart = server.requests.length;
+        const sentryRoot = join(root, "sentry-state");
+        const sentryTarget = join(root, "sentry-target");
+        await writeCredentials(sentryRoot, server.url, ["sentry"]);
+        const sentryFirst = await runCli(
+          provisionArgs(sentryTarget, "production", ["sentry"]),
+          sentryRoot,
+          sentryTarget,
+          server,
+        );
+        const sentryRepeat = await runCli(
+          provisionArgs(sentryTarget, "production", []),
+          sentryRoot,
+          sentryTarget,
+          server,
+        );
+        const sentryExport = await runCli(
+          ["env", "export", "--name", "livro-caixa", "--environment", "production"],
+          sentryRoot,
+          sentryTarget,
+          server,
+        );
+        expect(sentryFirst.exitCode).toBe(0);
+        expect(sentryRepeat.exitCode).toBe(0);
+        expect(sentryFirst.stdout).toContain("Sentry-only command");
+        expect(sentryExport.stdout.trim()).toBe(
+          'OTEL_SERVICE_NAME="livro-caixa"\nOTEL_DEPLOYMENT_ENVIRONMENT="production"\nSENTRY_DSN="https://public@sentry.example/1"',
+        );
+        const sentryRequests = server.requests.slice(sentryRequestStart);
+        expect(sentryRequests.filter((request) => request.path.startsWith("/v2/"))).toHaveLength(0);
+        expect(sentryRequests.map((request) => `${request.method} ${request.path}`)).toEqual([
+          "GET /api/0/projects/maxxi-cash/livro-caixa/",
+          "POST /api/0/teams/maxxi-cash/backend/projects/",
+          "GET /api/0/projects/maxxi-cash/livro-caixa/keys/",
+          "GET /api/0/projects/maxxi-cash/livro-caixa/",
+          "GET /api/0/projects/maxxi-cash/livro-caixa/keys/",
+        ]);
+        expect(JSON.parse(sentryRequests[1]?.body ?? "")).toEqual({
+          name: "livro-caixa",
+          slug: "livro-caixa",
+          platform: "node",
+        });
+        assertNoSecretOutput(sentryFirst);
+        assertNoSecretOutput(sentryRepeat);
+
+        const combinedRequestStart = server.requests.length;
+        const combinedRoot = join(root, "combined-state");
+        const combinedTarget = join(root, "combined-target");
+        await writeCredentials(combinedRoot, server.url, ["axiom", "sentry"]);
+        const combined = await runCli(
+          provisionArgs(combinedTarget, "canary", []),
+          combinedRoot,
+          combinedTarget,
+          server,
+        );
+        const combinedRepeat = await runCli(
+          provisionArgs(combinedTarget, "canary", ["sentry", "axiom", "sentry"]),
+          combinedRoot,
+          combinedTarget,
+          server,
+        );
+        expect(combined.exitCode).toBe(0);
+        expect(combinedRepeat.exitCode).toBe(0);
+        expect(combined.stdout).toContain("providers=axiom,sentry");
+        expect(combinedRepeat.stdout).toContain("providers=axiom,sentry");
+        assertNoSecretOutput(combinedRepeat);
+        const combinedExport = await runCli(
+          ["env", "export", "--name", "livro-caixa", "--environment", "canary"],
+          combinedRoot,
+          combinedTarget,
+          server,
+        );
+        expect(combinedExport.exitCode).toBe(0);
+        expect(combinedExport.stdout.trim().split("\n")).toEqual([
+          'OTEL_SERVICE_NAME="livro-caixa"',
+          'OTEL_DEPLOYMENT_ENVIRONMENT="canary"',
+          'OTEL_EXPORTER_OTLP_ENDPOINT="http://otel-collector:4318"',
+          'AXIOM_TOKEN="ingest-secret-2"',
+          'AXIOM_DATASET_TRACES="livro-caixa-canary-traces"',
+          'AXIOM_DATASET_LOGS="livro-caixa-canary-logs"',
+          'AXIOM_DATASET_METRICS="livro-caixa-canary-metrics"',
+          'SENTRY_DSN="https://public@sentry.example/1"',
+        ]);
+        expect(
+          server.requests
+            .slice(combinedRequestStart)
+            .map((request) => `${request.method} ${request.path}`),
+        ).toEqual([
+          "GET /api/0/projects/maxxi-cash/livro-caixa/",
+          "GET /api/0/projects/maxxi-cash/livro-caixa/keys/",
+          "GET /v2/datasets",
+          "GET /v2/tokens",
+          "POST /v2/datasets",
+          "POST /v2/datasets",
+          "POST /v2/datasets",
+          "POST /v2/tokens",
+          "GET /api/0/projects/maxxi-cash/livro-caixa/",
+          "GET /api/0/projects/maxxi-cash/livro-caixa/keys/",
+          "GET /v2/datasets",
+          "GET /v2/tokens",
+        ]);
+        expect((await readPersisted(combinedRoot)).environments[0]?.providers.type).toBe(
+          "combined",
+        );
+        expect((await stat(join(combinedRoot, "credentials.json"))).mode & 0o777).toBe(0o600);
+        assertNoSecretOutput(combined);
+      } finally {
+        server.stop();
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
+
+  test.serial(
+    "rejects invalid and missing selections before provider requests and preserves no-environment compatibility",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "observability-provider-errors-"));
+      const server = startProviderServer();
+      try {
+        const stateRoot = join(root, "state");
+        const target = join(root, "target");
+        await writeCredentials(stateRoot, server.url, ["sentry"]);
+
+        for (const rejectedEnvironment of [
+          {
+            NODE_ENV: "test",
+            OBSERVABILITY_CLI_TEST_AXIOM_BASE_URL: "http://localhost:4318",
+          },
+          {
+            NODE_ENV: "production",
+            OBSERVABILITY_CLI_TEST_AXIOM_BASE_URL: server.url,
+          },
+        ]) {
+          const child = Bun.spawn(["bun", cli, "--version"], {
+            cwd: repository,
+            stdout: "pipe",
+            stderr: "pipe",
+            env: { ...process.env, ...rejectedEnvironment, NO_COLOR: "1" },
+          });
+          const [exitCode, stderr] = await Promise.all([
+            child.exited,
+            new Response(child.stderr).text(),
+          ]);
+          expect(exitCode).toBe(1);
+          expect(stderr).toContain("The internal Axiom test endpoint is invalid");
+        }
+
+        const invalid = await runCli(
+          [
+            "provision",
+            "--dir",
+            target,
+            "--name",
+            "livro-caixa",
+            "--environment",
+            "staging",
+            "--provider",
+            "honeycomb",
+          ],
+          stateRoot,
+          target,
+          server,
+        );
+        expect(invalid.exitCode).toBe(1);
+        expect(invalid.stderr).toContain("OBS_CLI_REMOTE_INVALID_PROVIDER");
+        expect(
+          await Bun.file(join(target, "observability", "collector.yaml")).exists(),
+        ).toBeFalse();
+        expect(server.requests).toHaveLength(0);
+
+        const missing = await runCli(
+          provisionArgs(target, "staging", ["axiom"]),
+          stateRoot,
+          target,
+          server,
+        );
+        expect(missing.exitCode).toBe(1);
+        expect(missing.stderr).toContain("OBS_CLI_REMOTE_PROVIDER_CREDENTIALS_MISSING");
+        expect(server.requests).toHaveLength(0);
+
+        const localOnly = await runCli(
+          [
+            "provision",
+            "--dir",
+            target,
+            "--name",
+            "livro-caixa",
+            "--provider",
+            "sentry",
+            "--rotate-token",
+            "--sentry-platform",
+            "javascript",
+          ],
+          stateRoot,
+          target,
+          server,
+        );
+        expect(localOnly.exitCode).toBe(0);
+        expect(localOnly.stdout).toContain("set the AXIOM_TOKEN secret");
+        expect(server.requests).toHaveLength(0);
+        assertNoSecretOutput(localOnly);
+      } finally {
+        server.stop();
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
+
+  test.serial(
+    "migrates legacy state, rotates Axiom, and serializes concurrent subprocess updates",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "observability-provider-state-"));
+      const server = startProviderServer();
+      try {
+        const migrationRoot = join(root, "migration-state");
+        const migrationTarget = join(root, "migration-target");
+        await mkdir(migrationRoot, { recursive: true, mode: 0o700 });
+        const legacy = {
+          version: 1,
+          axiom: { token: "legacy-admin", organizationId: "org-id" },
+          sentry: {
+            token: "legacy-sentry",
+            organization: "maxxi-cash",
+            team: "backend",
+            baseUrl: server.url,
+          },
+          environments: [
+            {
+              project: "livro-caixa",
+              environment: "legacy",
+              axiomTokenId: "legacy-id",
+              axiomToken: "legacy-ingest-secret",
+              tracesDataset: "livro-caixa-legacy-traces",
+              logsDataset: "livro-caixa-legacy-logs",
+              metricsDataset: "livro-caixa-legacy-metrics",
+              sentryProject: "livro-caixa",
+              sentryDsn: "https://legacy@sentry.example/1",
+            },
+          ],
+        };
+        const migrationPath = join(migrationRoot, "credentials.json");
+        await Bun.write(migrationPath, `${JSON.stringify(legacy)}\n`);
+        await chmod(migrationPath, 0o600);
+        const migratedExport = await runCli(
+          ["env", "export", "--name", "livro-caixa", "--environment", "legacy"],
+          migrationRoot,
+          migrationTarget,
+          server,
+        );
+        expect(migratedExport.exitCode).toBe(0);
+        expect(migratedExport.stdout).toContain('AXIOM_TOKEN="legacy-ingest-secret"');
+        expect(migratedExport.stdout).toContain('SENTRY_DSN="https://legacy@sentry.example/1"');
+        expect((await readPersisted(migrationRoot)).version).toBe(2);
+        expect((await stat(migrationPath)).mode & 0o777).toBe(0o600);
+        const rotated = await runCli(
+          [...provisionArgs(migrationTarget, "legacy", ["axiom"]), "--rotate-token"],
+          migrationRoot,
+          migrationTarget,
+          server,
+        );
+        expect(rotated.exitCode).toBe(0);
+        expect(
+          server.requests.filter(
+            (request) => request.method === "POST" && request.path === "/v2/tokens",
+          ),
+        ).toHaveLength(1);
+        assertNoSecretOutput(rotated);
+
+        const sentryFailureRoot = join(root, "sentry-failure-state");
+        const sentryFailureTarget = join(root, "sentry-failure-target");
+        await writeCredentials(sentryFailureRoot, server.url, ["axiom", "sentry"]);
+        const axiomCallsBeforeSentryFailure = server.requests.filter((request) =>
+          request.path.startsWith("/v2/"),
+        ).length;
+        server.failNextSentryProject();
+        const sentryFailure = await runCli(
+          provisionArgs(sentryFailureTarget, "sentry-failure", ["axiom", "sentry"]),
+          sentryFailureRoot,
+          sentryFailureTarget,
+          server,
+        );
+        expect(sentryFailure.exitCode).toBe(1);
+        expect(sentryFailure.stderr).toContain("OBS_CLI_REMOTE_FAILED");
+        expect(server.requests.filter((request) => request.path.startsWith("/v2/")).length).toBe(
+          axiomCallsBeforeSentryFailure,
+        );
+        expect((await readPersisted(sentryFailureRoot)).environments).toHaveLength(0);
+        assertNoSecretOutput(sentryFailure);
+
+        const partialRoot = join(root, "partial-state");
+        const partialTarget = join(root, "partial-target");
+        await writeCredentials(partialRoot, server.url, ["axiom"]);
+        server.failDataset("livro-caixa-partial-two-traces");
+        const partial = await runCli(
+          [
+            "provision",
+            "--dir",
+            partialTarget,
+            "--name",
+            "livro-caixa",
+            "--environment",
+            "partial-one",
+            "--environment",
+            "partial-two",
+            "--provider",
+            "axiom",
+          ],
+          partialRoot,
+          partialTarget,
+          server,
+        );
+        expect(partial.exitCode).toBe(1);
+        expect(partial.stderr).toContain("OBS_CLI_REMOTE_PARTIAL_FAILURE");
+        expect(partial.stderr).toContain("livro-caixa/partial-one");
+        expect(
+          (await readPersisted(partialRoot)).environments.map((item) => item.environment),
+        ).toEqual(["partial-one"]);
+        assertNoSecretOutput(partial);
+
+        const unknownRoot = join(root, "unknown-state");
+        const unknownTarget = join(root, "unknown-target");
+        await writeCredentials(unknownRoot, server.url, ["axiom"]);
+        server.failNextTokenResponse();
+        const unknown = await runCli(
+          provisionArgs(unknownTarget, "unknown", ["axiom"]),
+          unknownRoot,
+          unknownTarget,
+          server,
+        );
+        expect(unknown.exitCode).toBe(1);
+        expect(unknown.stderr).toContain("OBS_CLI_REMOTE_OUTCOME_UNKNOWN");
+        expect((await readPersisted(unknownRoot)).environments).toHaveLength(0);
+        assertNoSecretOutput(unknown);
+
+        const concurrentRoot = join(root, "concurrent-state");
+        const concurrentTarget = join(root, "concurrent-target");
+        await writeCredentials(concurrentRoot, server.url, ["axiom"]);
+        const local = await runCli(
+          ["provision", "--dir", concurrentTarget, "--name", "livro-caixa"],
+          concurrentRoot,
+          concurrentTarget,
+          server,
+        );
+        expect(local.exitCode).toBe(0);
+        const [staging, production] = await Promise.all([
+          runCli(
+            provisionArgs(concurrentTarget, "staging", ["axiom"]),
+            concurrentRoot,
+            concurrentTarget,
+            server,
+          ),
+          runCli(
+            provisionArgs(concurrentTarget, "production", ["axiom"]),
+            concurrentRoot,
+            concurrentTarget,
+            server,
+          ),
+        ]);
+        expect(staging.exitCode).toBe(0);
+        expect(production.exitCode).toBe(0);
+        const persisted = await readPersisted(concurrentRoot);
+        expect(persisted.environments.map((environment) => environment.environment).sort()).toEqual(
+          ["production", "staging"],
+        );
+        expect(persisted.axiom?.token).toBe("axiom-admin-secret");
+        expect((await stat(join(concurrentRoot, "credentials.json"))).mode & 0o777).toBe(0o600);
+        assertNoSecretOutput(staging);
+        assertNoSecretOutput(production);
+      } finally {
+        server.stop();
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
+});

--- a/packages/cli/test/RemoteEnvironment.bun.test.ts
+++ b/packages/cli/test/RemoteEnvironment.bun.test.ts
@@ -2,81 +2,196 @@ import { describe, expect, test } from "bun:test";
 import { Effect, Layer, Option } from "effect";
 import {
   AxiomCredentials,
+  CredentialsAccess,
+  CredentialsError,
   CredentialsFile,
   CredentialsStore,
   SentryCredentials,
 } from "../src/CredentialsStore.ts";
-import { AxiomApi, SentryApi } from "../src/ProviderApis.ts";
+import { AxiomApi, RemoteApiError, SentryApi } from "../src/ProviderApis.ts";
 import {
+  environmentAxiom,
   environmentDatasets,
+  environmentSentry,
   parseEnvironmentName,
+  parseProviderSelection,
   RemoteEnvironment,
 } from "../src/RemoteEnvironment.ts";
 
-const makeRemoteLayer = () => {
-  let credentials = new CredentialsFile({
-    version: 1,
-    axiom: new AxiomCredentials({ token: "xapt-admin", organizationId: "org-id" }),
-    sentry: new SentryCredentials({
-      token: "sentry-admin",
-      organization: "maxxi-cash",
-      team: "backend",
-      baseUrl: new URL("https://sentry.io"),
-    }),
-    environments: [],
-  });
+type RemoteOptions = {
+  readonly axiom?: boolean;
+  readonly sentry?: boolean;
+};
+
+const makeRemoteLayer = (options: RemoteOptions = {}) => {
+  const includeAxiom = options.axiom ?? true;
+  const includeSentry = options.sentry ?? true;
+  const axiom = includeAxiom
+    ? new AxiomCredentials({ token: "xapt-admin", organizationId: "org-id" })
+    : undefined;
+  const sentry = includeSentry
+    ? new SentryCredentials({
+        token: "sentry-admin",
+        organization: "maxxi-cash",
+        team: "backend",
+        baseUrl: new URL("https://sentry.io"),
+      })
+    : undefined;
+  let credentials =
+    axiom !== undefined && sentry !== undefined
+      ? new CredentialsFile({ version: 2, axiom, sentry, environments: [] })
+      : axiom !== undefined
+        ? new CredentialsFile({ version: 2, axiom, environments: [] })
+        : sentry !== undefined
+          ? new CredentialsFile({ version: 2, sentry, environments: [] })
+          : new CredentialsFile({ version: 2, environments: [] });
   const datasets: Array<string> = [];
   const tokens: Array<{ readonly id: string; readonly name: string }> = [];
   let tokenCreations = 0;
   let tokenRegenerations = 0;
+  let axiomDatasetLists = 0;
+  let axiomTokenLists = 0;
+  let sentryProjectCalls = 0;
+  let sentryDsnCalls = 0;
+  let failedDataset = Option.none<string>();
+  let failSentry = false;
+  let failTokenMutation = false;
+  let failSave = false;
 
+  const access: CredentialsAccess = {
+    load: () => Effect.succeed(Option.some(credentials)),
+    save: (next) => {
+      if (failSave) {
+        return Effect.fail(
+          new CredentialsError({
+            code: "OBS_CLI_CREDENTIALS_FAILED",
+            message: "The credentials file could not be saved.",
+            cause: "test-save-failure",
+          }),
+        );
+      }
+      return Effect.sync(() => {
+        credentials = next;
+      });
+    },
+  };
   const store = CredentialsStore.of({
     path: "/private/credentials.json",
-    load: () => Effect.succeed(Option.some(credentials)),
-    save: (next) =>
-      Effect.sync(() => {
-        credentials = next;
-      }),
+    load: () => access.load(),
+    save: (next) => access.save(next),
+    exclusive: (use) => use(access),
   });
-  const axiom = AxiomApi.of({
+  const axiomApi = AxiomApi.of({
     identity: () => Effect.succeed("owner@example.com"),
-    datasets: () => Effect.succeed(datasets),
-    createDataset: (_credentials, name) =>
+    datasets: () =>
       Effect.sync(() => {
-        datasets.push(name);
+        axiomDatasetLists += 1;
+        return datasets;
       }),
-    tokens: () => Effect.succeed(tokens),
-    createToken: (_credentials, name) =>
+    createDataset: (_credentials, name) => {
+      if (Option.contains(failedDataset, name)) {
+        return Effect.fail(
+          new RemoteApiError({
+            code: "OBS_CLI_REMOTE_FAILED",
+            message: "Axiom returned HTTP 500. Retry the command.",
+            provider: "Axiom",
+            status: 500,
+            cause: name,
+          }),
+        );
+      }
+      return Effect.sync(() => {
+        datasets.push(name);
+      });
+    },
+    tokens: () =>
       Effect.sync(() => {
+        axiomTokenLists += 1;
+        return tokens;
+      }),
+    createToken: (_credentials, name) => {
+      if (failTokenMutation) {
+        return Effect.fail(
+          new RemoteApiError({
+            code: "OBS_CLI_REMOTE_INVALID_RESPONSE",
+            message: "Axiom returned an invalid response.",
+            provider: "Axiom",
+            status: 201,
+            cause: name,
+          }),
+        );
+      }
+      return Effect.sync(() => {
         tokenCreations += 1;
         const token = { id: `token-${tokenCreations}`, name };
         tokens.push(token);
         return { id: token.id, token: `secret-${tokenCreations}` };
-      }),
+      });
+    },
     regenerateToken: (_credentials, id) =>
       Effect.sync(() => {
         tokenRegenerations += 1;
         return { id, token: `rotated-${tokenRegenerations}` };
       }),
   });
-  const sentry = SentryApi.of({
+  const sentryApi = SentryApi.of({
     identity: () => Effect.succeed("Maxxi Cash"),
-    ensureProject: (_credentials, slug) => Effect.succeed(slug),
-    dsn: () => Effect.succeed("https://public@sentry.example/1"),
+    ensureProject: (_credentials, slug) => {
+      sentryProjectCalls += 1;
+      if (failSentry) {
+        return Effect.fail(
+          new RemoteApiError({
+            code: "OBS_CLI_REMOTE_FAILED",
+            message: "Sentry returned HTTP 500. Retry the command.",
+            provider: "Sentry",
+            status: 500,
+            cause: slug,
+          }),
+        );
+      }
+      return Effect.succeed(slug);
+    },
+    dsn: () =>
+      Effect.sync(() => {
+        sentryDsnCalls += 1;
+        return "https://public@sentry.example/1";
+      }),
   });
   const dependencies = Layer.mergeAll(
     Layer.succeed(CredentialsStore, store),
-    Layer.succeed(AxiomApi, axiom),
-    Layer.succeed(SentryApi, sentry),
+    Layer.succeed(AxiomApi, axiomApi),
+    Layer.succeed(SentryApi, sentryApi),
   );
 
   return {
     layer: RemoteEnvironment.layer.pipe(Layer.provide(dependencies)),
-    state: () => ({ credentials, datasets, tokens, tokenCreations, tokenRegenerations }),
+    failDataset: (name: string) => {
+      failedDataset = Option.some(name);
+    },
+    failSentry: () => {
+      failSentry = true;
+    },
+    failTokenMutation: () => {
+      failTokenMutation = true;
+    },
+    failSave: () => {
+      failSave = true;
+    },
+    state: () => ({
+      credentials,
+      datasets,
+      tokens,
+      tokenCreations,
+      tokenRegenerations,
+      axiomDatasetLists,
+      axiomTokenLists,
+      sentryProjectCalls,
+      sentryDsnCalls,
+    }),
   };
 };
 
-describe("environment names", () => {
+describe("environment and provider names", () => {
   test("builds one dataset per signal and environment", async () => {
     const result = await Effect.runPromise(environmentDatasets("livro-caixa", "staging"));
     expect(result).toEqual({
@@ -86,38 +201,145 @@ describe("environment names", () => {
     });
   });
 
-  test("rejects malformed environment names", async () => {
-    const error = await Effect.runPromise(Effect.flip(parseEnvironmentName("Production US")));
-    expect(error.code).toBe("OBS_CLI_REMOTE_INVALID_ENVIRONMENT");
+  test("rejects malformed environment and provider names", async () => {
+    const environment = await Effect.runPromise(Effect.flip(parseEnvironmentName("Production US")));
+    const provider = await Effect.runPromise(Effect.flip(parseProviderSelection(["honeycomb"])));
+    expect(environment.code).toBe("OBS_CLI_REMOTE_INVALID_ENVIRONMENT");
+    expect(provider.code).toBe("OBS_CLI_REMOTE_INVALID_PROVIDER");
+  });
+
+  test("deduplicates providers in canonical order", async () => {
+    const providers = await Effect.runPromise(
+      parseProviderSelection(["sentry", "axiom", "sentry"]),
+    );
+    expect(providers).toEqual(["axiom", "sentry"]);
   });
 });
 
 describe("RemoteEnvironment", () => {
-  test("provisions isolated datasets and one reusable ingest token", async () => {
+  test("preserves combined omission behavior and repeats without duplicate resources", async () => {
     const remote = makeRemoteLayer();
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         const service = yield* RemoteEnvironment;
-        const first = yield* service.provision("livro-caixa", ["staging"], "node", false);
-        const second = yield* service.provision("livro-caixa", ["staging"], "node", false);
+        const first = yield* service.provision("livro-caixa", ["staging"], [], "node", false);
+        const second = yield* service.provision("livro-caixa", ["staging"], [], "node", false);
         const exported = yield* service.export("livro-caixa", "staging");
         return { first, second, exported };
       }).pipe(Effect.provide(remote.layer)),
     );
     const state = remote.state();
 
-    expect(result.first).toHaveLength(1);
-    expect(result.second).toHaveLength(1);
-    expect(state.datasets).toEqual([
-      "livro-caixa-staging-traces",
-      "livro-caixa-staging-logs",
-      "livro-caixa-staging-metrics",
-    ]);
+    expect(result.first[0]?.providers.type).toBe("combined");
+    expect(result.second[0]?.providers.type).toBe("combined");
+    expect(state.datasets).toHaveLength(3);
     expect(state.tokenCreations).toBe(1);
+    expect(state.sentryProjectCalls).toBe(2);
     expect(state.credentials.environments).toHaveLength(1);
-    expect(result.exported).toContain('OTEL_DEPLOYMENT_ENVIRONMENT="staging"');
+    expect(result.exported.split("\n")).toHaveLength(8);
     expect(result.exported).toContain('AXIOM_TOKEN="secret-1"');
     expect(result.exported).toContain('SENTRY_DSN="https://public@sentry.example/1"');
+  });
+
+  test("provisions and repeats Axiom without calling Sentry", async () => {
+    const remote = makeRemoteLayer({ sentry: false });
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        yield* service.provision("livro-caixa", ["staging"], ["axiom"], "node", false);
+        const repeated = yield* service.provision("livro-caixa", ["staging"], [], "node", false);
+        return {
+          repeated,
+          exported: yield* service.export("livro-caixa", "staging"),
+        };
+      }).pipe(Effect.provide(remote.layer)),
+    );
+    const state = remote.state();
+
+    expect(result.repeated[0]?.providers.type).toBe("axiom");
+    expect(state.sentryProjectCalls).toBe(0);
+    expect(state.sentryDsnCalls).toBe(0);
+    expect(state.tokenCreations).toBe(1);
+    expect(result.exported.split("\n")).toHaveLength(7);
+    expect(result.exported).not.toContain("SENTRY_DSN");
+  });
+
+  test("provisions and repeats Sentry without calling Axiom", async () => {
+    const remote = makeRemoteLayer({ axiom: false });
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        yield* service.provision("livro-caixa", ["staging"], ["sentry"], "node", false);
+        const repeated = yield* service.provision("livro-caixa", ["staging"], [], "node", false);
+        return {
+          repeated,
+          exported: yield* service.export("livro-caixa", "staging"),
+        };
+      }).pipe(Effect.provide(remote.layer)),
+    );
+    const state = remote.state();
+
+    expect(result.repeated[0]?.providers.type).toBe("sentry");
+    expect(state.axiomDatasetLists).toBe(0);
+    expect(state.axiomTokenLists).toBe(0);
+    expect(result.exported).toBe(
+      'OTEL_SERVICE_NAME="livro-caixa"\nOTEL_DEPLOYMENT_ENVIRONMENT="staging"\nSENTRY_DSN="https://public@sentry.example/1"',
+    );
+  });
+
+  test("adds an explicitly selected provider to existing state", async () => {
+    const remote = makeRemoteLayer();
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        yield* service.provision("livro-caixa", ["staging"], ["sentry"], "node", false);
+        return yield* service.provision("livro-caixa", ["staging"], ["axiom"], "node", false);
+      }).pipe(Effect.provide(remote.layer)),
+    );
+
+    const managed = result[0];
+    expect(managed?.providers.type).toBe("combined");
+    if (managed !== undefined) {
+      expect(Option.isSome(environmentAxiom(managed))).toBeTrue();
+      expect(Option.isSome(environmentSentry(managed))).toBeTrue();
+    }
+  });
+
+  test("preserves the combined missing-credentials error when both providers are absent", async () => {
+    const remote = makeRemoteLayer({ axiom: false, sentry: false });
+    const error = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        return yield* Effect.flip(service.provision("livro-caixa", ["staging"], [], "node", false));
+      }).pipe(Effect.provide(remote.layer)),
+    );
+
+    expect(error._tag).toBe("RemoteEnvironmentError");
+    if (error._tag === "RemoteEnvironmentError") {
+      expect(error.code).toBe("OBS_CLI_REMOTE_CREDENTIALS_MISSING");
+    }
+    expect(remote.state().axiomDatasetLists).toBe(0);
+    expect(remote.state().sentryProjectCalls).toBe(0);
+  });
+
+  test("requires only selected provider credentials before provider calls", async () => {
+    const remote = makeRemoteLayer({ axiom: false });
+    const error = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        return yield* Effect.flip(
+          service.provision("livro-caixa", ["staging"], ["axiom"], "node", false),
+        );
+      }).pipe(Effect.provide(remote.layer)),
+    );
+
+    expect(error._tag).toBe("RemoteEnvironmentError");
+    if (error._tag === "RemoteEnvironmentError") {
+      expect(error.code).toBe("OBS_CLI_REMOTE_PROVIDER_CREDENTIALS_MISSING");
+      expect(error.message).toContain("auth login axiom");
+    }
+    expect(remote.state().axiomDatasetLists).toBe(0);
+    expect(remote.state().sentryProjectCalls).toBe(0);
   });
 
   test("requires rotation when the remote token has no local secret", async () => {
@@ -130,7 +352,9 @@ describe("RemoteEnvironment", () => {
     const error = await Effect.runPromise(
       Effect.gen(function* () {
         const service = yield* RemoteEnvironment;
-        return yield* Effect.flip(service.provision("livro-caixa", ["staging"], "node", false));
+        return yield* Effect.flip(
+          service.provision("livro-caixa", ["staging"], ["axiom"], "node", false),
+        );
       }).pipe(Effect.provide(remote.layer)),
     );
 
@@ -138,25 +362,128 @@ describe("RemoteEnvironment", () => {
     if (error._tag === "RemoteEnvironmentError") {
       expect(error.code).toBe("OBS_CLI_REMOTE_TOKEN_UNAVAILABLE");
       expect(error.message).toContain("--rotate-token");
-      expect(error.message).not.toContain("xapt-admin");
-      expect(error.message).not.toContain("sentry-admin");
     }
   });
 
-  test("rotates an existing Axiom token only when requested", async () => {
+  test("rotates Axiom state and preserves Sentry", async () => {
     const remote = makeRemoteLayer();
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         const service = yield* RemoteEnvironment;
-        yield* service.provision("livro-caixa", ["production"], "node", false);
-        return yield* service.provision("livro-caixa", ["production"], "node", true);
+        yield* service.provision("livro-caixa", ["production"], [], "node", false);
+        return yield* service.provision("livro-caixa", ["production"], ["axiom"], "node", true);
       }).pipe(Effect.provide(remote.layer)),
     );
-    const state = remote.state();
+    const managed = result[0];
 
-    expect(state.tokenCreations).toBe(1);
-    expect(state.tokenRegenerations).toBe(1);
-    expect(result[0]?.axiomToken).toBe("rotated-1");
-    expect(state.credentials.environments[0]?.axiomToken).toBe("rotated-1");
+    expect(remote.state().tokenRegenerations).toBe(1);
+    expect(managed?.providers.type).toBe("combined");
+    if (managed !== undefined) {
+      expect(Option.getOrThrow(environmentAxiom(managed)).token).toBe("rotated-1");
+      expect(Option.getOrThrow(environmentSentry(managed)).project).toBe("livro-caixa");
+    }
+  });
+
+  test("rejects rotation before provider calls when any environment excludes Axiom", async () => {
+    const remote = makeRemoteLayer();
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        yield* service.provision("livro-caixa", ["staging"], ["sentry"], "node", false);
+      }).pipe(Effect.provide(remote.layer)),
+    );
+    const calls = remote.state();
+
+    const error = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        return yield* Effect.flip(service.provision("livro-caixa", ["staging"], [], "node", true));
+      }).pipe(Effect.provide(remote.layer)),
+    );
+
+    expect(error._tag).toBe("RemoteEnvironmentError");
+    if (error._tag === "RemoteEnvironmentError") {
+      expect(error.code).toBe("OBS_CLI_REMOTE_ROTATION_NOT_SELECTED");
+    }
+    expect(remote.state().axiomDatasetLists).toBe(calls.axiomDatasetLists);
+    expect(remote.state().sentryProjectCalls).toBe(calls.sentryProjectCalls);
+  });
+
+  test("does not mutate an Axiom token when Sentry fails first", async () => {
+    const remote = makeRemoteLayer();
+    remote.failSentry();
+    const error = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        return yield* Effect.flip(service.provision("livro-caixa", ["staging"], [], "node", false));
+      }).pipe(Effect.provide(remote.layer)),
+    );
+
+    expect(error._tag).toBe("RemoteApiError");
+    expect(remote.state().axiomDatasetLists).toBe(0);
+    expect(remote.state().tokenCreations).toBe(0);
+  });
+
+  test("classifies an unreadable token mutation response as outcome unknown", async () => {
+    const remote = makeRemoteLayer();
+    remote.failTokenMutation();
+    const error = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        return yield* Effect.flip(
+          service.provision("livro-caixa", ["staging"], ["axiom"], "node", false),
+        );
+      }).pipe(Effect.provide(remote.layer)),
+    );
+
+    expect(error._tag).toBe("RemoteEnvironmentError");
+    if (error._tag === "RemoteEnvironmentError") {
+      expect(error.code).toBe("OBS_CLI_REMOTE_OUTCOME_UNKNOWN");
+      expect(error.message).toContain("Rotate the token");
+    }
+    expect(remote.state().credentials.environments).toHaveLength(0);
+  });
+
+  test("classifies a failed checkpoint after token creation as outcome unknown", async () => {
+    const remote = makeRemoteLayer();
+    remote.failSave();
+    const error = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        return yield* Effect.flip(
+          service.provision("livro-caixa", ["staging"], ["axiom"], "node", false),
+        );
+      }).pipe(Effect.provide(remote.layer)),
+    );
+
+    expect(error._tag).toBe("RemoteEnvironmentError");
+    if (error._tag === "RemoteEnvironmentError") {
+      expect(error.code).toBe("OBS_CLI_REMOTE_OUTCOME_UNKNOWN");
+      expect(error.message).toContain("Rotate the token");
+    }
+    expect(remote.state().tokenCreations).toBe(1);
+    expect(remote.state().credentials.environments).toHaveLength(0);
+  });
+
+  test("keeps an earlier checkpoint when a later environment fails", async () => {
+    const remote = makeRemoteLayer();
+    remote.failDataset("livro-caixa-production-traces");
+    const error = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        return yield* Effect.flip(
+          service.provision("livro-caixa", ["staging", "production"], ["axiom"], "node", false),
+        );
+      }).pipe(Effect.provide(remote.layer)),
+    );
+
+    expect(error._tag).toBe("RemoteEnvironmentError");
+    if (error._tag === "RemoteEnvironmentError") {
+      expect(error.code).toBe("OBS_CLI_REMOTE_PARTIAL_FAILURE");
+      expect(error.message).toContain("livro-caixa/staging");
+    }
+    expect(remote.state().credentials.environments.map((item) => item.environment)).toEqual([
+      "staging",
+    ]);
   });
 });

--- a/packages/cli/test/RemoteEnvironment.bun.test.ts
+++ b/packages/cli/test/RemoteEnvironment.bun.test.ts
@@ -56,7 +56,10 @@ const makeRemoteLayer = (options: RemoteOptions = {}) => {
   let sentryDsnCalls = 0;
   let failedDataset = Option.none<string>();
   let failSentry = false;
-  let failedTokenMutationStatus = Option.none<number>();
+  let failedTokenMutation = Option.none<{
+    readonly status: number;
+    readonly code: "OBS_CLI_REMOTE_FAILED" | "OBS_CLI_REMOTE_INVALID_RESPONSE";
+  }>();
   let failedSaveCall = Option.none<number>();
   let saveCalls = 0;
 
@@ -113,14 +116,13 @@ const makeRemoteLayer = (options: RemoteOptions = {}) => {
         return tokens;
       }),
     createToken: (_credentials, name) => {
-      if (Option.isSome(failedTokenMutationStatus)) {
-        const status = failedTokenMutationStatus.value;
+      if (Option.isSome(failedTokenMutation)) {
         return Effect.fail(
           new RemoteApiError({
-            code: status === 201 ? "OBS_CLI_REMOTE_INVALID_RESPONSE" : "OBS_CLI_REMOTE_FAILED",
+            code: failedTokenMutation.value.code,
             message: "Axiom token mutation failed.",
             provider: "Axiom",
-            status,
+            status: failedTokenMutation.value.status,
             cause: name,
           }),
         );
@@ -175,8 +177,13 @@ const makeRemoteLayer = (options: RemoteOptions = {}) => {
     failSentry: () => {
       failSentry = true;
     },
-    failTokenMutation: (status = 201) => {
-      failedTokenMutationStatus = Option.some(status);
+    failTokenMutation: (
+      status = 201,
+      code:
+        | "OBS_CLI_REMOTE_FAILED"
+        | "OBS_CLI_REMOTE_INVALID_RESPONSE" = "OBS_CLI_REMOTE_INVALID_RESPONSE",
+    ) => {
+      failedTokenMutation = Option.some({ status, code });
     },
     failSaveAt: (call: number) => {
       failedSaveCall = Option.some(call);
@@ -532,9 +539,25 @@ describe("RemoteEnvironment", () => {
     expect(remote.state().credentials.environments).toHaveLength(0);
   });
 
+  test("clears pending state only for definite HTTP 4xx token rejection", async () => {
+    const remote = makeRemoteLayer();
+    remote.failTokenMutation(400, "OBS_CLI_REMOTE_FAILED");
+    const error = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        return yield* Effect.flip(
+          service.provision("livro-caixa", ["staging"], ["axiom"], "node", false),
+        );
+      }).pipe(Effect.provide(remote.layer)),
+    );
+
+    expect(error._tag).toBe("RemoteApiError");
+    expect(remote.state().credentials.pendingAxiomMutations).toBeUndefined();
+  });
+
   test("classifies HTTP 5xx token mutation responses as outcome unknown", async () => {
     const remote = makeRemoteLayer();
-    remote.failTokenMutation(503);
+    remote.failTokenMutation(503, "OBS_CLI_REMOTE_FAILED");
     const error = await Effect.runPromise(
       Effect.gen(function* () {
         const service = yield* RemoteEnvironment;
@@ -554,7 +577,7 @@ describe("RemoteEnvironment", () => {
 
   test("classifies token mutation transport failures as outcome unknown", async () => {
     const remote = makeRemoteLayer();
-    remote.failTokenMutation(0);
+    remote.failTokenMutation(0, "OBS_CLI_REMOTE_FAILED");
     const error = await Effect.runPromise(
       Effect.gen(function* () {
         const service = yield* RemoteEnvironment;
@@ -571,6 +594,52 @@ describe("RemoteEnvironment", () => {
     expect(remote.state().credentials.pendingAxiomMutations).toEqual([
       { project: "livro-caixa", environment: "staging" },
     ]);
+  });
+
+  test("keeps pending state for successful-status token body failures", async () => {
+    for (const status of [200, 201]) {
+      const remote = makeRemoteLayer();
+      remote.failTokenMutation(status, "OBS_CLI_REMOTE_FAILED");
+      const error = await Effect.runPromise(
+        Effect.gen(function* () {
+          const service = yield* RemoteEnvironment;
+          return yield* Effect.flip(
+            service.provision("livro-caixa", ["staging"], ["axiom"], "node", false),
+          );
+        }).pipe(Effect.provide(remote.layer)),
+      );
+
+      expect(error._tag).toBe("RemoteEnvironmentError");
+      if (error._tag === "RemoteEnvironmentError") {
+        expect(error.code).toBe("OBS_CLI_REMOTE_OUTCOME_UNKNOWN");
+      }
+      expect(remote.state().credentials.pendingAxiomMutations).toEqual([
+        { project: "livro-caixa", environment: "staging" },
+      ]);
+    }
+  });
+
+  test("keeps pending state for unexpected successful token statuses", async () => {
+    for (const status of [202, 204]) {
+      const remote = makeRemoteLayer();
+      remote.failTokenMutation(status, "OBS_CLI_REMOTE_FAILED");
+      const error = await Effect.runPromise(
+        Effect.gen(function* () {
+          const service = yield* RemoteEnvironment;
+          return yield* Effect.flip(
+            service.provision("livro-caixa", ["staging"], ["axiom"], "node", false),
+          );
+        }).pipe(Effect.provide(remote.layer)),
+      );
+
+      expect(error._tag).toBe("RemoteEnvironmentError");
+      if (error._tag === "RemoteEnvironmentError") {
+        expect(error.code).toBe("OBS_CLI_REMOTE_OUTCOME_UNKNOWN");
+      }
+      expect(remote.state().credentials.pendingAxiomMutations).toEqual([
+        { project: "livro-caixa", environment: "staging" },
+      ]);
+    }
   });
 
   test("classifies a failed checkpoint after token creation as outcome unknown", async () => {

--- a/packages/cli/test/RemoteEnvironment.bun.test.ts
+++ b/packages/cli/test/RemoteEnvironment.bun.test.ts
@@ -6,6 +6,7 @@ import {
   CredentialsError,
   CredentialsFile,
   CredentialsStore,
+  PendingAxiomMutation,
   SentryCredentials,
 } from "../src/CredentialsStore.ts";
 import { AxiomApi, RemoteApiError, SentryApi } from "../src/ProviderApis.ts";
@@ -55,13 +56,15 @@ const makeRemoteLayer = (options: RemoteOptions = {}) => {
   let sentryDsnCalls = 0;
   let failedDataset = Option.none<string>();
   let failSentry = false;
-  let failTokenMutation = false;
-  let failSave = false;
+  let failedTokenMutationStatus = Option.none<number>();
+  let failedSaveCall = Option.none<number>();
+  let saveCalls = 0;
 
   const access: CredentialsAccess = {
     load: () => Effect.succeed(Option.some(credentials)),
     save: (next) => {
-      if (failSave) {
+      saveCalls += 1;
+      if (Option.contains(failedSaveCall, saveCalls)) {
         return Effect.fail(
           new CredentialsError({
             code: "OBS_CLI_CREDENTIALS_FAILED",
@@ -110,13 +113,14 @@ const makeRemoteLayer = (options: RemoteOptions = {}) => {
         return tokens;
       }),
     createToken: (_credentials, name) => {
-      if (failTokenMutation) {
+      if (Option.isSome(failedTokenMutationStatus)) {
+        const status = failedTokenMutationStatus.value;
         return Effect.fail(
           new RemoteApiError({
-            code: "OBS_CLI_REMOTE_INVALID_RESPONSE",
-            message: "Axiom returned an invalid response.",
+            code: status === 201 ? "OBS_CLI_REMOTE_INVALID_RESPONSE" : "OBS_CLI_REMOTE_FAILED",
+            message: "Axiom token mutation failed.",
             provider: "Axiom",
-            status: 201,
+            status,
             cause: name,
           }),
         );
@@ -171,11 +175,42 @@ const makeRemoteLayer = (options: RemoteOptions = {}) => {
     failSentry: () => {
       failSentry = true;
     },
-    failTokenMutation: () => {
-      failTokenMutation = true;
+    failTokenMutation: (status = 201) => {
+      failedTokenMutationStatus = Option.some(status);
     },
-    failSave: () => {
-      failSave = true;
+    failSaveAt: (call: number) => {
+      failedSaveCall = Option.some(call);
+    },
+    markPendingAxiomMutation: (project: string, environment: string) => {
+      const pendingAxiomMutations = [new PendingAxiomMutation({ project, environment })];
+      credentials =
+        credentials.axiom !== undefined && credentials.sentry !== undefined
+          ? new CredentialsFile({
+              version: 2,
+              axiom: credentials.axiom,
+              sentry: credentials.sentry,
+              environments: credentials.environments,
+              pendingAxiomMutations,
+            })
+          : credentials.axiom !== undefined
+            ? new CredentialsFile({
+                version: 2,
+                axiom: credentials.axiom,
+                environments: credentials.environments,
+                pendingAxiomMutations,
+              })
+            : credentials.sentry !== undefined
+              ? new CredentialsFile({
+                  version: 2,
+                  sentry: credentials.sentry,
+                  environments: credentials.environments,
+                  pendingAxiomMutations,
+                })
+              : new CredentialsFile({
+                  version: 2,
+                  environments: credentials.environments,
+                  pendingAxiomMutations,
+                });
     },
     state: () => ({
       credentials,
@@ -187,6 +222,7 @@ const makeRemoteLayer = (options: RemoteOptions = {}) => {
       axiomTokenLists,
       sentryProjectCalls,
       sentryDsnCalls,
+      saveCalls,
     }),
   };
 };
@@ -384,6 +420,58 @@ describe("RemoteEnvironment", () => {
     }
   });
 
+  test("rejects a stale local token after an unresolved mutation until explicit rotation", async () => {
+    const remote = makeRemoteLayer();
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        yield* service.provision("livro-caixa", ["production"], ["axiom"], "node", false);
+      }).pipe(Effect.provide(remote.layer)),
+    );
+    remote.markPendingAxiomMutation("livro-caixa", "production");
+    const callsBeforeRecovery = remote.state();
+    const exportError = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        return yield* Effect.flip(service.export("livro-caixa", "production"));
+      }).pipe(Effect.provide(remote.layer)),
+    );
+    expect(exportError._tag).toBe("RemoteEnvironmentError");
+    if (exportError._tag === "RemoteEnvironmentError") {
+      expect(exportError.code).toBe("OBS_CLI_REMOTE_TOKEN_UNAVAILABLE");
+    }
+
+    const error = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        return yield* Effect.flip(
+          service.provision("livro-caixa", ["production"], ["axiom"], "node", false),
+        );
+      }).pipe(Effect.provide(remote.layer)),
+    );
+
+    expect(error._tag).toBe("RemoteEnvironmentError");
+    if (error._tag === "RemoteEnvironmentError") {
+      expect(error.code).toBe("OBS_CLI_REMOTE_TOKEN_UNAVAILABLE");
+      expect(error.message).toContain("--rotate-token");
+    }
+    expect(remote.state().axiomDatasetLists).toBe(callsBeforeRecovery.axiomDatasetLists);
+    expect(remote.state().axiomTokenLists).toBe(callsBeforeRecovery.axiomTokenLists);
+
+    const recovered = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        return yield* service.provision("livro-caixa", ["production"], ["axiom"], "node", true);
+      }).pipe(Effect.provide(remote.layer)),
+    );
+    const recoveredEnvironment = recovered[0];
+    expect(recoveredEnvironment).toBeDefined();
+    if (recoveredEnvironment !== undefined) {
+      expect(Option.getOrThrow(environmentAxiom(recoveredEnvironment)).token).toBe("rotated-1");
+    }
+    expect(remote.state().credentials.pendingAxiomMutations).toBeUndefined();
+  });
+
   test("rejects rotation before provider calls when any environment excludes Axiom", async () => {
     const remote = makeRemoteLayer();
     await Effect.runPromise(
@@ -444,9 +532,50 @@ describe("RemoteEnvironment", () => {
     expect(remote.state().credentials.environments).toHaveLength(0);
   });
 
+  test("classifies HTTP 5xx token mutation responses as outcome unknown", async () => {
+    const remote = makeRemoteLayer();
+    remote.failTokenMutation(503);
+    const error = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        return yield* Effect.flip(
+          service.provision("livro-caixa", ["staging"], ["axiom"], "node", false),
+        );
+      }).pipe(Effect.provide(remote.layer)),
+    );
+
+    expect(error._tag).toBe("RemoteEnvironmentError");
+    if (error._tag === "RemoteEnvironmentError") {
+      expect(error.code).toBe("OBS_CLI_REMOTE_OUTCOME_UNKNOWN");
+      expect(error.message).toContain("Rotate the token");
+    }
+    expect(remote.state().credentials.environments).toHaveLength(0);
+  });
+
+  test("classifies token mutation transport failures as outcome unknown", async () => {
+    const remote = makeRemoteLayer();
+    remote.failTokenMutation(0);
+    const error = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        return yield* Effect.flip(
+          service.provision("livro-caixa", ["staging"], ["axiom"], "node", false),
+        );
+      }).pipe(Effect.provide(remote.layer)),
+    );
+
+    expect(error._tag).toBe("RemoteEnvironmentError");
+    if (error._tag === "RemoteEnvironmentError") {
+      expect(error.code).toBe("OBS_CLI_REMOTE_OUTCOME_UNKNOWN");
+    }
+    expect(remote.state().credentials.pendingAxiomMutations).toEqual([
+      { project: "livro-caixa", environment: "staging" },
+    ]);
+  });
+
   test("classifies a failed checkpoint after token creation as outcome unknown", async () => {
     const remote = makeRemoteLayer();
-    remote.failSave();
+    remote.failSaveAt(2);
     const error = await Effect.runPromise(
       Effect.gen(function* () {
         const service = yield* RemoteEnvironment;


### PR DESCRIPTION
## Summary

- add Axiom-only, Sentry-only, and combined remote provisioning with additive persisted provider state
- preserve v1 credentials through v2 migration, durable environment checkpoints, and explicit rotation recovery
- harden provider redirects, ambiguous mutation outcomes, secret handling, and cross-process credential locking

## Verification

- built CLI loopback provider flows with no live provider requests
- migration, concurrency, rotation, crash recovery, stale-lock, redirect, and secret-output tests
- `bun check`
- `bun run build`
- `bun run test`
- `bun run test:package`
- generated asset diff and project provisioning recipe
- independent exact-head review

Linear: OBS-8
