### PR TITLE
fix(collector): bound persistent queues and recovery operations

### DIFF
--- a/.agents/skills/verify-observability/features/README.md
+++ b/.agents/skills/verify-observability/features/README.md
@@ -43,6 +43,7 @@ Each feature file contains exactly four H2 sections in this order.
 
 - [Project asset setup](./project-provisioning.md) covers creation, idempotency, conflict protection, and forced replacement.
 - [Local stack lifecycle](./local-stack-lifecycle.md) covers launch, status, viewer readiness, and teardown.
+- [Collector production recovery](./collector-recovery.md) covers persistent queue restart, drain, saturation, health, and internal metrics.
 - [Pipeline canary](./pipeline-canary.md) covers traces, logs, metrics, browser events, and redaction.
 - [Provider authentication](./provider-authentication.md) covers protected login prompts, credential permissions, and provider status.
 - [Package delivery](./package-delivery.md) covers package files, imports, declarations, CLI help, and packaged assets.

--- a/.agents/skills/verify-observability/features/collector-recovery.md
+++ b/.agents/skills/verify-observability/features/collector-recovery.md
@@ -1,0 +1,49 @@
+# Collector production recovery
+
+This recipe proves persistent queue recovery and bounded rejection with the pinned Collector image. It never uses provider credentials or existing Docker resources.
+
+## Sub-features
+
+- `queue-outage` accepts traces, logs, and metrics while the disposable sink is unavailable.
+- `queue-restart` restarts the source Collector with the same disposable queue directory.
+- `queue-drain` recovers the sink and proves exact receipt and zero queue depth.
+- `queue-saturation` fills a four-request canary queue and proves synchronous HTTP 503 responses.
+- `queue-health` proves that destination outage and queue saturation keep the process health endpoint available.
+- `queue-metrics` proves capacity, depth, receiver refusal, and enqueue failure metrics.
+
+## How to get to it (user POV)
+
+- Provision `observability/collector.yaml` and `observability/kamal.accessory.yml` into a project.
+- Prepare the dedicated host filesystem and directory described in `docs/collector-production-operations.md`.
+- Probe `http://127.0.0.1:13133/health` from the host.
+- Scrape `http://127.0.0.1:8888/metrics` from the host.
+- Follow the documented inspect, drain, backup, token rotation, quarantine, and rollback sequences.
+
+## Driving it with verify-observability
+
+Preconditions:
+
+- Docker is available.
+- `otel/opentelemetry-collector-contrib:0.159.0` can run.
+- The parent skill created `ARTIFACT_ROOT`.
+- No resource name begins with the test's generated `obs10-<pid>-<uuid>` prefix.
+
+1. Record `docker version` and the pinned image digest in the artifact directory.
+2. Run `bun test packages/cli/test/CollectorAssets.bun.test.ts --timeout 30000` and record stdout, stderr, and exit code.
+3. Run the pinned production validation command from the implementation brief and record stdout, stderr, and exit code.
+4. Run `OBSERVABILITY_COLLECTOR_RECOVERY=1 OBSERVABILITY_COLLECTOR_RECOVERY_ARTIFACT_ROOT="$ARTIFACT_ROOT/collector-recovery" bun test packages/cli/test/CollectorRecovery.bun.test.ts --timeout 120000` and record stdout, stderr, and exit code.
+5. Require one passing recovery test and no failures.
+6. Confirm that `docker ps -a --format '{{.Names}}'` and `docker network ls --format '{{.Name}}'` contain no resource with the generated prefix after the test.
+7. Copy the production Collector asset, accessory asset, test output, pinned image digest, and build revision into `ARTIFACT_ROOT/collector-recovery`.
+
+The maintained test creates a unique Docker network, unique bind-mounted queue and receipt directories, random loopback host ports, one source Collector, and disposable sink Collectors. It sends unique event identities. It verifies accepted outage requests, queue growth for all signals, process health, a changed source container identity after restart, exact sink receipt, complete drain, four accepted saturation requests and four HTTP 503 responses per signal, refusal metrics, enqueue failure metrics, and health during saturation. Cleanup removes only resources with the generated prefix and only its temporary directory.
+
+## Gotchas
+
+- The production queue capacity is 64 requests per exporter. The saturation proof intentionally uses four requests so the test stays fast.
+- `queue_size` counts export requests, not bytes or telemetry items.
+- The health endpoint reports process and component startup, not destination availability.
+- File storage `max_size` is a fail-safe, not the normal rejection boundary.
+- Docker Desktop bind-mount permissions differ from a Linux production host. The canary runs the source as `10001:10001`, while production additionally requires owner `10001:10001` and mode `0700`.
+- At-least-once delivery may duplicate data after an unclean failure. The maintained clean outage case expects exactly one receipt.
+- Never point this recipe at Axiom, production credentials, an existing queue, or fixed shared ports.

--- a/.agents/skills/verify-observability/features/collector-recovery.md
+++ b/.agents/skills/verify-observability/features/collector-recovery.md
@@ -28,7 +28,7 @@ Preconditions:
 - The parent skill created `ARTIFACT_ROOT`.
 - No resource name begins with the test's generated `obs10-<pid>-<uuid>` prefix.
 
-1. Record `docker version` and the pinned image digest in the artifact directory.
+1. Record `docker version`, `kamal version`, and the pinned image digest in the artifact directory.
 2. Run `bun test packages/cli/test/CollectorAssets.bun.test.ts --timeout 30000` and record stdout, stderr, and exit code.
 3. Run the pinned production validation command from the implementation brief and record stdout, stderr, and exit code.
 4. Run `OBSERVABILITY_COLLECTOR_RECOVERY=1 OBSERVABILITY_COLLECTOR_RECOVERY_ARTIFACT_ROOT="$ARTIFACT_ROOT/collector-recovery" bun test packages/cli/test/CollectorRecovery.bun.test.ts --timeout 120000` and record stdout, stderr, and exit code.
@@ -36,7 +36,7 @@ Preconditions:
 6. Confirm that `docker ps -a --format '{{.Names}}'` and `docker network ls --format '{{.Name}}'` contain no resource with the generated prefix after the test.
 7. Copy the production Collector asset, accessory asset, test output, pinned image digest, and build revision into `ARTIFACT_ROOT/collector-recovery`.
 
-The maintained test creates a unique Docker network, unique bind-mounted queue and receipt directories, random loopback host ports, one source Collector, and disposable sink Collectors. It sends unique event identities. It verifies accepted outage requests, queue growth for all signals, process health, a changed source container identity after restart, exact sink receipt, complete drain, four accepted saturation requests and four HTTP 503 responses per signal, refusal metrics, enqueue failure metrics, and health during saturation. Cleanup removes only resources with the generated prefix and only its temporary directory.
+The maintained test creates a unique Docker network, unique bind-mounted queue and receipt directories, random loopback host ports, one source Collector, and disposable sink Collectors. It sends unique event identities. It sends unique traces, logs, and metrics before outage, during outage, and after restart. It verifies queue growth for all signals, process health, a changed source container identity after restart, exact final receipt counts after queues remain empty for one second, four accepted saturation requests and four HTTP 503 responses per signal, refusal metrics, enqueue failure metrics, and health during saturation. Cleanup removes only resources with the generated prefix and only its temporary directory.
 
 ## Gotchas
 
@@ -44,6 +44,6 @@ The maintained test creates a unique Docker network, unique bind-mounted queue a
 - `queue_size` counts export requests, not bytes or telemetry items.
 - The health endpoint reports process and component startup, not destination availability.
 - File storage `max_size` is a fail-safe, not the normal rejection boundary.
-- Docker Desktop bind-mount permissions differ from a Linux production host. The canary runs the source as `10001:10001`, while production additionally requires owner `10001:10001` and mode `0700`.
+- Docker Desktop bind-mount permissions differ from a Linux production host. The canary runs the source as `10001:10001`, while a Linux host must separately prove owner `10001:10001` and mode `0700` with the documented bootstrap and post-boot checks.
 - At-least-once delivery may duplicate data after an unclean failure. The maintained clean outage case expects exactly one receipt.
 - Never point this recipe at Axiom, production credentials, an existing queue, or fixed shared ports.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
       - run: bun run test:package
       - run: docker run --rm -v "$PWD/packages/cli/src/assets/local.yaml:/etc/otelcol/config.yaml:ro" otel/opentelemetry-collector-contrib:0.159.0 validate --config=/etc/otelcol/config.yaml
       - run: docker run --rm -e AXIOM_TOKEN=test -e AXIOM_DATASET_TRACES=traces -e AXIOM_DATASET_LOGS=logs -e AXIOM_DATASET_METRICS=metrics -v "$PWD/packages/cli/src/assets/production.yaml:/etc/otelcol/config.yaml:ro" otel/opentelemetry-collector-contrib:0.159.0 validate --config=/etc/otelcol/config.yaml
+      - name: Collector outage, restart, and saturation proof
+        timeout-minutes: 3
+        env:
+          OBSERVABILITY_COLLECTOR_RECOVERY: "1"
+          OBSERVABILITY_COLLECTOR_RECOVERY_ARTIFACT_ROOT: ${{ runner.temp }}/collector-recovery
+        run: bun test packages/cli/test/CollectorRecovery.bun.test.ts --timeout 120000
       - run: bun packages/cli/src/main.ts dev up
       - run: curl --fail --silent --show-error --retry 10 --retry-all-errors --retry-delay 1 http://localhost:8000/ > /dev/null
       - run: OBSERVABILITY_E2E=1 bun test:canary

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ O [otel-desktop-viewer](https://github.com/CtrlSpice/otel-desktop-viewer) recebe
 app -> otel-collector (Kamal accessory) -> Axiom
 ```
 
-O Collector roda como accessory do [Kamal](https://kamal-deploy.org), com fila persistente e sem porta OTLP pública.
+O Collector roda como accessory do [Kamal](https://kamal-deploy.org), com filas persistentes limitadas por sinal e sem porta OTLP pública. Saúde e métricas internas são publicadas somente em loopback. Consulte [Operar a fila persistente do Collector](docs/collector-production-operations.md) antes do primeiro deploy.
 
 ## Estrutura
 
@@ -115,7 +115,7 @@ O comando escreve no projeto alvo:
 - `observability/collector.yaml`: configuração do OTel Collector de produção (fila persistente e exporters Axiom)
 - `observability/kamal.accessory.yml`: trecho de accessory para mesclar em `config/deploy.yml`, com os datasets `<name>-traces|logs|metrics`
 
-O comando é idempotente. Um arquivo provisionado que foi modificado localmente gera o erro `OBS_CLI_PROVISION_CONFLICT`; use `--force` para sobrescrever. Depois do merge do accessory, defina o secret `AXIOM_TOKEN` no Kamal.
+O comando é idempotente. Um arquivo provisionado que foi modificado localmente gera o erro `OBS_CLI_PROVISION_CONFLICT`; use `--force` para sobrescrever. Depois do merge do accessory, prepare o filesystem dedicado de 8 GiB, valide owner `10001:10001` e mode `0700`, e defina o secret `AXIOM_TOKEN` no Kamal. Pare produtores antes de 75% de uso ou com menos de 2 GiB livres. O procedimento completo de health, alertas, drain, backup e rotação está em [Operar a fila persistente do Collector](docs/collector-production-operations.md).
 
 ### Ambientes remotos
 

--- a/docs/collector-production-operations.md
+++ b/docs/collector-production-operations.md
@@ -1,0 +1,154 @@
+# Operar a fila persistente do Collector
+
+O Collector de produção mantém uma fila independente para traces, logs e métricas. Cada fila aceita no máximo 64 requisições. O batching do exporter limita cada requisição exportada a 8 MiB quando o sinal pode ser dividido. O limite lógico aproximado é 512 MiB por sinal, sem contar o overhead do bbolt.
+
+O retry não expira. Capacidade de fila e capacidade do filesystem limitam o uso de recursos. Erros permanentes do destino, incluindo credenciais inválidas, podem descartar telemetria. Nunca exponha uma fila não vazia a uma credencial que ainda não foi verificada.
+
+## Preparar o host
+
+O asset provisionado usa `/var/lib/observability/<name>/collector/queue`. Antes do primeiro boot:
+
+1. Monte um filesystem dedicado de 8 GiB em `/var/lib/observability/<name>/collector`.
+2. Confirme que o path é um mount separado.
+3. Confirme capacidade total de 8 GiB e pelo menos 2 GiB livres.
+4. Confirme owner `10001:10001` e mode `0700` no diretório `queue`.
+5. Interrompa o deploy se qualquer precondição falhar.
+
+O Kamal prepara o diretório com owner e mode declarados no accessory. O filesystem dedicado continua sendo uma precondição de infraestrutura. Não substitua esse diretório por um named volume root-owned.
+
+Execute o preflight no host e não prossiga se um teste falhar:
+
+```sh
+QUEUE_ROOT="/var/lib/observability/<name>/collector"
+test "$(findmnt --noheadings --output TARGET --target "$QUEUE_ROOT")" = "$QUEUE_ROOT"
+test "$(find "$QUEUE_ROOT/queue" -maxdepth 0 -printf '%U:%G %m')" = "10001:10001 700"
+test "$(df --block-size=1 --output=size "$QUEUE_ROOT" | tail -1 | tr -d ' ')" -ge "8589934592"
+test "$(df --block-size=1 --output=avail "$QUEUE_ROOT" | tail -1 | tr -d ' ')" -ge "2147483648"
+```
+
+Cada banco do `file_storage` tem limite terminal de 2 GiB. Os três bancos podem ocupar até 6 GiB. `max_size` é somente um último limite de proteção. A saturação física pode ocorrer sem incremento confiável nos contadores de rejeição. Não espere um banco chegar a 2 GiB.
+
+## Saúde, métricas e alertas
+
+O accessory publica somente em loopback:
+
+- `http://127.0.0.1:13133/health` para saúde do processo.
+- `http://127.0.0.1:8888/metrics` para telemetria interna.
+
+Use timeout de 5 segundos no probe externo e alerte depois de três falhas consecutivas:
+
+```sh
+curl --max-time 5 --fail --silent --show-error http://127.0.0.1:13133/health
+```
+
+HTTP 200 informa que o processo e os componentes configurados iniciaram. Uma indisponibilidade do destino ou uma fila saturada permanece saudável enquanto o Collector continua executando. Falha de conexão indica startup, restart, shutdown, falha do processo ou falha de bind. O asset não declara Docker health porque a imagem distroless não contém uma ferramenta interna de probe.
+
+Consulte estes contadores e gauges em `0.159.0`:
+
+- Entrada aceita: `otelcol_receiver_accepted_spans`, `otelcol_receiver_accepted_log_records`, `otelcol_receiver_accepted_metric_points`.
+- Entrada recusada: `otelcol_receiver_refused_spans`, `otelcol_receiver_refused_log_records`, `otelcol_receiver_refused_metric_points`.
+- Estado da fila: `otelcol_exporter_queue_size`, `otelcol_exporter_queue_capacity`, `otelcol_exporter_in_flight_requests`.
+- Falha de enqueue: `otelcol_exporter_enqueue_failed_spans`, `otelcol_exporter_enqueue_failed_log_records`, `otelcol_exporter_enqueue_failed_metric_points`.
+- Falha de envio: `otelcol_exporter_send_failed_spans`, `otelcol_exporter_send_failed_log_records`, `otelcol_exporter_send_failed_metric_points`.
+- Envio concluído: `otelcol_exporter_sent_spans`, `otelcol_exporter_sent_log_records`, `otelcol_exporter_sent_metric_points`.
+- Tamanho do batch: `otelcol_exporter_enqueue_size_bytes`, `otelcol_exporter_queue_batch_send_size_bytes`.
+
+A versão `0.159.0` não expõe um contador estável dedicado a retry. Falhas de envio crescentes junto com fila persistente indicam retry. Essas métricas detalhadas de exporter têm estabilidade alpha.
+
+Use estes thresholds por exporter:
+
+| Estado    |                                  Fila |    Duração |
+| --------- | ------------------------------------: | ---------: |
+| Warning   |           pelo menos 45 de 64, ou 70% | 15 minutos |
+| Critical  |           pelo menos 55 de 64, ou 85% |  5 minutos |
+| Emergency |           pelo menos 61 de 64, ou 95% |   1 minuto |
+| Saturated | 64 de 64 ou qualquer falha de enqueue |   imediato |
+
+No filesystem dedicado:
+
+- Warning em 60% usados, ou 4,8 GiB.
+- Critical em 70% usados, ou 5,6 GiB.
+- Hard stop em 75% usados, ou 6 GiB.
+- Hard stop com menos de 2 GiB livres.
+
+No hard stop, interrompa os produtores de telemetria e preserve a fila. Não apague arquivos para recuperar capacidade.
+
+## Inspecionar e drenar
+
+Para inspecionar:
+
+1. Verifique o health endpoint.
+2. Capture todas as métricas de fila, enqueue e envio.
+3. Registre o container ID e o digest da imagem.
+4. Registre capacidade e espaço livre do filesystem.
+5. Registre o tamanho de cada banco.
+6. Mantenha o Collector ativo.
+
+Não abra um banco bbolt vivo com outro writer. Não copie arquivos bbolt vivos como backup.
+
+Para drenar:
+
+1. Interrompa os produtores de telemetria.
+2. Mantenha o Collector ativo.
+3. Verifique que o destino aceita telemetria.
+4. Aguarde cada `otelcol_exporter_queue_size` chegar a zero.
+5. Aguarde 30 segundos e confirme zero novamente.
+6. Confirme que os contadores de envio cresceram.
+7. Confirme que os contadores de enqueue failure não cresceram.
+8. Faça backup frio antes de qualquer manutenção.
+
+## Backup frio
+
+1. Interrompa os produtores.
+2. Aguarde o fim de entrada em voo.
+3. Pare o accessory.
+4. Confirme que nenhum container usa o diretório.
+5. Crie um archive fora do filesystem dedicado, preservando owners numéricos.
+6. Gere e registre o SHA-256.
+7. Registre source path, image digest e timestamp.
+8. Reinicie com a mesma configuração.
+9. Verifique saúde e métricas de fila.
+
+```sh
+sudo tar --numeric-owner -C "$QUEUE_ROOT" -czf "$BACKUP_PATH" queue
+sha256sum "$BACKUP_PATH" > "$BACKUP_PATH.sha256"
+```
+
+## Rotacionar token
+
+1. Mantenha o token antigo ativo.
+2. Crie o token novo.
+3. Verifique o token novo fora da fila de produção.
+4. Interrompa os produtores.
+5. Drene com o token antigo.
+6. Confirme fila zero duas vezes.
+7. Faça backup frio.
+8. Instale o novo secret do Kamal.
+9. Reinicie o accessory com o mesmo diretório.
+10. Envie um canário único para cada sinal.
+11. Confirme export bem-sucedido e fila zero.
+12. Revogue o token antigo.
+
+Se a verificação do token novo falhar, restaure o secret antigo. Não reinicie uma fila não vazia com credenciais não verificadas.
+
+## Quarentena e rollback
+
+Quarentena é uma operação destrutiva do ponto de vista da fila ativa. Exige aprovação explícita de perda de dados. Nunca é automática.
+
+1. Confirme que recuperação do destino e rollback de token falharam.
+2. Obtenha aprovação explícita de perda de dados.
+3. Interrompa produtores e Collector.
+4. Faça e assine um backup frio.
+5. Renomeie `queue` para um diretório irmão com timestamp.
+6. Crie um novo `queue` com mode `0700` e owner `10001:10001`.
+7. Inicie o Collector e verifique saúde.
+8. Envie um canário único por sinal e verifique export.
+9. Retenha a quarentena até o fim da janela de rollback.
+
+Nunca apague a quarentena durante a recuperação.
+
+Para rollback, interrompa produtores e Collector, mova a fila nova para outro path de quarentena, restaure o nome original, confira owner e mode, restaure o token antigo quando necessário, reinicie e só então retome produtores depois de verificar saúde e profundidade da fila.
+
+## Garantias e limites
+
+A fila oferece entrega pelo menos uma vez. Uma falha abrupta pode duplicar dados. Payload comprimido pode expandir na memória. O bbolt retém a alocação máxima depois do drain. Erros permanentes do destino podem descartar itens. A garantia de 8 GiB depende do filesystem provisionado no host e não pode ser criada somente pelo asset do Kamal.

--- a/docs/collector-production-operations.md
+++ b/docs/collector-production-operations.md
@@ -8,23 +8,27 @@ O retry não expira. Capacidade de fila e capacidade do filesystem limitam o uso
 
 O asset provisionado usa `/var/lib/observability/<name>/collector/queue`. Antes do primeiro boot:
 
-1. Monte um filesystem dedicado de 8 GiB em `/var/lib/observability/<name>/collector`.
-2. Confirme que o path é um mount separado.
-3. Confirme capacidade total de 8 GiB e pelo menos 2 GiB livres.
-4. Confirme owner `10001:10001` e mode `0700` no diretório `queue`.
+1. Monte um filesystem dedicado de pelo menos 8 GiB em `/var/lib/observability/<name>/collector`.
+2. Confirme que o path é um mount separado e tem pelo menos 2 GiB livres.
+3. Crie `queue` com owner `10001:10001` e mode `0700`.
+4. Confirme owner e mode depois da criação e novamente depois do primeiro boot.
 5. Interrompa o deploy se qualquer precondição falhar.
 
-O Kamal prepara o diretório com owner e mode declarados no accessory. O filesystem dedicado continua sendo uma precondição de infraestrutura. Não substitua esse diretório por um named volume root-owned.
+O Kamal também declara owner e mode no accessory. O bootstrap explícito permite validar o host antes que o container exista. O filesystem dedicado continua sendo uma precondição de infraestrutura. Não substitua esse diretório por um named volume root-owned.
 
-Execute o preflight no host e não prossiga se um teste falhar:
+Execute o bootstrap e o preflight no host e não prossiga se um teste falhar:
 
 ```sh
 QUEUE_ROOT="/var/lib/observability/<name>/collector"
+test -d "$QUEUE_ROOT"
 test "$(findmnt --noheadings --output TARGET --target "$QUEUE_ROOT")" = "$QUEUE_ROOT"
-test "$(find "$QUEUE_ROOT/queue" -maxdepth 0 -printf '%U:%G %m')" = "10001:10001 700"
 test "$(df --block-size=1 --output=size "$QUEUE_ROOT" | tail -1 | tr -d ' ')" -ge "8589934592"
 test "$(df --block-size=1 --output=avail "$QUEUE_ROOT" | tail -1 | tr -d ' ')" -ge "2147483648"
+sudo install -d -o 10001 -g 10001 -m 0700 "$QUEUE_ROOT/queue"
+test "$(find "$QUEUE_ROOT/queue" -maxdepth 0 -printf '%U:%G %m')" = "10001:10001 700"
 ```
+
+Depois do primeiro boot, repita o último teste antes de liberar produtores.
 
 Cada banco do `file_storage` tem limite terminal de 2 GiB. Os três bancos podem ocupar até 6 GiB. `max_size` é somente um último limite de proteção. A saturação física pode ocorrer sem incremento confiável nos contadores de rejeição. Não espere um banco chegar a 2 GiB.
 
@@ -53,7 +57,7 @@ Consulte estes contadores e gauges em `0.159.0`:
 - Envio concluído: `otelcol_exporter_sent_spans`, `otelcol_exporter_sent_log_records`, `otelcol_exporter_sent_metric_points`.
 - Tamanho do batch: `otelcol_exporter_enqueue_size_bytes`, `otelcol_exporter_queue_batch_send_size_bytes`.
 
-A versão `0.159.0` não expõe um contador estável dedicado a retry. Falhas de envio crescentes junto com fila persistente indicam retry. Essas métricas detalhadas de exporter têm estabilidade alpha.
+A versão `0.159.0` não expõe um contador estável dedicado a retry. Fila crescente ou persistente com contadores `sent` estáveis indica retry. Um contador `send_failed` crescente indica falha permanente de export e possível descarte, não retry. Essas métricas detalhadas de exporter têm estabilidade alpha.
 
 Use estes thresholds por exporter:
 
@@ -139,15 +143,32 @@ Quarentena é uma operação destrutiva do ponto de vista da fila ativa. Exige a
 2. Obtenha aprovação explícita de perda de dados.
 3. Interrompa produtores e Collector.
 4. Faça e assine um backup frio.
-5. Renomeie `queue` para um diretório irmão com timestamp.
-6. Crie um novo `queue` com mode `0700` e owner `10001:10001`.
-7. Inicie o Collector e verifique saúde.
-8. Envie um canário único por sinal e verifique export.
-9. Retenha a quarentena até o fim da janela de rollback.
+5. Selecione um `QUARANTINE_ROOT` em outro filesystem.
+6. Confirme com `findmnt` que os filesystems são distintos.
+7. Confirme que o espaço livre em `QUARANTINE_ROOT` é maior que o tamanho total de `queue`.
+8. Mova `queue` para `QUARANTINE_ROOT/queue-<timestamp>` enquanto o Collector permanece parado.
+9. Crie um novo `queue` com mode `0700` e owner `10001:10001`.
+10. Inicie o Collector e verifique saúde.
+11. Envie um canário único por sinal e verifique export.
+12. Retenha a quarentena até o fim da janela de rollback.
 
-Nunca apague a quarentena durante a recuperação.
+Nunca mantenha a quarentena no filesystem dedicado de 8 GiB. Nunca apague a quarentena durante a recuperação.
 
-Para rollback, interrompa produtores e Collector, mova a fila nova para outro path de quarentena, restaure o nome original, confira owner e mode, restaure o token antigo quando necessário, reinicie e só então retome produtores depois de verificar saúde e profundidade da fila.
+Para rollback, interrompa produtores e Collector, mova a fila nova para um segundo path fora do filesystem dedicado, restaure a fila original a partir de `QUARANTINE_ROOT`, confira owner e mode, restaure o token antigo quando necessário, reinicie e só então retome produtores depois de verificar saúde e profundidade da fila.
+
+## Migrar deployments existentes
+
+O asset anterior usava o named volume `otel-collector-queue`. Não troque diretamente para o bind mount com uma fila ativa.
+
+1. Registre `kamal version`, o container ID, o digest da imagem e o nome do volume.
+2. Interrompa os produtores e drene a fila com a configuração antiga.
+3. Confirme profundidade zero duas vezes e faça backup frio do named volume.
+4. Prepare o filesystem e o bind mount com o bootstrap desta página.
+5. Com o Collector parado, copie o backup para o novo diretório e aplique owner `10001:10001` e mode `0700`.
+6. Inicie somente a configuração nova, verifique saúde, fila e um canário por sinal.
+7. Retenha o named volume antigo até o fim da janela de rollback.
+
+Os nomes `otlphttp/traces`, `otlphttp/logs` e `otlphttp/metrics` fazem parte da identidade persistida das filas. Renomear um exporter pode deixar itens antigos inacessíveis. Drene, faça backup frio e prove a migração antes de qualquer mudança futura nesses nomes.
 
 ## Garantias e limites
 

--- a/packages/cli/src/RemoteEnvironment.ts
+++ b/packages/cli/src/RemoteEnvironment.ts
@@ -327,7 +327,7 @@ export class RemoteEnvironment extends Context.Service<
           const variables = [
             ["OTEL_SERVICE_NAME", managed.project],
             ["OTEL_DEPLOYMENT_ENVIRONMENT", managed.environment],
-            ["OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector:4318"],
+            ["OTEL_EXPORTER_OTLP_ENDPOINT", `http://${managed.project}-otel-collector:4318`],
             ["AXIOM_TOKEN", managed.axiomToken],
             ["AXIOM_DATASET_TRACES", managed.tracesDataset],
             ["AXIOM_DATASET_LOGS", managed.logsDataset],

--- a/packages/cli/src/assets/kamal.accessory.yml
+++ b/packages/cli/src/assets/kamal.accessory.yml
@@ -1,5 +1,6 @@
 accessories:
   otel-collector:
+    service: "{{name}}-otel-collector"
     image: otel/opentelemetry-collector-contrib:0.159.0
     roles:
       - web

--- a/packages/cli/src/assets/kamal.accessory.yml
+++ b/packages/cli/src/assets/kamal.accessory.yml
@@ -6,8 +6,17 @@ accessories:
     cmd: --config=/etc/otelcol/collector.yaml
     files:
       - observability/collector.yaml:/etc/otelcol/collector.yaml
-    volumes:
-      - otel-collector-queue:/var/lib/otelcol/queue
+    directories:
+      - local: /var/lib/observability/{{name}}/collector/queue
+        remote: /var/lib/otelcol/queue
+        mode: "0700"
+        owner: "10001:10001"
+    port: "127.0.0.1:13133:13133"
+    options:
+      publish:
+        - "127.0.0.1:8888:8888"
+      restart: unless-stopped
+      user: "10001:10001"
     env:
       secret:
         - AXIOM_TOKEN

--- a/packages/cli/src/assets/production.yaml
+++ b/packages/cli/src/assets/production.yaml
@@ -2,14 +2,22 @@ extensions:
   file_storage/queue:
     directory: /var/lib/otelcol/queue
     create_directory: true
+    max_size: 2147483648
+    fsync: true
+    recreate: false
+  health_check:
+    endpoint: 0.0.0.0:13133
+    path: /health
 
 receivers:
   otlp:
     protocols:
       grpc:
         endpoint: 0.0.0.0:4317
+        max_recv_msg_size_mib: 8
       http:
         endpoint: 0.0.0.0:4318
+        max_request_body_size: 8388608
 
 processors:
   memory_limiter:
@@ -63,9 +71,6 @@ processors:
       - "(?s)-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----.*?-----END (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"
     redact_all_types: true
     summary: silent
-  batch:
-    send_batch_size: 2048
-    timeout: 5s
 
 exporters:
   otlphttp/traces:
@@ -77,8 +82,18 @@ exporters:
     sending_queue:
       enabled: true
       storage: file_storage/queue
+      queue_size: 64
+      num_consumers: 1
+      block_on_overflow: false
+      batch:
+        flush_timeout: 200ms
+        min_size: 1
+        max_size: 8388608
+        sizer: bytes
     retry_on_failure:
       enabled: true
+      initial_interval: 5s
+      max_interval: 30s
       max_elapsed_time: 0
   otlphttp/logs:
     endpoint: https://api.axiom.co
@@ -89,8 +104,18 @@ exporters:
     sending_queue:
       enabled: true
       storage: file_storage/queue
+      queue_size: 64
+      num_consumers: 1
+      block_on_overflow: false
+      batch:
+        flush_timeout: 200ms
+        min_size: 1
+        max_size: 8388608
+        sizer: bytes
     retry_on_failure:
       enabled: true
+      initial_interval: 5s
+      max_interval: 30s
       max_elapsed_time: 0
   otlphttp/metrics:
     endpoint: https://api.axiom.co
@@ -101,24 +126,41 @@ exporters:
     sending_queue:
       enabled: true
       storage: file_storage/queue
+      queue_size: 64
+      num_consumers: 1
+      block_on_overflow: false
+      batch:
+        flush_timeout: 200ms
+        min_size: 1
+        max_size: 8388608
+        sizer: bytes
     retry_on_failure:
       enabled: true
+      initial_interval: 5s
+      max_interval: 30s
       max_elapsed_time: 0
 
 service:
-  extensions: [file_storage/queue]
+  telemetry:
+    metrics:
+      level: detailed
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: 0.0.0.0
+                port: 8888
+  extensions: [file_storage/queue, health_check]
   pipelines:
     traces:
       receivers: [otlp]
-      processors:
-        [memory_limiter, transform/environment, transform/redact, redaction/sensitive, batch]
+      processors: [memory_limiter, transform/environment, transform/redact, redaction/sensitive]
       exporters: [otlphttp/traces]
     logs:
       receivers: [otlp]
-      processors:
-        [memory_limiter, transform/environment, transform/redact, redaction/sensitive, batch]
+      processors: [memory_limiter, transform/environment, transform/redact, redaction/sensitive]
       exporters: [otlphttp/logs]
     metrics:
       receivers: [otlp]
-      processors: [memory_limiter, transform/environment, redaction/sensitive, batch]
+      processors: [memory_limiter, transform/environment, redaction/sensitive]
       exporters: [otlphttp/metrics]

--- a/packages/cli/test/CollectorAssets.bun.test.ts
+++ b/packages/cli/test/CollectorAssets.bun.test.ts
@@ -114,6 +114,7 @@ const ProductionConfig = Schema.Struct({
 const KamalAccessory = Schema.Struct({
   accessories: Schema.Struct({
     "otel-collector": Schema.Struct({
+      service: Schema.String,
       image: Schema.String,
       directories: Schema.Array(
         Schema.Struct({
@@ -262,6 +263,14 @@ describe("Collector assets", () => {
     expectCollectorContract(production, true);
     expectProductionOperations(production);
 
+    const changedQueueCapacity = production.replace("queue_size: 64", "queue_size: 65");
+    expect(changedQueueCapacity).not.toBe(production);
+    expect(() => expectProductionOperations(changedQueueCapacity)).toThrow(/64/);
+
+    const changedQueueBatchLimit = production.replace("max_size: 8388608", "max_size: 8388609");
+    expect(changedQueueBatchLimit).not.toBe(production);
+    expect(() => expectProductionOperations(changedQueueBatchLimit)).toThrow(/8388608/);
+
     const withoutTraceAttributeRedaction = production.replace(
       "transform/redact, redaction/sensitive",
       "transform/redact",
@@ -280,6 +289,8 @@ describe("Collector assets", () => {
     const parsed: unknown = Bun.YAML.parse(rendered);
     const decoded = decodeKamalAccessory(parsed).accessories["otel-collector"];
 
+    expect(decoded.service).toBe("verify-app-otel-collector");
+    expect(decoded.service).not.toBe("otel-collector");
     expect(decoded.image).toBe("otel/opentelemetry-collector-contrib:0.159.0");
     expect(decoded.directories).toEqual([
       {

--- a/packages/cli/test/CollectorAssets.bun.test.ts
+++ b/packages/cli/test/CollectorAssets.bun.test.ts
@@ -28,7 +28,114 @@ const CollectorConfig = Schema.Struct({
   }),
 });
 
+const QueueBatch = Schema.Struct({
+  flush_timeout: Schema.String,
+  min_size: Schema.Number,
+  max_size: Schema.Number,
+  sizer: Schema.String,
+});
+
+const SendingQueue = Schema.Struct({
+  enabled: Schema.Boolean,
+  storage: Schema.String,
+  queue_size: Schema.Number,
+  num_consumers: Schema.Number,
+  block_on_overflow: Schema.Boolean,
+  batch: QueueBatch,
+});
+
+const RetryPolicy = Schema.Struct({
+  enabled: Schema.Boolean,
+  initial_interval: Schema.String,
+  max_interval: Schema.String,
+  max_elapsed_time: Schema.Number,
+});
+
+const ProductionExporter = Schema.Struct({
+  sending_queue: SendingQueue,
+  retry_on_failure: RetryPolicy,
+});
+
+const ProductionConfig = Schema.Struct({
+  extensions: Schema.Struct({
+    "file_storage/queue": Schema.Struct({
+      directory: Schema.String,
+      create_directory: Schema.Boolean,
+      max_size: Schema.Number,
+      fsync: Schema.Boolean,
+      recreate: Schema.Boolean,
+    }),
+    health_check: Schema.Struct({
+      endpoint: Schema.String,
+      path: Schema.String,
+    }),
+  }),
+  receivers: Schema.Struct({
+    otlp: Schema.Struct({
+      protocols: Schema.Struct({
+        grpc: Schema.Struct({
+          endpoint: Schema.String,
+          max_recv_msg_size_mib: Schema.Number,
+        }),
+        http: Schema.Struct({
+          endpoint: Schema.String,
+          max_request_body_size: Schema.Number,
+        }),
+      }),
+    }),
+  }),
+  exporters: Schema.Struct({
+    "otlphttp/traces": ProductionExporter,
+    "otlphttp/logs": ProductionExporter,
+    "otlphttp/metrics": ProductionExporter,
+  }),
+  service: Schema.Struct({
+    telemetry: Schema.Struct({
+      metrics: Schema.Struct({
+        level: Schema.String,
+        readers: Schema.Array(
+          Schema.Struct({
+            pull: Schema.Struct({
+              exporter: Schema.Struct({
+                prometheus: Schema.Struct({
+                  host: Schema.String,
+                  port: Schema.Number,
+                }),
+              }),
+            }),
+          }),
+        ),
+      }),
+    }),
+    extensions: Schema.Array(Schema.String),
+  }),
+});
+
+const KamalAccessory = Schema.Struct({
+  accessories: Schema.Struct({
+    "otel-collector": Schema.Struct({
+      image: Schema.String,
+      directories: Schema.Array(
+        Schema.Struct({
+          local: Schema.String,
+          remote: Schema.String,
+          mode: Schema.String,
+          owner: Schema.String,
+        }),
+      ),
+      port: Schema.String,
+      options: Schema.Struct({
+        publish: Schema.Array(Schema.String),
+        restart: Schema.String,
+        user: Schema.String,
+      }),
+    }),
+  }),
+});
+
 const decodeCollectorConfig = Schema.decodeUnknownSync(CollectorConfig);
+const decodeProductionConfig = Schema.decodeUnknownSync(ProductionConfig);
+const decodeKamalAccessory = Schema.decodeUnknownSync(KamalAccessory);
 
 const collectorBlock = (config: string, startMarker: string, endMarker: string): string => {
   const start = config.indexOf(startMarker);
@@ -41,15 +148,20 @@ const collectorBlock = (config: string, startMarker: string, endMarker: string):
 const environmentBlock = (config: string): string =>
   collectorBlock(config, "  transform/environment:", "  transform/redact:");
 
-const redactionBlock = (config: string): string =>
-  collectorBlock(config, "  transform/redact:", "  batch:");
+const redactionTransformBlock = (config: string): string =>
+  collectorBlock(config, "  transform/redact:", "  redaction/sensitive:");
+
+const sensitiveRedactionBlock = (config: string): string => {
+  const endMarker = config.includes("\n  batch:") ? "\n  batch:" : "\nexporters:";
+  return collectorBlock(config, "  redaction/sensitive:", endMarker);
+};
 
 const legacyToCanonical =
   'set(resource.attributes["deployment.environment.name"], resource.attributes["deployment.environment"]) where resource.attributes["deployment.environment.name"] == nil and resource.attributes["deployment.environment"] != nil';
 const canonicalToLegacy =
   'set(resource.attributes["deployment.environment"], resource.attributes["deployment.environment.name"]) where resource.attributes["deployment.environment.name"] != nil';
 
-const expectCollectorContract = (config: string): void => {
+const expectCollectorContract = (config: string, production: boolean): void => {
   const parsed: unknown = Bun.YAML.parse(config);
   const decoded = decodeCollectorConfig(parsed);
   const environment = decoded.processors["transform/environment"];
@@ -74,12 +186,64 @@ const expectCollectorContract = (config: string): void => {
     "transform/environment",
     "transform/redact",
     "redaction/sensitive",
-    "batch",
   ];
-  const metrics = ["memory_limiter", "transform/environment", "redaction/sensitive", "batch"];
+  const metrics = ["memory_limiter", "transform/environment", "redaction/sensitive"];
+  if (!production) {
+    tracesAndLogs.push("batch");
+    metrics.push("batch");
+  }
   expect(pipelines.traces.processors).toEqual(tracesAndLogs);
   expect(pipelines.logs.processors).toEqual(tracesAndLogs);
   expect(pipelines.metrics.processors).toEqual(metrics);
+};
+
+const expectProductionOperations = (config: string): void => {
+  const parsed: unknown = Bun.YAML.parse(config);
+  const decoded = decodeProductionConfig(parsed);
+  expect(decoded.extensions["file_storage/queue"]).toEqual({
+    directory: "/var/lib/otelcol/queue",
+    create_directory: true,
+    max_size: 2_147_483_648,
+    fsync: true,
+    recreate: false,
+  });
+  expect(decoded.extensions.health_check).toEqual({
+    endpoint: "0.0.0.0:13133",
+    path: "/health",
+  });
+  expect(decoded.receivers.otlp.protocols.grpc.max_recv_msg_size_mib).toBe(8);
+  expect(decoded.receivers.otlp.protocols.http.max_request_body_size).toBe(8_388_608);
+  expect(decoded.service.extensions).toEqual(["file_storage/queue", "health_check"]);
+  expect(decoded.service.telemetry.metrics).toEqual({
+    level: "detailed",
+    readers: [{ pull: { exporter: { prometheus: { host: "0.0.0.0", port: 8888 } } } }],
+  });
+
+  for (const exporter of [
+    decoded.exporters["otlphttp/traces"],
+    decoded.exporters["otlphttp/logs"],
+    decoded.exporters["otlphttp/metrics"],
+  ]) {
+    expect(exporter.sending_queue).toEqual({
+      enabled: true,
+      storage: "file_storage/queue",
+      queue_size: 64,
+      num_consumers: 1,
+      block_on_overflow: false,
+      batch: {
+        flush_timeout: "200ms",
+        min_size: 1,
+        max_size: 8_388_608,
+        sizer: "bytes",
+      },
+    });
+    expect(exporter.retry_on_failure).toEqual({
+      enabled: true,
+      initial_interval: "5s",
+      max_interval: "30s",
+      max_elapsed_time: 0,
+    });
+  }
 };
 
 describe("Collector assets", () => {
@@ -90,17 +254,48 @@ describe("Collector assets", () => {
     ]);
 
     expect(environmentBlock(local)).toBe(environmentBlock(production));
-    expect(redactionBlock(local)).toBe(redactionBlock(production));
-    expectCollectorContract(local);
-    expectCollectorContract(production);
+    expect(redactionTransformBlock(local)).toBe(redactionTransformBlock(production));
+    expect(sensitiveRedactionBlock(local).trimEnd()).toBe(
+      sensitiveRedactionBlock(production).trimEnd(),
+    );
+    expectCollectorContract(local, false);
+    expectCollectorContract(production, true);
+    expectProductionOperations(production);
 
     const withoutTraceAttributeRedaction = production.replace(
       "transform/redact, redaction/sensitive",
       "transform/redact",
     );
     expect(withoutTraceAttributeRedaction).not.toBe(production);
-    expect(() => expectCollectorContract(withoutTraceAttributeRedaction)).toThrow(
+    expect(() => expectCollectorContract(withoutTraceAttributeRedaction, true)).toThrow(
       /redaction\/sensitive/,
     );
+  });
+
+  test("binds health and metrics to loopback and prepares the Collector queue directory", async () => {
+    const asset = await Bun.file(
+      new URL("../src/assets/kamal.accessory.yml", import.meta.url),
+    ).text();
+    const rendered = asset.replaceAll("{{name}}", "verify-app");
+    const parsed: unknown = Bun.YAML.parse(rendered);
+    const decoded = decodeKamalAccessory(parsed).accessories["otel-collector"];
+
+    expect(decoded.image).toBe("otel/opentelemetry-collector-contrib:0.159.0");
+    expect(decoded.directories).toEqual([
+      {
+        local: "/var/lib/observability/verify-app/collector/queue",
+        remote: "/var/lib/otelcol/queue",
+        mode: "0700",
+        owner: "10001:10001",
+      },
+    ]);
+    expect(decoded.port).toBe("127.0.0.1:13133:13133");
+    expect(decoded.options).toEqual({
+      publish: ["127.0.0.1:8888:8888"],
+      restart: "unless-stopped",
+      user: "10001:10001",
+    });
+    expect(rendered).not.toContain("volumes:");
+    expect(rendered).not.toContain("healthcheck");
   });
 });

--- a/packages/cli/test/CollectorRecovery.bun.test.ts
+++ b/packages/cli/test/CollectorRecovery.bun.test.ts
@@ -1,0 +1,625 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const image = "otel/opentelemetry-collector-contrib:0.159.0";
+const enabled = process.env["OBSERVABILITY_COLLECTOR_RECOVERY"] === "1";
+const evidenceRoot = process.env["OBSERVABILITY_COLLECTOR_RECOVERY_ARTIFACT_ROOT"] ?? "";
+const runId = `obs10-${process.pid}-${crypto.randomUUID().slice(0, 8)}`;
+const network = `${runId}-network`;
+const containers = new Set<string>();
+let root = "";
+
+const runDocker = (args: ReadonlyArray<string>): string => {
+  const result = Bun.spawnSync(["docker", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = result.stdout.toString().trim();
+  const stderr = result.stderr.toString().trim();
+  if (result.exitCode !== 0) {
+    throw new Error(`docker ${args.join(" ")} failed with ${result.exitCode}: ${stderr}`);
+  }
+  return stdout;
+};
+
+const dockerLogs = (container: string): string => {
+  const result = Bun.spawnSync(["docker", "logs", container], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(`docker logs ${container} failed with ${result.exitCode}`);
+  }
+  return `${result.stdout.toString()}${result.stderr.toString()}`;
+};
+
+const hostPort = (container: string, port: number): number => {
+  const binding = runDocker(["port", container, `${port}/tcp`]);
+  const value = Number(binding.slice(binding.lastIndexOf(":") + 1));
+  expect(Number.isInteger(value)).toBe(true);
+  return value;
+};
+
+const saveEvidence = async (name: string, content: string): Promise<void> => {
+  if (evidenceRoot !== "") {
+    await mkdir(evidenceRoot, { recursive: true });
+    await writeFile(join(evidenceRoot, name), `${content.trimEnd()}\n`);
+  }
+};
+
+const waitForText = async (
+  load: () => Promise<string>,
+  predicate: (value: string) => boolean,
+  timeoutMs = 30_000,
+): Promise<string> => {
+  const deadline = Date.now() + timeoutMs;
+  let latest = "";
+  while (Date.now() < deadline) {
+    try {
+      latest = await load();
+      if (predicate(latest)) {
+        return latest;
+      }
+    } catch {
+      latest = "";
+    }
+    await Bun.sleep(100);
+  }
+  throw new Error(`condition did not become true within ${timeoutMs}ms: ${latest}`);
+};
+
+const fetchText = async (url: string): Promise<string> => {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`${url} returned ${response.status}`);
+  }
+  return response.text();
+};
+
+const tracePayload = (name: string, sequence: number): string => {
+  const traceId = sequence.toString(16).padStart(32, "0");
+  const spanId = sequence.toString(16).padStart(16, "0");
+  return JSON.stringify({
+    resourceSpans: [
+      {
+        resource: {},
+        scopeSpans: [
+          {
+            scope: {},
+            spans: [
+              {
+                traceId,
+                spanId,
+                name,
+                startTimeUnixNano: "1",
+                endTimeUnixNano: "2",
+                status: {},
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+};
+
+const logPayload = (name: string): string =>
+  JSON.stringify({
+    resourceLogs: [
+      {
+        resource: { attributes: [{ key: "canary.id", value: { stringValue: name } }] },
+        scopeLogs: [{ scope: {}, logRecords: [{ body: { stringValue: name } }] }],
+      },
+    ],
+  });
+
+const metricPayload = (name: string): string =>
+  JSON.stringify({
+    resourceMetrics: [
+      {
+        resource: { attributes: [{ key: "canary.id", value: { stringValue: name } }] },
+        scopeMetrics: [
+          {
+            scope: {},
+            metrics: [
+              {
+                name,
+                sum: {
+                  dataPoints: [{ asInt: "1" }],
+                  aggregationTemporality: 2,
+                  isMonotonic: true,
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+
+const send = async (port: number, signal: string, body: string): Promise<number> => {
+  const response = await fetch(`http://127.0.0.1:${port}/v1/${signal}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body,
+  });
+  await response.text();
+  return response.status;
+};
+
+const sourceConfig = (sink: string, queueSize: number): string => `extensions:
+  file_storage/queue:
+    directory: /var/lib/otelcol/queue
+    create_directory: true
+    max_size: 2147483648
+    fsync: true
+    recreate: false
+  health_check:
+    endpoint: 0.0.0.0:13133
+    path: /health
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+        max_request_body_size: 8388608
+exporters:
+  otlp_http/traces:
+    endpoint: http://${sink}:4318
+    encoding: json
+    compression: none
+    sending_queue:
+      enabled: true
+      storage: file_storage/queue
+      queue_size: ${queueSize}
+      num_consumers: 1
+      block_on_overflow: false
+      batch:
+        flush_timeout: 200ms
+        min_size: 1
+        max_size: 8388608
+        sizer: bytes
+    retry_on_failure:
+      enabled: true
+      initial_interval: 1s
+      max_interval: 2s
+      max_elapsed_time: 0
+  otlp_http/logs:
+    endpoint: http://${sink}:4318
+    encoding: json
+    compression: none
+    sending_queue:
+      enabled: true
+      storage: file_storage/queue
+      queue_size: ${queueSize}
+      num_consumers: 1
+      block_on_overflow: false
+      batch:
+        flush_timeout: 200ms
+        min_size: 1
+        max_size: 8388608
+        sizer: bytes
+    retry_on_failure:
+      enabled: true
+      initial_interval: 1s
+      max_interval: 2s
+      max_elapsed_time: 0
+  otlp_http/metrics:
+    endpoint: http://${sink}:4318
+    encoding: json
+    compression: none
+    sending_queue:
+      enabled: true
+      storage: file_storage/queue
+      queue_size: ${queueSize}
+      num_consumers: 1
+      block_on_overflow: false
+      batch:
+        flush_timeout: 200ms
+        min_size: 1
+        max_size: 8388608
+        sizer: bytes
+    retry_on_failure:
+      enabled: true
+      initial_interval: 1s
+      max_interval: 2s
+      max_elapsed_time: 0
+service:
+  telemetry:
+    metrics:
+      level: detailed
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: 0.0.0.0
+                port: 8888
+  extensions: [file_storage/queue, health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp_http/traces]
+    logs:
+      receivers: [otlp]
+      exporters: [otlp_http/logs]
+    metrics:
+      receivers: [otlp]
+      exporters: [otlp_http/metrics]
+`;
+
+const sinkConfig = (): string => `receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+exporters:
+  file/receipts:
+    path: /receipts/otlp.jsonl
+    format: json
+    flush_interval: 100ms
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [file/receipts]
+    logs:
+      receivers: [otlp]
+      exporters: [file/receipts]
+    metrics:
+      receivers: [otlp]
+      exporters: [file/receipts]
+`;
+
+const startSource = (
+  name: string,
+  config: string,
+  queue: string,
+): {
+  readonly id: string;
+  readonly otlpPort: number;
+  readonly healthPort: number;
+  readonly metricsPort: number;
+} => {
+  containers.add(name);
+  const id = runDocker([
+    "run",
+    "--detach",
+    "--name",
+    name,
+    "--network",
+    network,
+    "--publish",
+    "127.0.0.1::4318",
+    "--publish",
+    "127.0.0.1::13133",
+    "--publish",
+    "127.0.0.1::8888",
+    "--user",
+    "10001:10001",
+    "--volume",
+    `${config}:/etc/otelcol/config.yaml:ro`,
+    "--volume",
+    `${queue}:/var/lib/otelcol/queue`,
+    image,
+    "--config=/etc/otelcol/config.yaml",
+  ]);
+  return {
+    id,
+    otlpPort: hostPort(name, 4318),
+    healthPort: hostPort(name, 13133),
+    metricsPort: hostPort(name, 8888),
+  };
+};
+
+const startSink = (name: string, config: string, receipts: string): string => {
+  containers.add(name);
+  return runDocker([
+    "run",
+    "--detach",
+    "--name",
+    name,
+    "--network",
+    network,
+    "--volume",
+    `${config}:/etc/otelcol/config.yaml:ro`,
+    "--volume",
+    `${receipts}:/receipts`,
+    image,
+    "--config=/etc/otelcol/config.yaml",
+  ]);
+};
+
+const removeContainer = (name: string): void => {
+  if (containers.delete(name)) {
+    runDocker(["rm", "--force", name]);
+  }
+};
+
+const receiptCount = (receipts: string, identity: string): number =>
+  receipts.split("\n").filter((line) => line.includes(identity)).length;
+
+const metricValue = (metrics: string, name: string, exporter: string): number => {
+  const line = metrics
+    .split("\n")
+    .find(
+      (candidate) =>
+        candidate.startsWith(`${name}{`) && candidate.includes(`exporter="${exporter}"`),
+    );
+  if (line === undefined) {
+    throw new Error(`${name} for ${exporter} was absent`);
+  }
+  return Number(line.slice(line.lastIndexOf(" ") + 1));
+};
+
+const receiverMetricValue = (metrics: string, name: string): number => {
+  const line = metrics
+    .split("\n")
+    .find(
+      (candidate) =>
+        candidate.startsWith(`${name}{`) &&
+        candidate.includes('receiver="otlp"') &&
+        candidate.includes('transport="http"'),
+    );
+  if (line === undefined) {
+    throw new Error(`${name} for the OTLP HTTP receiver was absent`);
+  }
+  return Number(line.slice(line.lastIndexOf(" ") + 1));
+};
+
+interface SaturationResult {
+  readonly signal: string;
+  readonly acceptedNames: ReadonlyArray<string>;
+  readonly allNames: ReadonlyArray<string>;
+  readonly statuses: ReadonlyArray<number>;
+}
+
+afterAll(async () => {
+  for (const container of containers) {
+    Bun.spawnSync(["docker", "rm", "--force", container], { stdout: "ignore", stderr: "ignore" });
+  }
+  Bun.spawnSync(["docker", "network", "rm", network], { stdout: "ignore", stderr: "ignore" });
+  if (root !== "") {
+    await rm(root, { recursive: true, force: true });
+  }
+  if (enabled) {
+    const remainingContainers = Bun.spawnSync([
+      "docker",
+      "ps",
+      "--all",
+      "--filter",
+      `name=${runId}`,
+      "--format",
+      "{{.Names}}",
+    ]).stdout.toString();
+    const remainingNetworks = Bun.spawnSync([
+      "docker",
+      "network",
+      "ls",
+      "--filter",
+      `name=${network}`,
+      "--format",
+      "{{.Name}}",
+    ]).stdout.toString();
+    await saveEvidence(
+      "cleanup.txt",
+      `containers=${remainingContainers.trim()}\nnetworks=${remainingNetworks.trim()}`,
+    );
+  }
+});
+
+const recoveryDescribe = enabled ? describe : describe.skip;
+
+recoveryDescribe("Collector recovery", () => {
+  test("persists every signal across restart and rejects requests at queue saturation", async () => {
+    root = await mkdtemp(join(tmpdir(), `${runId}-`));
+    runDocker(["network", "create", network]);
+    await saveEvidence("run.txt", `run_id=${runId}\nnetwork=${network}\nroot=${root}`);
+    await saveEvidence(
+      "image-digest.txt",
+      runDocker(["image", "inspect", image, "--format", "{{.Id}}"]),
+    );
+
+    const recoveryQueue = join(root, "recovery-queue");
+    const recoveryReceipts = join(root, "recovery-receipts");
+    const recoveryConfig = join(root, "recovery-source.yaml");
+    const recoverySinkConfig = join(root, "recovery-sink.yaml");
+    await Promise.all([
+      mkdir(recoveryQueue),
+      mkdir(recoveryReceipts),
+      writeFile(recoveryConfig, sourceConfig(`${runId}-sink`, 64)),
+      writeFile(recoverySinkConfig, sinkConfig()),
+    ]);
+    await Promise.all([chmod(recoveryQueue, 0o777), chmod(recoveryReceipts, 0o777)]);
+
+    const original = startSource(`${runId}-source`, recoveryConfig, recoveryQueue);
+    await saveEvidence("recovery-source-original-id.txt", original.id);
+    await waitForText(
+      () => fetchText(`http://127.0.0.1:${original.healthPort}/health`),
+      (value) => value.length > 0,
+    );
+
+    const outageTrace = `${runId}-outage-trace`;
+    const outageLog = `${runId}-outage-log`;
+    const outageMetric = `${runId}.outage.metric`;
+    expect(await send(original.otlpPort, "traces", tracePayload(outageTrace, 1))).toBe(200);
+    expect(await send(original.otlpPort, "logs", logPayload(outageLog))).toBe(200);
+    expect(await send(original.otlpPort, "metrics", metricPayload(outageMetric))).toBe(200);
+
+    const queued = await waitForText(
+      () => fetchText(`http://127.0.0.1:${original.metricsPort}/metrics`),
+      (value) =>
+        metricValue(value, "otelcol_exporter_queue_size", "otlp_http/traces") === 1 &&
+        metricValue(value, "otelcol_exporter_queue_size", "otlp_http/logs") === 1 &&
+        metricValue(value, "otelcol_exporter_queue_size", "otlp_http/metrics") === 1,
+    );
+    expect(queued).toContain("otelcol_exporter_queue_capacity");
+    await saveEvidence("recovery-queued-metrics.txt", queued);
+    expect(await fetchText(`http://127.0.0.1:${original.healthPort}/health`)).toContain(
+      "Server available",
+    );
+    await saveEvidence("recovery-source-original.log", dockerLogs(`${runId}-source`));
+
+    removeContainer(`${runId}-source`);
+    const restarted = startSource(`${runId}-source-restarted`, recoveryConfig, recoveryQueue);
+    expect(restarted.id).not.toBe(original.id);
+    await saveEvidence("recovery-source-restarted-id.txt", restarted.id);
+    await waitForText(
+      () => fetchText(`http://127.0.0.1:${restarted.healthPort}/health`),
+      (value) => value.length > 0,
+    );
+
+    startSink(`${runId}-sink`, recoverySinkConfig, recoveryReceipts);
+    const recoveryReceiptPath = join(recoveryReceipts, "otlp.jsonl");
+    const recovered = await waitForText(
+      () => readFile(recoveryReceiptPath, "utf8"),
+      (value) =>
+        value.includes(outageTrace) && value.includes(outageLog) && value.includes(outageMetric),
+    );
+    expect(receiptCount(recovered, outageTrace)).toBe(1);
+    expect(receiptCount(recovered, outageLog)).toBe(1);
+    expect(receiptCount(recovered, outageMetric)).toBe(1);
+    await saveEvidence("recovery-receipts.jsonl", recovered);
+
+    const postRestart = `${runId}-post-restart`;
+    expect(await send(restarted.otlpPort, "traces", tracePayload(postRestart, 2))).toBe(200);
+    await waitForText(
+      () => readFile(recoveryReceiptPath, "utf8"),
+      (value) => value.includes(postRestart),
+    );
+    const drainedMetrics = await waitForText(
+      () => fetchText(`http://127.0.0.1:${restarted.metricsPort}/metrics`),
+      (value) =>
+        metricValue(value, "otelcol_exporter_queue_size", "otlp_http/traces") === 0 &&
+        metricValue(value, "otelcol_exporter_queue_size", "otlp_http/logs") === 0 &&
+        metricValue(value, "otelcol_exporter_queue_size", "otlp_http/metrics") === 0,
+    );
+    await saveEvidence("recovery-drained-metrics.txt", drainedMetrics);
+
+    const saturationQueue = join(root, "saturation-queue");
+    const saturationReceipts = join(root, "saturation-receipts");
+    const saturationConfig = join(root, "saturation-source.yaml");
+    const saturationSinkConfig = join(root, "saturation-sink.yaml");
+    await Promise.all([
+      mkdir(saturationQueue),
+      mkdir(saturationReceipts),
+      writeFile(saturationConfig, sourceConfig(`${runId}-saturation-sink`, 4)),
+      writeFile(saturationSinkConfig, sinkConfig()),
+    ]);
+    await Promise.all([chmod(saturationQueue, 0o777), chmod(saturationReceipts, 0o777)]);
+
+    const saturation = startSource(`${runId}-saturation-source`, saturationConfig, saturationQueue);
+    await waitForText(
+      () => fetchText(`http://127.0.0.1:${saturation.healthPort}/health`),
+      (value) => value.length > 0,
+    );
+    const saturationSignals = [
+      {
+        signal: "traces",
+        exporter: "otlp_http/traces",
+        enqueueFailureMetric: "otelcol_exporter_enqueue_failed_spans",
+        receiverRefusalMetric: "otelcol_receiver_refused_spans",
+        payload: (name: string, index: number) => tracePayload(name, index + 10),
+      },
+      {
+        signal: "logs",
+        exporter: "otlp_http/logs",
+        enqueueFailureMetric: "otelcol_exporter_enqueue_failed_log_records",
+        receiverRefusalMetric: "otelcol_receiver_refused_log_records",
+        payload: (name: string) => logPayload(name),
+      },
+      {
+        signal: "metrics",
+        exporter: "otlp_http/metrics",
+        enqueueFailureMetric: "otelcol_exporter_enqueue_failed_metric_points",
+        receiverRefusalMetric: "otelcol_receiver_refused_metric_points",
+        payload: (name: string) => metricPayload(name.replaceAll("-", ".")),
+      },
+    ];
+    const saturationResults: Array<SaturationResult> = [];
+    for (const saturationSignal of saturationSignals) {
+      const requests = Array.from({ length: 8 }, (_, index) => {
+        const name = `${runId}-saturation-${saturationSignal.signal}-${index + 1}`;
+        return {
+          name,
+          response: send(
+            saturation.otlpPort,
+            saturationSignal.signal,
+            saturationSignal.payload(name, index),
+          ),
+        };
+      });
+      const statuses = await Promise.all(requests.map((request) => request.response));
+      const acceptedNames = requests
+        .filter((_, index) => statuses[index] === 200)
+        .map((request) => request.name);
+      expect(statuses.filter((status) => status === 200)).toHaveLength(4);
+      expect(statuses.filter((status) => status === 503)).toHaveLength(4);
+      saturationResults.push({
+        signal: saturationSignal.signal,
+        acceptedNames,
+        allNames: requests.map((request) => request.name),
+        statuses,
+      });
+    }
+    await saveEvidence("saturation-statuses.json", JSON.stringify(saturationResults, undefined, 2));
+
+    const saturatedMetrics = await waitForText(
+      () => fetchText(`http://127.0.0.1:${saturation.metricsPort}/metrics`),
+      (value) =>
+        saturationSignals.every(
+          (signal) =>
+            metricValue(value, "otelcol_exporter_queue_size", signal.exporter) === 4 &&
+            metricValue(value, signal.enqueueFailureMetric, signal.exporter) === 4 &&
+            receiverMetricValue(value, signal.receiverRefusalMetric) === 4,
+        ),
+    );
+    for (const signal of saturationSignals) {
+      expect(
+        metricValue(saturatedMetrics, "otelcol_exporter_queue_capacity", signal.exporter),
+      ).toBe(4);
+    }
+    await saveEvidence("saturation-metrics.txt", saturatedMetrics);
+    expect(await fetchText(`http://127.0.0.1:${saturation.healthPort}/health`)).toContain(
+      "Server available",
+    );
+
+    startSink(`${runId}-saturation-sink`, saturationSinkConfig, saturationReceipts);
+    const saturationReceiptPath = join(saturationReceipts, "otlp.jsonl");
+    const drained = await waitForText(
+      () => readFile(saturationReceiptPath, "utf8"),
+      (value) =>
+        saturationResults.every((result) =>
+          result.acceptedNames.every((name) =>
+            result.signal === "metrics"
+              ? value.includes(name.replaceAll("-", "."))
+              : value.includes(name),
+          ),
+        ),
+    );
+    for (const result of saturationResults) {
+      for (const name of result.allNames) {
+        const receiptName = result.signal === "metrics" ? name.replaceAll("-", ".") : name;
+        expect(drained.includes(receiptName)).toBe(result.acceptedNames.includes(name));
+      }
+    }
+    await saveEvidence("saturation-receipts.jsonl", drained);
+    await saveEvidence(
+      "collector-logs.txt",
+      [
+        dockerLogs(`${runId}-source-restarted`),
+        dockerLogs(`${runId}-sink`),
+        dockerLogs(`${runId}-saturation-source`),
+        dockerLogs(`${runId}-saturation-sink`),
+      ].join("\n"),
+    );
+    await waitForText(
+      () => fetchText(`http://127.0.0.1:${saturation.metricsPort}/metrics`),
+      (value) =>
+        saturationSignals.every(
+          (signal) => metricValue(value, "otelcol_exporter_queue_size", signal.exporter) === 0,
+        ),
+    );
+  }, 120_000);
+});

--- a/packages/cli/test/CollectorRecovery.bun.test.ts
+++ b/packages/cli/test/CollectorRecovery.bun.test.ts
@@ -149,6 +149,48 @@ const send = async (port: number, signal: string, body: string): Promise<number>
   return response.status;
 };
 
+interface RecoverySignal {
+  readonly signal: string;
+  readonly exporter: string;
+  readonly identity: string;
+  readonly body: string;
+}
+
+const recoverySignals = (phase: string, sequence: number): ReadonlyArray<RecoverySignal> => {
+  const traceIdentity = `${runId}-${phase}-trace`;
+  const logIdentity = `${runId}-${phase}-log`;
+  const metricIdentity = `${runId}.${phase}.metric`;
+  return [
+    {
+      signal: "traces",
+      exporter: "otlphttp/traces",
+      identity: traceIdentity,
+      body: tracePayload(traceIdentity, sequence),
+    },
+    {
+      signal: "logs",
+      exporter: "otlphttp/logs",
+      identity: logIdentity,
+      body: logPayload(logIdentity),
+    },
+    {
+      signal: "metrics",
+      exporter: "otlphttp/metrics",
+      identity: metricIdentity,
+      body: metricPayload(metricIdentity),
+    },
+  ];
+};
+
+const sendRecoverySignals = async (
+  port: number,
+  signals: ReadonlyArray<RecoverySignal>,
+): Promise<void> => {
+  for (const signal of signals) {
+    expect(await send(port, signal.signal, signal.body)).toBe(200);
+  }
+};
+
 const sourceConfig = (sink: string, queueSize: number): string => `extensions:
   file_storage/queue:
     directory: /var/lib/otelcol/queue
@@ -166,7 +208,7 @@ receivers:
         endpoint: 0.0.0.0:4318
         max_request_body_size: 8388608
 exporters:
-  otlp_http/traces:
+  otlphttp/traces:
     endpoint: http://${sink}:4318
     encoding: json
     compression: none
@@ -186,7 +228,7 @@ exporters:
       initial_interval: 1s
       max_interval: 2s
       max_elapsed_time: 0
-  otlp_http/logs:
+  otlphttp/logs:
     endpoint: http://${sink}:4318
     encoding: json
     compression: none
@@ -206,7 +248,7 @@ exporters:
       initial_interval: 1s
       max_interval: 2s
       max_elapsed_time: 0
-  otlp_http/metrics:
+  otlphttp/metrics:
     endpoint: http://${sink}:4318
     encoding: json
     compression: none
@@ -240,13 +282,13 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [otlp_http/traces]
+      exporters: [otlphttp/traces]
     logs:
       receivers: [otlp]
-      exporters: [otlp_http/logs]
+      exporters: [otlphttp/logs]
     metrics:
       receivers: [otlp]
-      exporters: [otlp_http/metrics]
+      exporters: [otlphttp/metrics]
 `;
 
 const sinkConfig = (): string => `receivers:
@@ -353,6 +395,23 @@ const metricValue = (metrics: string, name: string, exporter: string): number =>
   return Number(line.slice(line.lastIndexOf(" ") + 1));
 };
 
+const queuesAreEmpty = (metrics: string): boolean =>
+  ["otlphttp/traces", "otlphttp/logs", "otlphttp/metrics"].every(
+    (exporter) => metricValue(metrics, "otelcol_exporter_queue_size", exporter) === 0,
+  );
+
+const waitForSustainedEmptyQueues = async (metricsPort: number): Promise<string> => {
+  const first = await waitForText(
+    () => fetchText(`http://127.0.0.1:${metricsPort}/metrics`),
+    queuesAreEmpty,
+  );
+  expect(queuesAreEmpty(first)).toBe(true);
+  await Bun.sleep(1_000);
+  const second = await fetchText(`http://127.0.0.1:${metricsPort}/metrics`);
+  expect(queuesAreEmpty(second)).toBe(true);
+  return second;
+};
+
 const receiverMetricValue = (metrics: string, name: string): number => {
   const line = metrics
     .split("\n")
@@ -376,6 +435,9 @@ interface SaturationResult {
 }
 
 afterAll(async () => {
+  if (!enabled) {
+    return;
+  }
   for (const container of containers) {
     Bun.spawnSync(["docker", "rm", "--force", container], { stdout: "ignore", stderr: "ignore" });
   }
@@ -383,30 +445,28 @@ afterAll(async () => {
   if (root !== "") {
     await rm(root, { recursive: true, force: true });
   }
-  if (enabled) {
-    const remainingContainers = Bun.spawnSync([
-      "docker",
-      "ps",
-      "--all",
-      "--filter",
-      `name=${runId}`,
-      "--format",
-      "{{.Names}}",
-    ]).stdout.toString();
-    const remainingNetworks = Bun.spawnSync([
-      "docker",
-      "network",
-      "ls",
-      "--filter",
-      `name=${network}`,
-      "--format",
-      "{{.Name}}",
-    ]).stdout.toString();
-    await saveEvidence(
-      "cleanup.txt",
-      `containers=${remainingContainers.trim()}\nnetworks=${remainingNetworks.trim()}`,
-    );
-  }
+  const remainingContainers = Bun.spawnSync([
+    "docker",
+    "ps",
+    "--all",
+    "--filter",
+    `name=${runId}`,
+    "--format",
+    "{{.Names}}",
+  ]).stdout.toString();
+  const remainingNetworks = Bun.spawnSync([
+    "docker",
+    "network",
+    "ls",
+    "--filter",
+    `name=${network}`,
+    "--format",
+    "{{.Name}}",
+  ]).stdout.toString();
+  await saveEvidence(
+    "cleanup.txt",
+    `containers=${remainingContainers.trim()}\nnetworks=${remainingNetworks.trim()}`,
+  );
 });
 
 const recoveryDescribe = enabled ? describe : describe.skip;
@@ -433,26 +493,42 @@ recoveryDescribe("Collector recovery", () => {
     ]);
     await Promise.all([chmod(recoveryQueue, 0o777), chmod(recoveryReceipts, 0o777)]);
 
+    const recoveryReceiptPath = join(recoveryReceipts, "otlp.jsonl");
+    const beforeOutage = recoverySignals("before-outage", 1);
+    const duringOutage = recoverySignals("during-outage", 2);
+    const afterRestart = recoverySignals("after-restart", 3);
+    const expectedRecoverySignals = [...beforeOutage, ...duringOutage, ...afterRestart];
+    await saveEvidence(
+      "recovery-identities.json",
+      JSON.stringify(expectedRecoverySignals, undefined, 2),
+    );
+
+    startSink(`${runId}-sink`, recoverySinkConfig, recoveryReceipts);
     const original = startSource(`${runId}-source`, recoveryConfig, recoveryQueue);
     await saveEvidence("recovery-source-original-id.txt", original.id);
     await waitForText(
       () => fetchText(`http://127.0.0.1:${original.healthPort}/health`),
       (value) => value.length > 0,
     );
+    await sendRecoverySignals(original.otlpPort, beforeOutage);
+    const beforeOutageReceipts = await waitForText(
+      () => readFile(recoveryReceiptPath, "utf8"),
+      (value) => beforeOutage.every((signal) => value.includes(signal.identity)),
+    );
+    for (const signal of beforeOutage) {
+      expect(receiptCount(beforeOutageReceipts, signal.identity)).toBe(1);
+    }
+    await waitForSustainedEmptyQueues(original.metricsPort);
 
-    const outageTrace = `${runId}-outage-trace`;
-    const outageLog = `${runId}-outage-log`;
-    const outageMetric = `${runId}.outage.metric`;
-    expect(await send(original.otlpPort, "traces", tracePayload(outageTrace, 1))).toBe(200);
-    expect(await send(original.otlpPort, "logs", logPayload(outageLog))).toBe(200);
-    expect(await send(original.otlpPort, "metrics", metricPayload(outageMetric))).toBe(200);
-
+    removeContainer(`${runId}-sink`);
+    await Bun.sleep(250);
+    await sendRecoverySignals(original.otlpPort, duringOutage);
     const queued = await waitForText(
       () => fetchText(`http://127.0.0.1:${original.metricsPort}/metrics`),
       (value) =>
-        metricValue(value, "otelcol_exporter_queue_size", "otlp_http/traces") === 1 &&
-        metricValue(value, "otelcol_exporter_queue_size", "otlp_http/logs") === 1 &&
-        metricValue(value, "otelcol_exporter_queue_size", "otlp_http/metrics") === 1,
+        duringOutage.every(
+          (signal) => metricValue(value, "otelcol_exporter_queue_size", signal.exporter) === 1,
+        ),
     );
     expect(queued).toContain("otelcol_exporter_queue_capacity");
     await saveEvidence("recovery-queued-metrics.txt", queued);
@@ -471,30 +547,23 @@ recoveryDescribe("Collector recovery", () => {
     );
 
     startSink(`${runId}-sink`, recoverySinkConfig, recoveryReceipts);
-    const recoveryReceiptPath = join(recoveryReceipts, "otlp.jsonl");
-    const recovered = await waitForText(
-      () => readFile(recoveryReceiptPath, "utf8"),
-      (value) =>
-        value.includes(outageTrace) && value.includes(outageLog) && value.includes(outageMetric),
-    );
-    expect(receiptCount(recovered, outageTrace)).toBe(1);
-    expect(receiptCount(recovered, outageLog)).toBe(1);
-    expect(receiptCount(recovered, outageMetric)).toBe(1);
-    await saveEvidence("recovery-receipts.jsonl", recovered);
-
-    const postRestart = `${runId}-post-restart`;
-    expect(await send(restarted.otlpPort, "traces", tracePayload(postRestart, 2))).toBe(200);
     await waitForText(
       () => readFile(recoveryReceiptPath, "utf8"),
-      (value) => value.includes(postRestart),
+      (value) => duringOutage.every((signal) => value.includes(signal.identity)),
     );
-    const drainedMetrics = await waitForText(
-      () => fetchText(`http://127.0.0.1:${restarted.metricsPort}/metrics`),
+    await sendRecoverySignals(restarted.otlpPort, afterRestart);
+    await waitForText(
+      () => readFile(recoveryReceiptPath, "utf8"),
       (value) =>
-        metricValue(value, "otelcol_exporter_queue_size", "otlp_http/traces") === 0 &&
-        metricValue(value, "otelcol_exporter_queue_size", "otlp_http/logs") === 0 &&
-        metricValue(value, "otelcol_exporter_queue_size", "otlp_http/metrics") === 0,
+        [...duringOutage, ...afterRestart].every((signal) => value.includes(signal.identity)),
     );
+    const drainedMetrics = await waitForSustainedEmptyQueues(restarted.metricsPort);
+    const afterRestartReceipts = await readFile(recoveryReceiptPath, "utf8");
+    const finalRecoveryReceipts = `${beforeOutageReceipts.trimEnd()}\n${afterRestartReceipts}`;
+    for (const signal of expectedRecoverySignals) {
+      expect(receiptCount(finalRecoveryReceipts, signal.identity)).toBe(1);
+    }
+    await saveEvidence("recovery-final-receipts.jsonl", finalRecoveryReceipts);
     await saveEvidence("recovery-drained-metrics.txt", drainedMetrics);
 
     const saturationQueue = join(root, "saturation-queue");
@@ -517,21 +586,21 @@ recoveryDescribe("Collector recovery", () => {
     const saturationSignals = [
       {
         signal: "traces",
-        exporter: "otlp_http/traces",
+        exporter: "otlphttp/traces",
         enqueueFailureMetric: "otelcol_exporter_enqueue_failed_spans",
         receiverRefusalMetric: "otelcol_receiver_refused_spans",
         payload: (name: string, index: number) => tracePayload(name, index + 10),
       },
       {
         signal: "logs",
-        exporter: "otlp_http/logs",
+        exporter: "otlphttp/logs",
         enqueueFailureMetric: "otelcol_exporter_enqueue_failed_log_records",
         receiverRefusalMetric: "otelcol_receiver_refused_log_records",
         payload: (name: string) => logPayload(name),
       },
       {
         signal: "metrics",
-        exporter: "otlp_http/metrics",
+        exporter: "otlphttp/metrics",
         enqueueFailureMetric: "otelcol_exporter_enqueue_failed_metric_points",
         receiverRefusalMetric: "otelcol_receiver_refused_metric_points",
         payload: (name: string) => metricPayload(name.replaceAll("-", ".")),
@@ -587,7 +656,7 @@ recoveryDescribe("Collector recovery", () => {
 
     startSink(`${runId}-saturation-sink`, saturationSinkConfig, saturationReceipts);
     const saturationReceiptPath = join(saturationReceipts, "otlp.jsonl");
-    const drained = await waitForText(
+    await waitForText(
       () => readFile(saturationReceiptPath, "utf8"),
       (value) =>
         saturationResults.every((result) =>
@@ -598,13 +667,16 @@ recoveryDescribe("Collector recovery", () => {
           ),
         ),
     );
+    await waitForSustainedEmptyQueues(saturation.metricsPort);
+    const finalSaturationReceipts = await readFile(saturationReceiptPath, "utf8");
     for (const result of saturationResults) {
       for (const name of result.allNames) {
         const receiptName = result.signal === "metrics" ? name.replaceAll("-", ".") : name;
-        expect(drained.includes(receiptName)).toBe(result.acceptedNames.includes(name));
+        const expectedCount = result.acceptedNames.includes(name) ? 1 : 0;
+        expect(receiptCount(finalSaturationReceipts, receiptName)).toBe(expectedCount);
       }
     }
-    await saveEvidence("saturation-receipts.jsonl", drained);
+    await saveEvidence("saturation-final-receipts.jsonl", finalSaturationReceipts);
     await saveEvidence(
       "collector-logs.txt",
       [
@@ -613,13 +685,6 @@ recoveryDescribe("Collector recovery", () => {
         dockerLogs(`${runId}-saturation-source`),
         dockerLogs(`${runId}-saturation-sink`),
       ].join("\n"),
-    );
-    await waitForText(
-      () => fetchText(`http://127.0.0.1:${saturation.metricsPort}/metrics`),
-      (value) =>
-        saturationSignals.every(
-          (signal) => metricValue(value, "otelcol_exporter_queue_size", signal.exporter) === 0,
-        ),
     );
   }, 120_000);
 });

--- a/packages/cli/test/RemoteEnvironment.bun.test.ts
+++ b/packages/cli/test/RemoteEnvironment.bun.test.ts
@@ -116,6 +116,12 @@ describe("RemoteEnvironment", () => {
     expect(state.tokenCreations).toBe(1);
     expect(state.credentials.environments).toHaveLength(1);
     expect(result.exported).toContain('OTEL_DEPLOYMENT_ENVIRONMENT="staging"');
+    expect(result.exported).toContain(
+      'OTEL_EXPORTER_OTLP_ENDPOINT="http://livro-caixa-otel-collector:4318"',
+    );
+    expect(result.exported).not.toContain(
+      'OTEL_EXPORTER_OTLP_ENDPOINT="http://otel-collector:4318"',
+    );
     expect(result.exported).toContain('AXIOM_TOKEN="secret-1"');
     expect(result.exported).toContain('SENTRY_DSN="https://public@sentry.example/1"');
   });


### PR DESCRIPTION
## Summary

- bound production persistent queues and exporter-side batches for synchronous backpressure
- add durable host storage, loopback health, detailed queue telemetry, and safe recovery operations
- add exact all-signal outage, restart, drain, and saturation proof to CI

## Verification

- Collector 0.159.0 validation
- traces, logs, and metrics before outage, during outage, and after restart
- exact final receipt counts plus stable empty queues
- queue saturation with HTTP 503, enqueue failures, and receiver refusals
- Kamal 2.12 generated service and endpoint proof
- `bun check`, build, full tests, package smoke, and independent exact-head review

Linear: OBS-10
