### PR TITLE
feat(telemetry): add framework-neutral browser client

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ repos/                repositórios vendorados para agentes (gitignored)
 
 O pacote `@equipe-tech/observability` publica um subpath por runtime:
 
-| Subpath     | Conteúdo                                                                                                                     |
-| ----------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `./node`    | `runMain` (telemetria do ambiente, interrupção em `SIGINT`/`SIGTERM`, flush no shutdown) e ingestão de eventos do browser    |
-| `./nestjs`  | `TelemetryInterceptor` (spans de fronteira HTTP), `withRequestSpan` e `createBrowserEventsController` (`/_telemetry/events`) |
-| `./browser` | `BrowserTelemetry` (fila limitada, batch e flush de wide events para `/_telemetry/events`) com transporte `fetch` injetável  |
-| `./testing` | Captura em memória dos exports OTLP reais (`run`, `makeCapture`) para asserts de spans, logs e métricas em testes            |
+| Subpath     | Conteúdo                                                                                                                                    |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `./node`    | `runMain` (telemetria do ambiente, interrupção em `SIGINT`/`SIGTERM`, flush no shutdown) e ingestão de eventos do browser                   |
+| `./nestjs`  | `TelemetryInterceptor` (spans de fronteira HTTP), `withRequestSpan` e `createBrowserEventsController` (`/_telemetry/events`)                |
+| `./browser` | `createBrowserTelemetryClient` imperativo e `BrowserTelemetry` compatível com Effect, ambos com fila limitada, batch e transporte injetável |
+| `./testing` | Captura em memória dos exports OTLP reais (`run`, `makeCapture`) para asserts de spans, logs e métricas em testes                           |
 
-O contrato do endpoint `/_telemetry/events` vive em `BrowserEvents` no entrypoint raiz. O servidor faz o parse com `parseBrowserEventBatch` e re-emite os eventos como wide events com atributos de servidor (`event.source`, `browser.event.id`). O cliente sanitiza nomes e campos antes da fila conforme a [política de dados da telemetria do browser](docs/browser-telemetry-data-policy.md).
+O [cliente imperativo do browser](docs/browser-client.md) publica `emit`, `flush`, `pending` e `dispose` sem tipos Effect e documenta o ciclo de vida React suportado. O contrato do endpoint `/_telemetry/events` vive em `BrowserEvents` no entrypoint raiz. O servidor faz o parse com `parseBrowserEventBatch` e re-emite os eventos como wide events com atributos de servidor (`event.source`, `browser.event.id`). O cliente sanitiza nomes e campos antes da fila conforme a [política de dados da telemetria do browser](docs/browser-telemetry-data-policy.md).
 
 O adapter `./nestjs` publica o endpoint pronto: registre `createBrowserEventsController(runtime)` nos controllers do módulo. O controller responde `202 { accepted }` e rejeita batches inválidos com `400 { code, message, correlationId }`. O valor `correlationId` é um identificador seguro para suporte. O limite de corpo bruto pertence ao transporte HTTP; o Express responde `413` acima do limite configurado.
 

--- a/docs/browser-client.md
+++ b/docs/browser-client.md
@@ -10,6 +10,7 @@ const telemetry = createBrowserTelemetryClient({
   maxBatchSize: 32,
   maxQueueSize: 256,
   flushIntervalMs: 5_000,
+  shutdownTimeoutMs: 2_000,
 });
 
 telemetry.emit("checkout.completed", { "page.path": "/checkout" });
@@ -17,7 +18,9 @@ await telemetry.flush();
 await telemetry.dispose();
 ```
 
-`emit` and `pending` are synchronous. `flush` and `dispose` return Promises. Concurrent flushes share one delivery operation. A rejected delivery keeps the same sanitized batch queued for a later flush. Disposal clears the client-owned interval, waits for active delivery, flushes remaining events, and is idempotent. A disposed client ignores new events and explicit flushes. A failed final delivery rejects disposal and remains visible through `pending`.
+`emit` and `pending` are synchronous. `flush` and `dispose` return Promises. Concurrent flushes share one delivery operation. A rejected delivery keeps the same sanitized batch queued for a later flush. Empty event names use the valid bounded name `browser.event`. Non-positive numeric options use their documented defaults.
+
+Disposal clears the client-owned interval, settles an active failed flush, and makes one final queued delivery attempt. Calls share one idempotent disposal Promise. The default finite shutdown deadline is 2,000 milliseconds and can be configured with positive `shutdownTimeoutMs`. At the deadline, the client aborts every active transport signal and rejects with `BrowserTelemetryClientShutdownError`. Disposal still settles by the deadline when a custom transport ignores abort. The sanitized active batch remains counted by `pending`. A disposed client ignores new events and explicit flushes. A final delivery failure rejects disposal and retains its sanitized batch.
 
 Set `disabled: true` when browser telemetry is off. A disabled client creates no interval, calls no transport, ignores events, reports zero pending events, and resolves flush and disposal.
 

--- a/docs/browser-client.md
+++ b/docs/browser-client.md
@@ -1,0 +1,54 @@
+# Browser telemetry client
+
+The browser entrypoint provides a framework-neutral imperative client without exposing Effect types.
+
+```ts
+import { createBrowserTelemetryClient } from "@equipe-tech/observability/browser/client";
+
+const telemetry = createBrowserTelemetryClient({
+  endpoint: "/_telemetry/events",
+  maxBatchSize: 32,
+  maxQueueSize: 256,
+  flushIntervalMs: 5_000,
+});
+
+telemetry.emit("checkout.completed", { "page.path": "/checkout" });
+await telemetry.flush();
+await telemetry.dispose();
+```
+
+`emit` and `pending` are synchronous. `flush` and `dispose` return Promises. Concurrent flushes share one delivery operation. A rejected delivery keeps the same sanitized batch queued for a later flush. Disposal clears the client-owned interval, waits for active delivery, flushes remaining events, and is idempotent. A disposed client ignores new events and explicit flushes. A failed final delivery rejects disposal and remains visible through `pending`.
+
+Set `disabled: true` when browser telemetry is off. A disabled client creates no interval, calls no transport, ignores events, reports zero pending events, and resolves flush and disposal.
+
+## React startup and cleanup
+
+Create one client alongside the React root, pass it through context, and dispose it from the owner that unmounts that root. Do not create or dispose clients during rendering. Keeping disposal at the root owner also avoids React development Strict Mode's simulated effect cleanup from terminating a live singleton.
+
+```tsx
+import { createContext } from "react";
+import { createRoot } from "react-dom/client";
+import { createBrowserTelemetryClient } from "@equipe-tech/observability/browser/client";
+import { App } from "./App.tsx";
+
+export const BrowserTelemetryContext = createContext(
+  createBrowserTelemetryClient({ disabled: true }),
+);
+
+export function startReactApp(container: HTMLElement) {
+  const telemetry = createBrowserTelemetryClient();
+  const root = createRoot(container);
+  root.render(
+    <BrowserTelemetryContext.Provider value={telemetry}>
+      <App />
+    </BrowserTelemetryContext.Provider>,
+  );
+
+  return async () => {
+    root.unmount();
+    await telemetry.dispose();
+  };
+}
+```
+
+Call the returned cleanup when the application root is permanently stopped. Repeated cleanup remains safe because disposal is idempotent.

--- a/docs/browser-telemetry-data-policy.md
+++ b/docs/browser-telemetry-data-policy.md
@@ -4,7 +4,7 @@
 
 ## Sink boundary
 
-Sanitization runs before a `BrowserEvent` is constructed and before the event enters the in-memory queue. Recording transports, retry batches, periodic flushes, finalizers, and fetch transports therefore receive only the sanitized representation.
+Sanitization runs before a `BrowserEvent` is constructed and before the event enters the in-memory queue. An empty sanitized event name becomes the bounded name `browser.event`, so queued events always satisfy the wire schema. Recording transports, retry batches, periodic flushes, finalizers, and fetch transports therefore receive only the sanitized representation.
 
 `BrowserTelemetry` has no console sink. This policy does not cover application-owned console calls and does not add console interception.
 
@@ -29,7 +29,7 @@ The following content becomes `[REDACTED]` within safe string values and event n
 - RSA, EC, OpenSSH, and generic private-key blocks
 - Sensitive `key=value` and `key:value` assignments, including quoted values
 
-Valid serialized JSON beginning with an object or array is parsed and sanitized iteratively. Values under sensitive property keys become `[REDACTED]`, credential-bearing keys disappear, credential patterns are replaced in string leaves, array order is retained, and compact valid JSON is emitted. Traversal is limited to 32 levels and 1,024 values. Inputs beyond either limit become `[REDACTED]`.
+Valid serialized JSON beginning with an object or array is parsed and sanitized iteratively. Values under sensitive property keys become `[REDACTED]`, credential-bearing keys disappear, credential patterns and structured sensitive assignments are replaced in string leaves, array order is retained, and compact valid JSON is emitted. Traversal is limited to 32 levels and 1,024 values. Inputs beyond either limit become `[REDACTED]`.
 
 Malformed JSON-like text containing a sensitive term becomes `[REDACTED]`. Browser structured-text handling is intentionally stricter than the Collector policy because the browser can parse a bounded JSON string before queue insertion.
 

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -24,6 +24,10 @@
       "types": "./dist/browser/index.d.ts",
       "import": "./dist/browser/index.js"
     },
+    "./browser/client": {
+      "types": "./dist/browser/client.d.ts",
+      "import": "./dist/browser/client.js"
+    },
     "./testing": {
       "types": "./dist/testing/index.d.ts",
       "import": "./dist/testing/index.js"

--- a/packages/telemetry/src/RedactionPolicy.ts
+++ b/packages/telemetry/src/RedactionPolicy.ts
@@ -180,7 +180,7 @@ const sanitizeJson = (source: JsonValue): Option.Option<string> => {
       continue;
     }
     if (Predicate.isString(current.source)) {
-      current.assign(replaceCoreValues(current.source));
+      current.assign(replaceCoreValues(replaceStructuredAssignments(current.source)));
       continue;
     }
     if (Array.isArray(current.source)) {

--- a/packages/telemetry/src/browser/BrowserClient.ts
+++ b/packages/telemetry/src/browser/BrowserClient.ts
@@ -1,0 +1,194 @@
+import { sanitizeBrowserEventName, sanitizeBrowserFields } from "../RedactionPolicy.ts";
+
+export type BrowserTelemetryClientFields = {
+  readonly [field: string]: string | number | boolean;
+};
+
+export type BrowserTelemetryClientEvent = {
+  readonly id: string;
+  readonly name: string;
+  readonly occurredAt: number;
+  readonly fields: BrowserTelemetryClientFields;
+};
+
+export type BrowserTelemetryClientBatch = {
+  readonly version: 1;
+  readonly events: ReadonlyArray<BrowserTelemetryClientEvent>;
+};
+
+export type BrowserTelemetryClientTransport = (
+  batch: BrowserTelemetryClientBatch,
+  signal: AbortSignal,
+) => Promise<void>;
+
+export type BrowserTelemetryClientConfig = {
+  readonly disabled?: boolean;
+  readonly endpoint?: string;
+  readonly maxBatchSize?: number;
+  readonly maxQueueSize?: number;
+  readonly flushIntervalMs?: number;
+  readonly transport?: BrowserTelemetryClientTransport;
+};
+
+export type BrowserTelemetryClient = {
+  emit(name: string, fields?: BrowserTelemetryClientFields): void;
+  flush(): Promise<void>;
+  pending(): number;
+  dispose(): Promise<void>;
+};
+
+export class BrowserTelemetryClientDeliveryError extends Error {
+  readonly code = "OBS_BROWSER_EVENTS_DELIVERY_FAILED";
+
+  constructor(
+    message: string,
+    readonly retryable: boolean,
+    options: { readonly cause: unknown },
+  ) {
+    super(message, options);
+    this.name = "BrowserTelemetryClientDeliveryError";
+  }
+}
+
+const defaultEndpoint = "/_telemetry/events";
+const defaultMaxBatchSize = 32;
+const defaultMaxQueueSize = 256;
+const defaultFlushIntervalMs = 5_000;
+const maxBatchSizeLimit = 64;
+
+const positiveInteger = (value: number | undefined, fallback: number): number =>
+  value === undefined || !Number.isSafeInteger(value) || value <= 0 ? fallback : value;
+
+const fetchTransport =
+  (endpoint: string): BrowserTelemetryClientTransport =>
+  async (batch, signal) => {
+    let response: Response;
+    try {
+      response = await fetch(endpoint, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(batch),
+        keepalive: true,
+        signal,
+      });
+    } catch (cause) {
+      throw new BrowserTelemetryClientDeliveryError(
+        "The browser events could not be sent. The events stay queued and the next flush retries the same batch.",
+        true,
+        { cause },
+      );
+    }
+    if (!response.ok) {
+      throw new BrowserTelemetryClientDeliveryError(
+        `The telemetry endpoint rejected the batch with status ${response.status}. Check the /_telemetry/events route of the project API.`,
+        response.status === 429 || response.status >= 500,
+        { cause: response.status },
+      );
+    }
+  };
+
+type BrowserClientEngineOptions = {
+  readonly disabled: boolean;
+  readonly maxBatchSize: number;
+  readonly maxQueueSize: number;
+  readonly flushIntervalMs: number;
+  readonly transport: BrowserTelemetryClientTransport;
+  readonly startTimer: boolean;
+};
+
+export class BrowserClientEngine implements BrowserTelemetryClient {
+  private events: Array<BrowserTelemetryClientEvent> = [];
+  private activeFlush: Promise<void> | undefined;
+  private disposal: Promise<void> | undefined;
+  private disposed = false;
+  private timer: ReturnType<typeof setInterval> | undefined;
+  private droppedEvents = 0;
+
+  constructor(private readonly options: BrowserClientEngineOptions) {
+    if (!options.disabled && options.startTimer) {
+      this.timer = setInterval(() => {
+        this.flush().catch(() => undefined);
+      }, options.flushIntervalMs);
+    }
+  }
+
+  emit(name: string, fields: BrowserTelemetryClientFields = {}): void {
+    if (this.options.disabled || this.disposed) return;
+    const event: BrowserTelemetryClientEvent = {
+      id: crypto.randomUUID(),
+      name: sanitizeBrowserEventName(name),
+      occurredAt: Date.now(),
+      fields: sanitizeBrowserFields(fields),
+    };
+    if (this.events.length >= this.options.maxQueueSize) {
+      this.events.shift();
+      this.droppedEvents += 1;
+    }
+    this.events.push(event);
+  }
+
+  flush(): Promise<void> {
+    if (this.options.disabled || this.disposed) return Promise.resolve();
+    return this.flushQueued();
+  }
+
+  pending(): number {
+    return this.options.disabled ? 0 : this.events.length;
+  }
+
+  dropped(): number {
+    return this.droppedEvents;
+  }
+
+  dispose(): Promise<void> {
+    if (this.disposal !== undefined) return this.disposal;
+    this.disposed = true;
+    if (this.timer !== undefined) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+    this.disposal = this.options.disabled
+      ? Promise.resolve()
+      : (this.activeFlush ?? Promise.resolve()).then(() => this.flushQueued(true));
+    return this.disposal;
+  }
+
+  private flushQueued(allowDisposed = false): Promise<void> {
+    if (this.activeFlush !== undefined) return this.activeFlush;
+    const run = async (): Promise<void> => {
+      while (this.events.length > 0 && (!this.disposed || allowDisposed)) {
+        const batchEvents = this.events.splice(0, this.options.maxBatchSize);
+        try {
+          const controller = new AbortController();
+          await this.options.transport({ version: 1, events: batchEvents }, controller.signal);
+        } catch (cause) {
+          const requeued = [...batchEvents, ...this.events];
+          this.events = requeued.slice(0, this.options.maxQueueSize);
+          this.droppedEvents += Math.max(0, requeued.length - this.options.maxQueueSize);
+          throw cause;
+        }
+      }
+    };
+    this.activeFlush = run().finally(() => {
+      this.activeFlush = undefined;
+    });
+    return this.activeFlush;
+  }
+}
+
+export const createBrowserTelemetryClient = (
+  config: BrowserTelemetryClientConfig = {},
+): BrowserTelemetryClient => {
+  const maxBatchSize = Math.min(
+    positiveInteger(config.maxBatchSize, defaultMaxBatchSize),
+    maxBatchSizeLimit,
+  );
+  return new BrowserClientEngine({
+    disabled: config.disabled ?? false,
+    maxBatchSize,
+    maxQueueSize: positiveInteger(config.maxQueueSize, defaultMaxQueueSize),
+    flushIntervalMs: positiveInteger(config.flushIntervalMs, defaultFlushIntervalMs),
+    transport: config.transport ?? fetchTransport(config.endpoint ?? defaultEndpoint),
+    startTimer: true,
+  });
+};

--- a/packages/telemetry/src/browser/BrowserClient.ts
+++ b/packages/telemetry/src/browser/BrowserClient.ts
@@ -27,6 +27,7 @@ export type BrowserTelemetryClientConfig = {
   readonly maxBatchSize?: number;
   readonly maxQueueSize?: number;
   readonly flushIntervalMs?: number;
+  readonly shutdownTimeoutMs?: number;
   readonly transport?: BrowserTelemetryClientTransport;
 };
 
@@ -50,14 +51,30 @@ export class BrowserTelemetryClientDeliveryError extends Error {
   }
 }
 
+export class BrowserTelemetryClientShutdownError extends Error {
+  readonly code = "OBS_BROWSER_EVENTS_SHUTDOWN_TIMEOUT";
+  readonly retryable = true;
+
+  constructor(readonly timeoutMs: number) {
+    super(
+      `Browser telemetry shutdown exceeded ${timeoutMs} milliseconds. The client aborted active delivery and retained its sanitized batch.`,
+    );
+    this.name = "BrowserTelemetryClientShutdownError";
+  }
+}
+
 const defaultEndpoint = "/_telemetry/events";
 const defaultMaxBatchSize = 32;
 const defaultMaxQueueSize = 256;
 const defaultFlushIntervalMs = 5_000;
+const defaultShutdownTimeoutMs = 2_000;
 const maxBatchSizeLimit = 64;
+const fallbackEventName = "browser.event";
 
-const positiveInteger = (value: number | undefined, fallback: number): number =>
+export const normalizePositiveInteger = (value: number | undefined, fallback: number): number =>
   value === undefined || !Number.isSafeInteger(value) || value <= 0 ? fallback : value;
+
+const positiveInteger = normalizePositiveInteger;
 
 const fetchTransport =
   (endpoint: string): BrowserTelemetryClientTransport =>
@@ -92,13 +109,21 @@ type BrowserClientEngineOptions = {
   readonly maxBatchSize: number;
   readonly maxQueueSize: number;
   readonly flushIntervalMs: number;
+  readonly shutdownTimeoutMs: number;
   readonly transport: BrowserTelemetryClientTransport;
   readonly startTimer: boolean;
+};
+
+type ActiveDelivery = {
+  readonly events: Array<BrowserTelemetryClientEvent>;
+  abandoned: boolean;
 };
 
 export class BrowserClientEngine implements BrowserTelemetryClient {
   private events: Array<BrowserTelemetryClientEvent> = [];
   private activeFlush: Promise<void> | undefined;
+  private activeDelivery: ActiveDelivery | undefined;
+  private readonly activeControllers = new Set<AbortController>();
   private disposal: Promise<void> | undefined;
   private disposed = false;
   private timer: ReturnType<typeof setInterval> | undefined;
@@ -114,9 +139,10 @@ export class BrowserClientEngine implements BrowserTelemetryClient {
 
   emit(name: string, fields: BrowserTelemetryClientFields = {}): void {
     if (this.options.disabled || this.disposed) return;
+    const sanitizedName = sanitizeBrowserEventName(name);
     const event: BrowserTelemetryClientEvent = {
       id: crypto.randomUUID(),
-      name: sanitizeBrowserEventName(name),
+      name: sanitizedName.length === 0 ? fallbackEventName : sanitizedName,
       occurredAt: Date.now(),
       fields: sanitizeBrowserFields(fields),
     };
@@ -147,10 +173,42 @@ export class BrowserClientEngine implements BrowserTelemetryClient {
       clearInterval(this.timer);
       this.timer = undefined;
     }
-    this.disposal = this.options.disabled
-      ? Promise.resolve()
-      : (this.activeFlush ?? Promise.resolve()).then(() => this.flushQueued(true));
+    this.disposal = this.options.disabled ? Promise.resolve() : this.shutdown();
     return this.disposal;
+  }
+
+  private async shutdown(): Promise<void> {
+    let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<never>((_, reject) => {
+      deadlineTimer = setTimeout(() => {
+        for (const controller of this.activeControllers) controller.abort();
+        this.abandonActiveDelivery();
+        reject(new BrowserTelemetryClientShutdownError(this.options.shutdownTimeoutMs));
+      }, this.options.shutdownTimeoutMs);
+    });
+    try {
+      if (this.activeFlush !== undefined) {
+        try {
+          await Promise.race([this.activeFlush, deadline]);
+        } catch (cause) {
+          if (cause instanceof BrowserTelemetryClientShutdownError) throw cause;
+        }
+      }
+      await Promise.race([this.flushQueued(true), deadline]);
+    } finally {
+      if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
+    }
+  }
+
+  private abandonActiveDelivery(): void {
+    if (this.activeDelivery === undefined || this.activeDelivery.abandoned) return;
+    this.activeDelivery.abandoned = true;
+    const requeued = [...this.activeDelivery.events, ...this.events];
+    this.events = requeued.slice(0, this.options.maxQueueSize);
+    this.droppedEvents += Math.max(0, requeued.length - this.options.maxQueueSize);
+    this.activeDelivery = undefined;
+    this.activeControllers.clear();
+    this.activeFlush = undefined;
   }
 
   private flushQueued(allowDisposed = false): Promise<void> {
@@ -158,14 +216,22 @@ export class BrowserClientEngine implements BrowserTelemetryClient {
     const run = async (): Promise<void> => {
       while (this.events.length > 0 && (!this.disposed || allowDisposed)) {
         const batchEvents = this.events.splice(0, this.options.maxBatchSize);
+        const delivery: ActiveDelivery = { events: batchEvents, abandoned: false };
+        const controller = new AbortController();
+        this.activeDelivery = delivery;
+        this.activeControllers.add(controller);
         try {
-          const controller = new AbortController();
           await this.options.transport({ version: 1, events: batchEvents }, controller.signal);
+          if (delivery.abandoned) return;
         } catch (cause) {
+          if (delivery.abandoned) return;
           const requeued = [...batchEvents, ...this.events];
           this.events = requeued.slice(0, this.options.maxQueueSize);
           this.droppedEvents += Math.max(0, requeued.length - this.options.maxQueueSize);
           throw cause;
+        } finally {
+          this.activeControllers.delete(controller);
+          if (this.activeDelivery === delivery) this.activeDelivery = undefined;
         }
       }
     };
@@ -188,6 +254,7 @@ export const createBrowserTelemetryClient = (
     maxBatchSize,
     maxQueueSize: positiveInteger(config.maxQueueSize, defaultMaxQueueSize),
     flushIntervalMs: positiveInteger(config.flushIntervalMs, defaultFlushIntervalMs),
+    shutdownTimeoutMs: positiveInteger(config.shutdownTimeoutMs, defaultShutdownTimeoutMs),
     transport: config.transport ?? fetchTransport(config.endpoint ?? defaultEndpoint),
     startTimer: true,
   });

--- a/packages/telemetry/src/browser/client.ts
+++ b/packages/telemetry/src/browser/client.ts
@@ -1,5 +1,6 @@
 export {
   BrowserTelemetryClientDeliveryError,
+  BrowserTelemetryClientShutdownError,
   createBrowserTelemetryClient,
 } from "./BrowserClient.ts";
 export type {

--- a/packages/telemetry/src/browser/client.ts
+++ b/packages/telemetry/src/browser/client.ts
@@ -1,0 +1,12 @@
+export {
+  BrowserTelemetryClientDeliveryError,
+  createBrowserTelemetryClient,
+} from "./BrowserClient.ts";
+export type {
+  BrowserTelemetryClient,
+  BrowserTelemetryClientBatch,
+  BrowserTelemetryClientConfig,
+  BrowserTelemetryClientEvent,
+  BrowserTelemetryClientFields,
+  BrowserTelemetryClientTransport,
+} from "./BrowserClient.ts";

--- a/packages/telemetry/src/browser/index.ts
+++ b/packages/telemetry/src/browser/index.ts
@@ -1,12 +1,25 @@
-import { Clock, Context, Duration, Effect, Layer, Ref, Schema } from "effect";
+import { Cause, Context, Duration, Effect, Exit, Layer, Option, Schema } from "effect";
 import {
   BrowserEvent,
   BrowserEventBatch,
   encodeBrowserEventBatch,
   maxEventsPerBatch,
 } from "../BrowserEvents.ts";
-import { sanitizeBrowserEventName, sanitizeBrowserFields } from "../RedactionPolicy.ts";
 import type { WideEventFields } from "../WideEvent.ts";
+import { BrowserClientEngine } from "./BrowserClient.ts";
+
+export {
+  BrowserTelemetryClientDeliveryError,
+  createBrowserTelemetryClient,
+} from "./BrowserClient.ts";
+export type {
+  BrowserTelemetryClient,
+  BrowserTelemetryClientBatch,
+  BrowserTelemetryClientConfig,
+  BrowserTelemetryClientEvent,
+  BrowserTelemetryClientFields,
+  BrowserTelemetryClientTransport,
+} from "./BrowserClient.ts";
 
 export {
   BrowserEvent,
@@ -84,67 +97,65 @@ export type BrowserTelemetryOptions = {
   readonly flushInterval?: Duration.Input;
 };
 
-type EventQueue = {
-  readonly events: ReadonlyArray<BrowserEvent>;
-  readonly dropped: number;
-};
-
 const makeBrowserTelemetry = Effect.fn("makeBrowserTelemetry")(function* (
   options?: BrowserTelemetryOptions,
 ) {
   const transport = yield* BrowserEventTransport;
-  const maxBatchSize = Math.min(options?.maxBatchSize ?? 32, maxEventsPerBatch);
-  const maxQueueSize = options?.maxQueueSize ?? 256;
   const flushInterval = Duration.fromInputUnsafe(options?.flushInterval ?? "5 seconds");
-  const queue = yield* Ref.make<EventQueue>({ events: [], dropped: 0 });
+  const engine = new BrowserClientEngine({
+    disabled: false,
+    maxBatchSize: Math.min(options?.maxBatchSize ?? 32, maxEventsPerBatch),
+    maxQueueSize: options?.maxQueueSize ?? 256,
+    flushIntervalMs: Duration.toMillis(flushInterval),
+    transport: (batch) =>
+      new Promise<void>((resolve, reject) => {
+        Effect.runCallback(
+          transport.send(
+            new BrowserEventBatch({
+              version: 1,
+              events: batch.events.map((event) => new BrowserEvent(event)),
+            }),
+          ),
+          {
+            onExit: (exit) => {
+              if (Exit.isSuccess(exit)) {
+                resolve();
+                return;
+              }
+              const failure = Cause.findErrorOption(exit.cause);
+              reject(Option.isSome(failure) ? failure.value : Cause.squash(exit.cause));
+            },
+          },
+        );
+      }),
+    startTimer: false,
+  });
 
-  const emit = (name: string, fields?: WideEventFields): Effect.Effect<void> =>
-    Effect.gen(function* () {
-      const occurredAt = yield* Clock.currentTimeMillis;
-      const event = new BrowserEvent({
-        id: crypto.randomUUID(),
-        name: sanitizeBrowserEventName(name),
-        occurredAt,
-        fields: sanitizeBrowserFields(fields ?? {}),
-      });
-      yield* Ref.update(queue, (state) =>
-        state.events.length >= maxQueueSize
-          ? { events: [...state.events.slice(1), event], dropped: state.dropped + 1 }
-          : { events: [...state.events, event], dropped: state.dropped },
-      );
-    });
-
-  const flush: Effect.Effect<void, BrowserEventDeliveryError> = Effect.gen(function* () {
-    while (true) {
-      const batchEvents = yield* Ref.modify(queue, (state) => [
-        state.events.slice(0, maxBatchSize),
-        { events: state.events.slice(maxBatchSize), dropped: state.dropped },
-      ]);
-      if (batchEvents.length === 0) {
-        return;
-      }
-      yield* transport.send(new BrowserEventBatch({ version: 1, events: batchEvents })).pipe(
-        Effect.tapError(() =>
-          Ref.update(queue, (state) => {
-            const requeued = [...batchEvents, ...state.events];
-            return {
-              events: requeued.slice(0, maxQueueSize),
-              dropped: state.dropped + Math.max(0, requeued.length - maxQueueSize),
-            };
+  const flush = Effect.tryPromise({
+    try: () => engine.flush(),
+    catch: (cause) =>
+      cause instanceof BrowserEventDeliveryError
+        ? cause
+        : new BrowserEventDeliveryError({
+            code: "OBS_BROWSER_EVENTS_DELIVERY_FAILED",
+            message:
+              "The browser events could not be sent. The events stay queued and the next flush retries the same batch.",
+            retryable: true,
+            cause,
           }),
-        ),
-      );
-    }
   });
 
   yield* Effect.forkScoped(flush.pipe(Effect.ignore, Effect.delay(flushInterval), Effect.forever));
-  yield* Effect.addFinalizer(() => flush.pipe(Effect.ignore));
+  yield* Effect.addFinalizer(() =>
+    Effect.tryPromise({ try: () => engine.dispose(), catch: () => undefined }).pipe(Effect.ignore),
+  );
 
   return {
-    emit,
+    emit: (name: string, fields?: WideEventFields) =>
+      Effect.sync(() => engine.emit(name, fields ?? {})),
     flush: () => flush,
-    pending: () => Ref.get(queue).pipe(Effect.map((state) => state.events.length)),
-    dropped: () => Ref.get(queue).pipe(Effect.map((state) => state.dropped)),
+    pending: () => Effect.sync(() => engine.pending()),
+    dropped: () => Effect.sync(() => engine.dropped()),
   };
 });
 

--- a/packages/telemetry/src/browser/index.ts
+++ b/packages/telemetry/src/browser/index.ts
@@ -6,10 +6,11 @@ import {
   maxEventsPerBatch,
 } from "../BrowserEvents.ts";
 import type { WideEventFields } from "../WideEvent.ts";
-import { BrowserClientEngine } from "./BrowserClient.ts";
+import { BrowserClientEngine, normalizePositiveInteger } from "./BrowserClient.ts";
 
 export {
   BrowserTelemetryClientDeliveryError,
+  BrowserTelemetryClientShutdownError,
   createBrowserTelemetryClient,
 } from "./BrowserClient.ts";
 export type {
@@ -104,9 +105,10 @@ const makeBrowserTelemetry = Effect.fn("makeBrowserTelemetry")(function* (
   const flushInterval = Duration.fromInputUnsafe(options?.flushInterval ?? "5 seconds");
   const engine = new BrowserClientEngine({
     disabled: false,
-    maxBatchSize: Math.min(options?.maxBatchSize ?? 32, maxEventsPerBatch),
-    maxQueueSize: options?.maxQueueSize ?? 256,
-    flushIntervalMs: Duration.toMillis(flushInterval),
+    maxBatchSize: Math.min(normalizePositiveInteger(options?.maxBatchSize, 32), maxEventsPerBatch),
+    maxQueueSize: normalizePositiveInteger(options?.maxQueueSize, 256),
+    flushIntervalMs: normalizePositiveInteger(Duration.toMillis(flushInterval), 5_000),
+    shutdownTimeoutMs: 2_000,
     transport: (batch) =>
       new Promise<void>((resolve, reject) => {
         Effect.runCallback(

--- a/packages/telemetry/test/browser.test.ts
+++ b/packages/telemetry/test/browser.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest";
-import { Effect, Layer, Option, Schema } from "effect";
+import { Duration, Effect, Layer, Option, Schema } from "effect";
 import { createServer, type Server } from "node:http";
 import {
   BrowserEventBatch,
@@ -64,6 +64,29 @@ describe("BrowserTelemetry", () => {
       const long = event.fields["page.long"];
       assert.strictEqual(String(long).length, maxFieldValueLength);
       assert.strictEqual(Object.keys(event.fields).length, 32);
+    }),
+  );
+
+  it.live("normalizes non-positive queue and interval options", () =>
+    Effect.gen(function* () {
+      for (const value of [0, -1]) {
+        const sent: RecordedBatches = [];
+        yield* Effect.gen(function* () {
+          const telemetry = yield* BrowserTelemetry;
+          yield* telemetry.emit("", {});
+          yield* telemetry.flush();
+          assert.strictEqual(yield* telemetry.pending(), 0);
+        }).pipe(
+          Effect.provide(
+            BrowserTelemetry.layer({
+              maxBatchSize: value,
+              maxQueueSize: value,
+              flushInterval: Duration.millis(value),
+            }).pipe(Layer.provide(recordingTransport(sent))),
+          ),
+        );
+        assert.strictEqual(sent[0]?.events[0]?.name, "browser.event");
+      }
     }),
   );
 
@@ -269,6 +292,10 @@ describe("BrowserEventTransport.layerFetch", () => {
       const secret = crypto.randomUUID().replaceAll("-", "");
       const bodies: Array<string> = [];
       const endpoint = yield* Effect.promise(() => startEndpoint(200, bodies));
+      const nestedJson = JSON.stringify({
+        object: { assignment: `authorization=${secret}`, ordinary: "authorization guide" },
+        array: [`password:${secret}`, "ordinary value"],
+      });
       const fields: WideEventFields = Object.fromEntries([
         ["authorization", secret],
         ["note", `before Bearer ${secret} after`],
@@ -277,6 +304,7 @@ describe("BrowserEventTransport.layerFetch", () => {
         ["constructor", "safe-constructor"],
         ["hasOwnProperty", "safe-has-own-property"],
         ["__proto__", "safe-proto"],
+        ["nested.json", nestedJson],
       ]);
       Object.defineProperty(fields, "nested", { value: { token: secret }, enumerable: true });
       yield* Effect.gen(function* () {
@@ -298,7 +326,11 @@ describe("BrowserEventTransport.layerFetch", () => {
       assert.include(body, sensitiveFieldReplacement);
       assert.include(body, sensitiveTextReplacement);
       assert.include(body, "tokenizer");
-      assert.notInclude(body, "nested");
+      assert.notInclude(body, '"nested":');
+      assert.include(body, `authorization=${sensitiveTextReplacement}`);
+      assert.include(body, `password:${sensitiveTextReplacement}`);
+      assert.include(body, "authorization guide");
+      assert.include(body, "ordinary value");
       assert.include(body, '"toString":"safe-to-string"');
       assert.include(body, '"constructor":"safe-constructor"');
       assert.include(body, '"hasOwnProperty":"safe-has-own-property"');

--- a/packages/telemetry/test/browserClient.test.ts
+++ b/packages/telemetry/test/browserClient.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
   BrowserTelemetryClientDeliveryError,
+  BrowserTelemetryClientShutdownError,
   createBrowserTelemetryClient,
   type BrowserTelemetryClientBatch,
   type BrowserTelemetryClientTransport,
@@ -10,12 +11,15 @@ import { sensitiveFieldReplacement, sensitiveTextReplacement } from "../src/Reda
 const deferred = (): {
   readonly promise: Promise<void>;
   readonly resolve: () => void;
+  readonly reject: (error: Error) => void;
 } => {
   let complete = (): void => undefined;
-  const promise = new Promise<void>((resolve) => {
+  let fail = (_error: Error): void => undefined;
+  const promise = new Promise<void>((resolve, reject) => {
     complete = resolve;
+    fail = reject;
   });
-  return { promise, resolve: complete };
+  return { promise, resolve: complete, reject: fail };
 };
 
 describe("browser telemetry client", () => {
@@ -70,6 +74,82 @@ describe("browser telemetry client", () => {
     await firstFlush;
     expect(batches.map((batch) => batch.events[0]?.name)).toEqual(["first", "second"]);
     expect(client.pending()).toBe(0);
+    await client.dispose();
+  });
+
+  it("settles a failed active flush and retries its queued batch during disposal", async () => {
+    const active = deferred();
+    const batches: Array<BrowserTelemetryClientBatch> = [];
+    const client = createBrowserTelemetryClient({
+      transport: async (batch) => {
+        batches.push(batch);
+        if (batches.length === 1) await active.promise;
+      },
+      flushIntervalMs: 60_000,
+      shutdownTimeoutMs: 200,
+    });
+    client.emit("active-failure");
+    const flush = client.flush();
+    const disposal = client.dispose();
+    active.reject(new Error("active failed"));
+    await expect(flush).rejects.toThrow("active failed");
+    await disposal;
+    expect(batches).toHaveLength(2);
+    expect(batches[1]).toEqual(batches[0]);
+    expect(client.pending()).toBe(0);
+  });
+
+  it("aborts a hung transport at the shutdown deadline with one disposal promise", async () => {
+    let aborted = false;
+    const client = createBrowserTelemetryClient({
+      transport: (_batch, signal) =>
+        new Promise<void>((_resolve, reject) => {
+          signal.addEventListener("abort", () => {
+            aborted = true;
+            reject(new Error("aborted"));
+          });
+        }),
+      flushIntervalMs: 60_000,
+      shutdownTimeoutMs: 20,
+    });
+    client.emit("hung");
+    client.flush().catch(() => undefined);
+    const disposal = client.dispose();
+    expect(client.dispose()).toBe(disposal);
+    await expect(disposal).rejects.toMatchObject({
+      code: "OBS_BROWSER_EVENTS_SHUTDOWN_TIMEOUT",
+      retryable: true,
+      timeoutMs: 20,
+    });
+    expect(aborted).toBe(true);
+    expect(client.pending()).toBe(1);
+  });
+
+  it("bounds disposal when a custom transport ignores abort", async () => {
+    const client = createBrowserTelemetryClient({
+      transport: async () => new Promise<void>(() => undefined),
+      flushIntervalMs: 60_000,
+      shutdownTimeoutMs: 20,
+    });
+    client.emit("abort-ignored");
+    client.flush().catch(() => undefined);
+    const startedAt = Date.now();
+    await expect(client.dispose()).rejects.toBeInstanceOf(BrowserTelemetryClientShutdownError);
+    expect(Date.now() - startedAt).toBeLessThan(200);
+    expect(client.pending()).toBe(1);
+  });
+
+  it("uses a valid bounded fallback for empty names", async () => {
+    const batches: Array<BrowserTelemetryClientBatch> = [];
+    const client = createBrowserTelemetryClient({
+      transport: async (batch) => {
+        batches.push(batch);
+      },
+      flushIntervalMs: 60_000,
+    });
+    client.emit("");
+    await client.flush();
+    expect(batches[0]?.events[0]?.name).toBe("browser.event");
     await client.dispose();
   });
 

--- a/packages/telemetry/test/browserClient.test.ts
+++ b/packages/telemetry/test/browserClient.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  BrowserTelemetryClientDeliveryError,
+  createBrowserTelemetryClient,
+  type BrowserTelemetryClientBatch,
+  type BrowserTelemetryClientTransport,
+} from "../src/browser/index.ts";
+import { sensitiveFieldReplacement, sensitiveTextReplacement } from "../src/RedactionPolicy.ts";
+
+const deferred = (): {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+} => {
+  let complete = (): void => undefined;
+  const promise = new Promise<void>((resolve) => {
+    complete = resolve;
+  });
+  return { promise, resolve: complete };
+};
+
+describe("browser telemetry client", () => {
+  it("emits synchronously, sanitizes before transport, and retries the same batch", async () => {
+    const secret = crypto.randomUUID().replaceAll("-", "");
+    const batches: Array<BrowserTelemetryClientBatch> = [];
+    let attempts = 0;
+    const transport: BrowserTelemetryClientTransport = async (batch) => {
+      batches.push(batch);
+      attempts += 1;
+      if (attempts === 1) throw new Error("offline");
+    };
+    const client = createBrowserTelemetryClient({ transport, flushIntervalMs: 60_000 });
+
+    const result = client.emit(`checkout token=${secret}`, {
+      authorization: secret,
+      note: `Bearer ${secret}`,
+      control: "tokenizer",
+    });
+    expect(result).toBeUndefined();
+    expect(client.pending()).toBe(1);
+    await expect(client.flush()).rejects.toThrow("offline");
+    expect(client.pending()).toBe(1);
+    await client.flush();
+    expect(client.pending()).toBe(0);
+    expect(batches[1]).toEqual(batches[0]);
+    const serialized = JSON.stringify(batches);
+    expect(serialized).not.toContain(secret);
+    expect(serialized).toContain(sensitiveFieldReplacement);
+    expect(serialized).toContain(sensitiveTextReplacement);
+    await client.dispose();
+  });
+
+  it("coalesces concurrent flushes and drains events emitted during delivery", async () => {
+    const firstDelivery = deferred();
+    const batches: Array<BrowserTelemetryClientBatch> = [];
+    const transport: BrowserTelemetryClientTransport = async (batch) => {
+      batches.push(batch);
+      if (batches.length === 1) await firstDelivery.promise;
+    };
+    const client = createBrowserTelemetryClient({
+      transport,
+      maxBatchSize: 1,
+      flushIntervalMs: 60_000,
+    });
+    client.emit("first");
+    const firstFlush = client.flush();
+    const concurrentFlush = client.flush();
+    expect(concurrentFlush).toBe(firstFlush);
+    client.emit("second");
+    firstDelivery.resolve();
+    await firstFlush;
+    expect(batches.map((batch) => batch.events[0]?.name)).toEqual(["first", "second"]);
+    expect(client.pending()).toBe(0);
+    await client.dispose();
+  });
+
+  it("disposes once, flushes pending work, and is terminal", async () => {
+    const batches: Array<BrowserTelemetryClientBatch> = [];
+    const client = createBrowserTelemetryClient({
+      transport: async (batch) => {
+        batches.push(batch);
+      },
+      flushIntervalMs: 60_000,
+    });
+    client.emit("cleanup");
+    const firstDispose = client.dispose();
+    expect(client.dispose()).toBe(firstDispose);
+    await firstDispose;
+    client.emit("ignored");
+    await client.flush();
+    expect(batches.map((batch) => batch.events.map((event) => event.name))).toEqual([["cleanup"]]);
+    expect(client.pending()).toBe(0);
+  });
+
+  it("keeps a failed final batch sanitized and stays disposed", async () => {
+    const failure = new BrowserTelemetryClientDeliveryError("offline", true, { cause: "network" });
+    const client = createBrowserTelemetryClient({
+      transport: async () => {
+        throw failure;
+      },
+      flushIntervalMs: 60_000,
+    });
+    client.emit("retained");
+    await expect(client.dispose()).rejects.toBe(failure);
+    expect(client.pending()).toBe(1);
+    await client.flush();
+    expect(client.pending()).toBe(1);
+  });
+
+  it("owns periodic delivery until disposal", async () => {
+    const batches: Array<BrowserTelemetryClientBatch> = [];
+    const client = createBrowserTelemetryClient({
+      transport: async (batch) => {
+        batches.push(batch);
+      },
+      flushIntervalMs: 10,
+    });
+    client.emit("periodic");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(batches).toHaveLength(1);
+    await client.dispose();
+    client.emit("after-disposal");
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(batches).toHaveLength(1);
+  });
+
+  it("is allocation-free at the transport boundary when disabled", async () => {
+    let calls = 0;
+    const client = createBrowserTelemetryClient({
+      disabled: true,
+      transport: async () => {
+        calls += 1;
+      },
+    });
+    client.emit("ignored");
+    expect(client.pending()).toBe(0);
+    await client.flush();
+    await client.dispose();
+    expect(calls).toBe(0);
+  });
+});

--- a/packages/telemetry/test/redactionPolicy.test.ts
+++ b/packages/telemetry/test/redactionPolicy.test.ts
@@ -15,6 +15,8 @@ const SanitizedJson = Schema.fromJsonString(
       email: Schema.String,
       display: Schema.String,
       escaped: Schema.String,
+      assignment: Schema.String,
+      ordinary: Schema.String,
     }),
     events: Schema.Array(Schema.Struct({ token: Schema.String, note: Schema.String })),
   }),
@@ -139,9 +141,11 @@ describe("browser telemetry redaction policy", () => {
         email: secret,
         display: `Bearer ${secret}`,
         escaped: `quoted "Bearer ${secret}"`,
+        assignment: `authorization=${secret}`,
+        ordinary: "authorization guide",
       },
       events: [
-        { token: secret, note: `sk_${secret}` },
+        { token: secret, note: `password:${secret}` },
         { token: secret, note: "ordinary value" },
       ],
     });
@@ -154,6 +158,10 @@ describe("browser telemetry redaction policy", () => {
     const decoded = decodeSanitizedJson(fields.json);
     assert.strictEqual(decoded.profile.email, sensitiveTextReplacement);
     assert.strictEqual(decoded.profile.escaped, `quoted "${sensitiveTextReplacement}"`);
+    assert.strictEqual(decoded.profile.assignment, `authorization=${sensitiveTextReplacement}`);
+    assert.strictEqual(decoded.profile.ordinary, "authorization guide");
+    assert.strictEqual(decoded.events[0]?.note, `password:${sensitiveTextReplacement}`);
+    assert.strictEqual(decoded.events[1]?.note, "ordinary value");
     assert.strictEqual(decoded.events[0]?.token, sensitiveTextReplacement);
     assert.strictEqual(decoded.events[1]?.token, sensitiveTextReplacement);
     assert.notInclude(JSON.stringify(fields), secret);

--- a/scripts/package-smoke.ts
+++ b/scripts/package-smoke.ts
@@ -224,7 +224,16 @@ try {
   const browserBytes = await Bun.file(browserBundle).bytes();
   const emptyBytes = await Bun.file(emptyBundle).bytes();
   const browserGzip = Bun.gzipSync(browserBytes, { level: 9 });
+  const reproducedBrowserGzip = Bun.gzipSync(browserBytes, { level: 9 });
   const emptyGzip = Bun.gzipSync(emptyBytes, { level: 9 });
+  if (
+    browserGzip.byteLength !== reproducedBrowserGzip.byteLength ||
+    !browserGzip.every((byte, index) => byte === reproducedBrowserGzip[index])
+  ) {
+    throw new Error("The isolated browser facade gzip output is not reproducible.");
+  }
+  const facadeGzipDeltaBytes = browserGzip.byteLength - emptyGzip.byteLength;
+  const facadeGzipRegressionCeilingBytes = 80_000;
   const evidence = join(root, ".verification/observability/obs-11-browser-facade");
   await rm(evidence, { recursive: true, force: true });
   await mkdir(evidence, { recursive: true });
@@ -245,7 +254,9 @@ try {
         browserMinifiedGzipBytes: browserGzip.byteLength,
         emptyMinifiedBytes: emptyBytes.byteLength,
         emptyMinifiedGzipBytes: emptyGzip.byteLength,
-        facadeMinifiedGzipDeltaBytes: browserGzip.byteLength - emptyGzip.byteLength,
+        facadeMinifiedGzipDeltaBytes: facadeGzipDeltaBytes,
+        facadeGzipRegressionCeilingBytes,
+        gzipReproductionMatched: true,
         hibouBudgetBytes: 550_000,
         hibouBaselineAssessed: false,
         budgetChanged: false,
@@ -255,6 +266,11 @@ try {
       2,
     ),
   );
+  if (facadeGzipDeltaBytes > facadeGzipRegressionCeilingBytes) {
+    throw new Error(
+      `The isolated browser facade gzip delta is ${facadeGzipDeltaBytes} bytes, above the ${facadeGzipRegressionCeilingBytes} byte regression ceiling.`,
+    );
+  }
 
   const executable = join(consumer, "node_modules/.bin/observability");
   const help = await run([executable, "--help"], consumer);

--- a/scripts/package-smoke.ts
+++ b/scripts/package-smoke.ts
@@ -68,6 +68,8 @@ try {
         "package/dist/nestjs/index.d.ts",
         "package/dist/browser/index.js",
         "package/dist/browser/index.d.ts",
+        "package/dist/browser/client.js",
+        "package/dist/browser/client.d.ts",
         "package/dist/testing/index.js",
         "package/dist/testing/index.d.ts",
       ],
@@ -140,7 +142,7 @@ try {
       [
         "bun",
         "-e",
-        "import { Telemetry, WideEvent } from '@equipe-tech/observability'; import { runMain, ingestBrowserEvents } from '@equipe-tech/observability/node'; import { BrowserTelemetry } from '@equipe-tech/observability/browser'; import { run } from '@equipe-tech/observability/testing'; if (!Telemetry.layer || !WideEvent.emit || !runMain || !ingestBrowserEvents || !BrowserTelemetry.layer || !run) process.exit(1);",
+        "import { Telemetry, WideEvent } from '@equipe-tech/observability'; import { runMain, ingestBrowserEvents } from '@equipe-tech/observability/node'; import { BrowserTelemetry } from '@equipe-tech/observability/browser'; import { createBrowserTelemetryClient } from '@equipe-tech/observability/browser/client'; import { run } from '@equipe-tech/observability/testing'; if (!Telemetry.layer || !WideEvent.emit || !runMain || !ingestBrowserEvents || !BrowserTelemetry.layer || !createBrowserTelemetryClient || !run) process.exit(1);",
       ],
       consumer,
     ),
@@ -148,7 +150,7 @@ try {
   );
   await writeFile(
     join(consumer, "index.ts"),
-    "import { TelemetryConfig } from '@equipe-tech/observability';\nimport { layer } from '@equipe-tech/observability/node';\nimport { BrowserTelemetry } from '@equipe-tech/observability/browser';\nimport { run } from '@equipe-tech/observability/testing';\nconst config = new TelemetryConfig({ serviceName: 'test', serviceVersion: '1.0.0', environment: 'test', otlpEndpoint: new URL('http://localhost:4318') });\nvoid config;\nvoid layer;\nvoid BrowserTelemetry;\nvoid run;\n",
+    "import { TelemetryConfig } from '@equipe-tech/observability';\nimport { layer } from '@equipe-tech/observability/node';\nimport { BrowserTelemetry } from '@equipe-tech/observability/browser';\nimport { createBrowserTelemetryClient } from '@equipe-tech/observability/browser/client';\nimport { run } from '@equipe-tech/observability/testing';\nconst config = new TelemetryConfig({ serviceName: 'test', serviceVersion: '1.0.0', environment: 'test', otlpEndpoint: new URL('http://localhost:4318') });\nvoid config;\nvoid layer;\nvoid BrowserTelemetry;\nvoid createBrowserTelemetryClient;\nvoid run;\n",
   );
   await writeFile(
     join(consumer, "tsconfig.json"),
@@ -169,6 +171,89 @@ try {
       consumer,
     ),
     "Checking the telemetry declarations",
+  );
+  const browserClientDeclaration = await readFile(
+    join(consumer, "node_modules/@equipe-tech/observability/dist/browser/BrowserClient.d.ts"),
+    "utf8",
+  );
+  if (/\bEffect\b|from ["']effect["']/.test(browserClientDeclaration)) {
+    throw new Error("The imperative browser client declaration exposes an Effect type.");
+  }
+
+  const browserSmokeSource = [
+    "import { createBrowserTelemetryClient } from '@equipe-tech/observability/browser/client';",
+    "const batches = [];",
+    "const client = createBrowserTelemetryClient({ transport: async (batch) => { batches.push(batch); }, flushIntervalMs: 60000 });",
+    "client.emit('packed.browser', { source: 'package-smoke' });",
+    "if (client.pending() !== 1) throw new Error('The packed browser client did not queue synchronously.');",
+    "await client.flush();",
+    "await client.dispose();",
+    "if (batches.length !== 1 || batches[0].events[0]?.name !== 'packed.browser') throw new Error('The packed browser client did not deliver through its public transport boundary.');",
+  ].join("\n");
+  const browserSmokeEntry = join(consumer, "browser-smoke.ts");
+  const emptyEntry = join(consumer, "empty.ts");
+  const browserBundle = join(consumer, "browser-smoke.min.js");
+  const emptyBundle = join(consumer, "empty.min.js");
+  await writeFile(browserSmokeEntry, browserSmokeSource);
+  await writeFile(emptyEntry, "export {};\n");
+  requireSuccess(
+    await run(
+      [
+        "bun",
+        "build",
+        browserSmokeEntry,
+        "--target=browser",
+        "--minify",
+        `--outfile=${browserBundle}`,
+      ],
+      consumer,
+    ),
+    "Bundling the packed browser facade",
+  );
+  requireSuccess(
+    await run(
+      ["bun", "build", emptyEntry, "--target=browser", "--minify", `--outfile=${emptyBundle}`],
+      consumer,
+    ),
+    "Bundling the empty browser baseline",
+  );
+  requireSuccess(
+    await run(["bun", browserBundle], consumer),
+    "Executing the packed browser bundle",
+  );
+  const browserBytes = await Bun.file(browserBundle).bytes();
+  const emptyBytes = await Bun.file(emptyBundle).bytes();
+  const browserGzip = Bun.gzipSync(browserBytes, { level: 9 });
+  const emptyGzip = Bun.gzipSync(emptyBytes, { level: 9 });
+  const evidence = join(root, ".verification/observability/obs-11-browser-facade");
+  await rm(evidence, { recursive: true, force: true });
+  await mkdir(evidence, { recursive: true });
+  await Bun.write(join(evidence, "browser-smoke.ts"), browserSmokeSource);
+  await Bun.write(join(evidence, "browser-smoke.min.js"), browserBytes);
+  await Bun.write(join(evidence, "browser-smoke.min.js.gz"), browserGzip);
+  await Bun.write(join(evidence, "empty.min.js"), emptyBytes);
+  await Bun.write(join(evidence, "empty.min.js.gz"), emptyGzip);
+  await Bun.write(
+    join(evidence, "evidence.json"),
+    JSON.stringify(
+      {
+        command:
+          "bun build browser-smoke.ts --target=browser --minify --outfile=browser-smoke.min.js",
+        baselineCommand: "bun build empty.ts --target=browser --minify --outfile=empty.min.js",
+        source: "packed @equipe-tech/observability ./browser/client public export only",
+        browserMinifiedBytes: browserBytes.byteLength,
+        browserMinifiedGzipBytes: browserGzip.byteLength,
+        emptyMinifiedBytes: emptyBytes.byteLength,
+        emptyMinifiedGzipBytes: emptyGzip.byteLength,
+        facadeMinifiedGzipDeltaBytes: browserGzip.byteLength - emptyGzip.byteLength,
+        hibouBudgetBytes: 550_000,
+        hibouBaselineAssessed: false,
+        budgetChanged: false,
+        bunVersion: Bun.version,
+      },
+      undefined,
+      2,
+    ),
   );
 
   const executable = join(consumer, "node_modules/.bin/observability");


### PR DESCRIPTION
## Summary

- add an Effect-free browser client with imperative emit, pending, flush, and dispose
- bound shutdown, coalesce flushes, preserve retries, and keep disabled mode inert
- preserve browser redaction and add packed declarations, React guidance, and reproducible gzip enforcement

## Verification

- focused browser client, redaction, retry, and shutdown tests
- packed external consumer and Effect-free declaration checks
- reproducible 74,330-byte isolated gzip delta under an 80,000-byte package ceiling
- `bun check`, build, full tests, package smoke, and independent exact-head review

Linear: OBS-11
