### PR TITLE
feat(telemetry): add framework-neutral metrics facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ O pacote `@equipe-tech/observability` publica um subpath por runtime:
 
 | Subpath     | Conteúdo                                                                                                                     |
 | ----------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `./metrics` | Facade sem dependência de framework para counters, histogramas, gauges observáveis, flush e close                            |
 | `./node`    | `runMain` (telemetria do ambiente, interrupção em `SIGINT`/`SIGTERM`, flush no shutdown) e ingestão de eventos do browser    |
 | `./nestjs`  | `TelemetryInterceptor` (spans de fronteira HTTP), `withRequestSpan` e `createBrowserEventsController` (`/_telemetry/events`) |
 | `./browser` | `BrowserTelemetry` (fila limitada, batch e flush de wide events para `/_telemetry/events`) com transporte `fetch` injetável  |
@@ -80,6 +81,8 @@ O pacote `@equipe-tech/observability` publica um subpath por runtime:
 O contrato do endpoint `/_telemetry/events` vive em `BrowserEvents` no entrypoint raiz. O servidor faz o parse com `parseBrowserEventBatch` e re-emite os eventos como wide events com atributos de servidor (`event.source`, `browser.event.id`).
 
 O adapter `./nestjs` publica o endpoint pronto: registre `createBrowserEventsController(runtime)` nos controllers do módulo. O controller responde `202 { accepted }` e rejeita batches inválidos com `400 { code, message, correlationId }`. O valor `correlationId` é um identificador seguro para suporte. O limite de corpo bruto pertence ao transporte HTTP; o Express responde `413` acima do limite configurado.
+
+Consulte [Métricas sem dependência de framework](docs/metrics.md) para lifecycle, limites de cardinalidade, atributos e erros.
 
 Consulte [Semântica HTTP do adapter NestJS](docs/nestjs-http-semantics.md) para rotas, status, proxy, privacidade e exclusões.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,87 @@
+# Framework-neutral metrics
+
+Use `@equipe-tech/observability/metrics` from NestJS, plain Node.js, or any other JavaScript runtime. The facade exports counters, histograms, observable gauges, bounded flush, and idempotent close without exposing Effect types.
+
+```ts
+import { createMetrics } from "@equipe-tech/observability/metrics";
+
+const metrics = await createMetrics({
+  serviceName: "checkout-api",
+  serviceVersion: "1.4.0",
+  environment: "production",
+  otlpEndpoint: "http://localhost:4318",
+});
+
+const orders = metrics.counter({
+  name: "orders.created",
+  description: "Created orders",
+  unit: "1",
+});
+
+const duration = metrics.histogram({
+  name: "orders.duration",
+  description: "Order duration",
+  unit: "ms",
+  boundaries: [10, 25, 50, 100, 250, 500],
+});
+
+const queue = metrics.observableGauge(
+  {
+    name: "orders.queue.depth",
+    description: "Pending order count",
+    unit: "1",
+  },
+  () => [{ value: 4, attributes: [{ key: "region", value: "south" }] }],
+);
+
+orders.add(1, [{ key: "region", value: "south" }]);
+duration.record(42, [{ key: "region", value: "south" }]);
+await metrics.flush();
+queue.unregister();
+await metrics.close();
+```
+
+## Lifecycle
+
+`createMetrics` validates the complete configuration before acquiring a runtime lease. Equal active configurations share one runtime, registry, periodic exporter, and lifecycle queue.
+
+`add`, `record`, gauge registration, and unregister are synchronous. `flush` and `close` are asynchronous and bounded by `flushTimeoutMilliseconds`, which defaults to 3 seconds. A repeated `close` returns the same promise. Recording, registration, or flushing after close throws `MetricsError` with code `CLOSED`.
+
+Observable callbacks run synchronously immediately before periodic, manual, and final exports. One callback may return up to 100 observations. Failures omit that gauge from the current export and appear in `FlushResult.gaugeFailures` without suppressing valid instruments. Unregistering the final callback removes the gauge from later exports.
+
+Set `enabled: false` to retain validation and no-op handles without an exporter, timer, callback invocation, request, or retained runtime lease.
+
+## Instrument identity
+
+The metric name is the instrument identity within one runtime. Repeating the exact kind, description, unit, and histogram boundaries is compatible. Any mismatch throws `INSTRUMENT_CONFLICT` before creating a partial instrument.
+
+Names use `[A-Za-z][A-Za-z0-9_.\-/]{0,254}`. Units are `1`, `%`, or a case-sensitive ASCII unit expression such as `ms`, `By/s`, or `m/s^2`. Descriptions contain 1 to 1,024 characters without control characters. Histograms require 1 to 50 finite, strictly increasing boundaries.
+
+Counters accept finite additions greater than or equal to zero. Histograms accept any finite observation.
+
+## Attributes and cardinality
+
+Pass attributes as an array of `{ key, value }` items. Values are strings, finite numbers, or booleans. Duplicate keys, `unit`, and `time_unit` are rejected. A measurement accepts at most 16 attributes. Attribute keys contain at most 128 characters. String values contain at most 256 characters and no control characters.
+
+The runtime enforces these lifetime limits:
+
+- 100 instruments per runtime
+- 1,000 series identities per instrument
+- 10,000 series identities per runtime
+- 16 callbacks per observable gauge
+- 100 observations per callback collection
+
+Series identity sorts attribute keys and preserves scalar types, so string `"1"`, number `1`, and boolean `true` remain distinct. Cardinality limits do not reset after gauge unregister.
+
+## Failures
+
+Synchronous validation and registration failures throw `MetricsError` with one of these codes:
+
+- `INVALID_CONFIGURATION`
+- `INVALID_INSTRUMENT`
+- `INVALID_MEASUREMENT`
+- `INSTRUMENT_CONFLICT`
+- `LIMIT_EXCEEDED`
+- `CLOSED`
+
+`flush` and the final export from `close` reject with `EXPORT_FAILED` or `FLUSH_TIMED_OUT`. Both are retryable on an open lifecycle. `close` releases the runtime lease even when its final export rejects.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -43,7 +43,7 @@ await metrics.close();
 
 ## Lifecycle
 
-`createMetrics` validates the complete configuration before acquiring a runtime lease. Equal active configurations share one runtime, registry, periodic exporter, and lifecycle queue. `exportIntervalMilliseconds` controls periodic collection and defaults to 10,000 milliseconds.
+`createMetrics` validates the complete configuration before acquiring a runtime lease. Equal active configurations share one runtime, registry, periodic exporter, and lifecycle queue. They also share exactly one exporter when facade and layer leases overlap. The most recently acquired active layer binding provides the transport; the built-in fetch transport is the fallback when no layer binding is active. Transport identity is deliberately excluded from the pool key because including it would create parallel runtimes and duplicate exporters. `exportIntervalMilliseconds` controls periodic collection and defaults to 10,000 milliseconds.
 
 `add`, `record`, gauge registration, and unregister are synchronous. `flush` and `close` are asynchronous and bounded by `flushTimeoutMilliseconds`, which defaults to 3 seconds. A repeated `close` returns the same promise. Recording, registration, or flushing after close throws `MetricsError` with code `CLOSED`. Cumulative counter and histogram values remain in the shared runtime after an individual lease closes and retain the runtime start time.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -43,17 +43,17 @@ await metrics.close();
 
 ## Lifecycle
 
-`createMetrics` validates the complete configuration before acquiring a runtime lease. Equal active configurations share one runtime, registry, periodic exporter, and lifecycle queue.
+`createMetrics` validates the complete configuration before acquiring a runtime lease. Equal active configurations share one runtime, registry, periodic exporter, and lifecycle queue. `exportIntervalMilliseconds` controls periodic collection and defaults to 10,000 milliseconds.
 
-`add`, `record`, gauge registration, and unregister are synchronous. `flush` and `close` are asynchronous and bounded by `flushTimeoutMilliseconds`, which defaults to 3 seconds. A repeated `close` returns the same promise. Recording, registration, or flushing after close throws `MetricsError` with code `CLOSED`.
+`add`, `record`, gauge registration, and unregister are synchronous. `flush` and `close` are asynchronous and bounded by `flushTimeoutMilliseconds`, which defaults to 3 seconds. A repeated `close` returns the same promise. Recording, registration, or flushing after close throws `MetricsError` with code `CLOSED`. Cumulative counter and histogram values remain in the shared runtime after an individual lease closes and retain the runtime start time.
 
 Observable callbacks run synchronously immediately before periodic, manual, and final exports. One callback may return up to 100 observations. Failures omit that gauge from the current export and appear in `FlushResult.gaugeFailures` without suppressing valid instruments. Unregistering the final callback removes the gauge from later exports.
 
-Set `enabled: false` to retain validation and no-op handles without an exporter, timer, callback invocation, request, or retained runtime lease.
+Set `enabled: false` to validate configuration, instrument definitions, measurement values, and measurement attributes while returning no-op handles without an exporter, timer, callback invocation, request, or retained runtime lease. Disabled mode cannot report callback-result failures, definition conflicts, or active-runtime cardinality limits because it retains no catalog, callbacks, or series.
 
 ## Instrument identity
 
-The metric name is the instrument identity within one runtime. Repeating the exact kind, description, unit, and histogram boundaries is compatible. Any mismatch throws `INSTRUMENT_CONFLICT` before creating a partial instrument.
+The metric name is the instrument identity within one runtime. Repeating the exact kind, description, unit, and histogram boundaries is compatible. A facade definition mismatch throws `INSTRUMENT_CONFLICT` before creating a partial instrument. A name collision discovered later against a direct Effect metric rejects export with non-retryable `EXPORT_FAILED` and sends no metrics request.
 
 Names use `[A-Za-z][A-Za-z0-9_.\-/]{0,254}`. Units are `1`, `%`, or a case-sensitive ASCII unit expression such as `ms`, `By/s`, or `m/s^2`. Descriptions contain 1 to 1,024 characters without control characters. Histograms require 1 to 50 finite, strictly increasing boundaries.
 
@@ -65,7 +65,7 @@ Pass attributes as an array of `{ key, value }` items. Values are strings, finit
 
 The runtime enforces these lifetime limits:
 
-- 100 instruments per runtime
+- 100 facade instrument names per runtime lifetime
 - 1,000 series identities per instrument
 - 10,000 series identities per runtime
 - 16 callbacks per observable gauge
@@ -84,4 +84,4 @@ Synchronous validation and registration failures throw `MetricsError` with one o
 - `LIMIT_EXCEEDED`
 - `CLOSED`
 
-`flush` and the final export from `close` reject with `EXPORT_FAILED` or `FLUSH_TIMED_OUT`. Both are retryable on an open lifecycle. `close` releases the runtime lease even when its final export rejects.
+`flush` and the final export from `close` reject with `EXPORT_FAILED` or `FLUSH_TIMED_OUT`. Transport failures and timeouts are retryable on an open lifecycle. Definition and name-conflict export failures are not retryable until the conflicting instrument is renamed or aligned. `close` releases the runtime lease even when its final export rejects.

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -12,6 +12,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./metrics": {
+      "types": "./dist/Metrics.d.ts",
+      "import": "./dist/Metrics.js"
+    },
     "./node": {
       "types": "./dist/node/index.d.ts",
       "import": "./dist/node/index.js"

--- a/packages/telemetry/src/Metrics.ts
+++ b/packages/telemetry/src/Metrics.ts
@@ -1,0 +1,119 @@
+import { createStandaloneMetrics } from "./MetricsRuntime.ts";
+
+export type MetricAttributeValue = string | number | boolean;
+
+export interface MetricAttribute {
+  readonly key: string;
+  readonly value: MetricAttributeValue;
+}
+
+export interface InstrumentDefinition {
+  readonly name: string;
+  readonly description: string;
+  readonly unit: string;
+}
+
+export interface CounterDefinition extends InstrumentDefinition {}
+
+export interface HistogramDefinition extends InstrumentDefinition {
+  readonly boundaries: ReadonlyArray<number>;
+}
+
+export interface GaugeObservation {
+  readonly value: number;
+  readonly attributes?: ReadonlyArray<MetricAttribute>;
+}
+
+export type ObservableGaugeCallback = () => ReadonlyArray<GaugeObservation>;
+
+export interface Counter {
+  add(value: number, attributes?: ReadonlyArray<MetricAttribute>): void;
+}
+
+export interface Histogram {
+  record(value: number, attributes?: ReadonlyArray<MetricAttribute>): void;
+}
+
+export interface ObservableGaugeRegistration {
+  unregister(): void;
+  [Symbol.dispose](): void;
+}
+
+export type GaugeCollectionFailureCode =
+  | "CALLBACK_FAILED"
+  | "INVALID_OBSERVATION"
+  | "ATTRIBUTE_LIMIT_EXCEEDED"
+  | "SERIES_LIMIT_EXCEEDED";
+
+export interface GaugeCollectionFailure {
+  readonly instrumentName: string;
+  readonly code: GaugeCollectionFailureCode;
+  readonly message: string;
+}
+
+export interface FlushResult {
+  readonly gaugeFailures: ReadonlyArray<GaugeCollectionFailure>;
+}
+
+export interface Metrics {
+  counter(definition: CounterDefinition): Counter;
+  histogram(definition: HistogramDefinition): Histogram;
+  observableGauge(
+    definition: InstrumentDefinition,
+    callback: ObservableGaugeCallback,
+  ): ObservableGaugeRegistration;
+  flush(): Promise<FlushResult>;
+  close(): Promise<FlushResult>;
+}
+
+export interface MetricsOptions {
+  readonly enabled?: boolean;
+  readonly serviceName: string;
+  readonly serviceVersion: string;
+  readonly environment: string;
+  readonly otlpEndpoint: string;
+  readonly exportIntervalMilliseconds?: number;
+  readonly flushTimeoutMilliseconds?: number;
+}
+
+export type MetricsErrorCode =
+  | "INVALID_CONFIGURATION"
+  | "INVALID_INSTRUMENT"
+  | "INVALID_MEASUREMENT"
+  | "INSTRUMENT_CONFLICT"
+  | "LIMIT_EXCEEDED"
+  | "EXPORT_FAILED"
+  | "FLUSH_TIMED_OUT"
+  | "CLOSED";
+
+interface MetricsErrorOptions {
+  readonly code: MetricsErrorCode;
+  readonly operation: string;
+  readonly message: string;
+  readonly instrumentName?: string;
+  readonly retryable: boolean;
+  readonly cause?: unknown;
+}
+
+export class MetricsError extends Error {
+  readonly code: MetricsErrorCode;
+  readonly operation: string;
+  readonly instrumentName?: string;
+  readonly retryable: boolean;
+  override readonly cause?: unknown;
+
+  constructor(options: MetricsErrorOptions) {
+    super(options.message);
+    this.name = "MetricsError";
+    this.code = options.code;
+    this.operation = options.operation;
+    if (options.instrumentName !== undefined) {
+      this.instrumentName = options.instrumentName;
+    }
+    this.retryable = options.retryable;
+    this.cause = options.cause;
+  }
+}
+
+export const createMetrics: (options: MetricsOptions) => Promise<Metrics> = (options) =>
+  createStandaloneMetrics(options);

--- a/packages/telemetry/src/MetricsRuntime.ts
+++ b/packages/telemetry/src/MetricsRuntime.ts
@@ -1,0 +1,1787 @@
+import { Context, Effect, Layer, Metric, Predicate, Schema } from "effect";
+import { HttpBody, HttpClient, HttpClientRequest } from "effect/unstable/http";
+import { OtlpExporter } from "effect/unstable/observability";
+import type {
+  Counter,
+  CounterDefinition,
+  FlushResult,
+  GaugeCollectionFailure,
+  GaugeObservation,
+  Histogram,
+  HistogramDefinition,
+  InstrumentDefinition,
+  MetricAttribute,
+  MetricAttributeValue,
+  Metrics,
+  MetricsOptions,
+  ObservableGaugeCallback,
+  ObservableGaugeRegistration,
+} from "./Metrics.ts";
+import { MetricsError } from "./Metrics.ts";
+import type { TelemetryConfig } from "./TelemetryConfig.ts";
+
+const instrumentNamePattern = /^[A-Za-z][A-Za-z0-9_.\-/]{0,254}$/;
+const unitPattern = /^(?:1|%|[A-Za-z][A-Za-z0-9]*(?:[./*^][A-Za-z0-9]+)*)$/;
+const containsControlCharacter = (value: string): boolean => {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint !== undefined && (codePoint <= 31 || codePoint === 127)) {
+      return true;
+    }
+  }
+  return false;
+};
+const maximumInstruments = 100;
+const maximumInstrumentSeries = 1_000;
+const maximumRuntimeSeries = 10_000;
+const maximumAttributes = 16;
+const maximumCallbacks = 16;
+const maximumObservations = 100;
+
+const MetricAttributeInput = Schema.Struct({
+  key: Schema.String,
+  value: Schema.Union([Schema.String, Schema.Number, Schema.Boolean]),
+});
+const MetricAttributesInput = Schema.Array(MetricAttributeInput);
+const InstrumentDefinitionInput = Schema.Struct({
+  name: Schema.String,
+  description: Schema.String,
+  unit: Schema.String,
+});
+const HistogramDefinitionInput = Schema.Struct({
+  name: Schema.String,
+  description: Schema.String,
+  unit: Schema.String,
+  boundaries: Schema.Array(Schema.Number),
+});
+const GaugeObservationsInput = Schema.Array(
+  Schema.Struct({
+    value: Schema.Number,
+    attributes: MetricAttributesInput.pipe(Schema.optionalKey),
+  }),
+);
+const MetricsOptionsInput = Schema.Struct({
+  enabled: Schema.Boolean.pipe(Schema.optionalKey),
+  serviceName: Schema.String,
+  serviceVersion: Schema.String,
+  environment: Schema.String,
+  otlpEndpoint: Schema.String,
+  exportIntervalMilliseconds: Schema.Number.pipe(Schema.optionalKey),
+  flushTimeoutMilliseconds: Schema.Number.pipe(Schema.optionalKey),
+});
+
+const decodeMetricAttributes = Schema.decodeUnknownSync(MetricAttributesInput);
+const decodeInstrumentDefinition = Schema.decodeUnknownSync(InstrumentDefinitionInput);
+const decodeHistogramDefinition = Schema.decodeUnknownSync(HistogramDefinitionInput);
+const decodeGaugeObservations = Schema.decodeUnknownSync(GaugeObservationsInput);
+const decodeMetricsOptions = Schema.decodeUnknownSync(MetricsOptionsInput);
+
+interface NormalizedOptions {
+  readonly enabled: boolean;
+  readonly serviceName: string;
+  readonly serviceVersion: string;
+  readonly environment: string;
+  readonly metricsEndpoint: string;
+  readonly exportIntervalMilliseconds: number;
+  readonly flushTimeoutMilliseconds: number;
+  readonly poolKey: string;
+}
+
+interface NormalizedDefinition {
+  readonly name: string;
+  readonly description: string;
+  readonly unit: string;
+}
+
+interface NormalizedHistogramDefinition extends NormalizedDefinition {
+  readonly boundaries: ReadonlyArray<number>;
+}
+
+interface NormalizedAttribute {
+  readonly key: string;
+  readonly value: MetricAttributeValue;
+}
+
+interface NormalizedAttributes {
+  readonly identity: string;
+  readonly values: ReadonlyArray<NormalizedAttribute>;
+}
+
+interface OtlpAnyValue {
+  readonly stringValue?: string;
+  readonly boolValue?: boolean;
+  readonly intValue?: number;
+  readonly doubleValue?: number;
+}
+
+interface OtlpKeyValue {
+  readonly key: string;
+  readonly value: OtlpAnyValue;
+}
+
+interface OtlpNumberDataPoint {
+  readonly attributes: ReadonlyArray<OtlpKeyValue>;
+  readonly startTimeUnixNano: string;
+  readonly timeUnixNano: string;
+  readonly asDouble?: number;
+  readonly asInt?: number;
+}
+
+interface OtlpHistogramDataPoint {
+  readonly attributes: ReadonlyArray<OtlpKeyValue>;
+  readonly startTimeUnixNano: string;
+  readonly timeUnixNano: string;
+  readonly count: number;
+  readonly sum: number;
+  readonly min: number;
+  readonly max: number;
+  readonly explicitBounds: ReadonlyArray<number>;
+  readonly bucketCounts: ReadonlyArray<number>;
+}
+
+interface OtlpSum {
+  readonly aggregationTemporality: 2;
+  readonly isMonotonic: boolean;
+  readonly dataPoints: Array<OtlpNumberDataPoint>;
+}
+
+interface OtlpGauge {
+  readonly dataPoints: Array<OtlpNumberDataPoint>;
+}
+
+interface OtlpHistogram {
+  readonly aggregationTemporality: 2;
+  readonly dataPoints: Array<OtlpHistogramDataPoint>;
+}
+
+interface OtlpMetric {
+  readonly name: string;
+  readonly description: string;
+  readonly unit: string;
+  readonly sum?: OtlpSum;
+  readonly gauge?: OtlpGauge;
+  readonly histogram?: OtlpHistogram;
+}
+
+interface MetricsPayload {
+  readonly resourceMetrics: ReadonlyArray<{
+    readonly resource: {
+      readonly attributes: ReadonlyArray<OtlpKeyValue>;
+      readonly droppedAttributesCount: number;
+    };
+    readonly scopeMetrics: ReadonlyArray<{
+      readonly scope: { readonly name: string };
+      readonly metrics: ReadonlyArray<OtlpMetric>;
+    }>;
+  }>;
+}
+
+interface CounterSeries {
+  readonly attributes: NormalizedAttributes;
+  value: number;
+}
+
+interface HistogramSeries {
+  readonly attributes: NormalizedAttributes;
+  count: number;
+  sum: number;
+  min: number;
+  max: number;
+  readonly bucketCounts: Array<number>;
+}
+
+interface GaugeCallbackState {
+  readonly id: number;
+  readonly leaseId: number;
+  readonly callback: ObservableGaugeCallback;
+}
+
+interface CounterEntry {
+  readonly kind: "counter";
+  readonly definition: NormalizedDefinition;
+  readonly leases: Set<number>;
+  readonly seriesByLease: Map<number, Map<string, CounterSeries>>;
+  readonly lifetimeSeries: Set<string>;
+}
+
+interface HistogramEntry {
+  readonly kind: "histogram";
+  readonly definition: NormalizedHistogramDefinition;
+  readonly leases: Set<number>;
+  readonly seriesByLease: Map<number, Map<string, HistogramSeries>>;
+  readonly lifetimeSeries: Set<string>;
+}
+
+interface GaugeEntry {
+  readonly kind: "gauge";
+  readonly definition: NormalizedDefinition;
+  readonly leases: Set<number>;
+  readonly callbacks: Map<number, GaugeCallbackState>;
+  readonly lifetimeSeries: Set<string>;
+}
+
+type CatalogEntry = CounterEntry | HistogramEntry | GaugeEntry;
+
+type MetricsTransport = (payload: MetricsPayload, signal: AbortSignal) => Promise<void>;
+
+interface RuntimeLease {
+  readonly leaseId: number;
+  readonly state: MetricsRuntimeState;
+}
+
+const metricError = (
+  code: MetricsError["code"],
+  operation: string,
+  message: string,
+  instrumentName: string | undefined,
+  retryable: boolean,
+  cause?: unknown,
+): MetricsError => {
+  const options = {
+    code,
+    operation,
+    message,
+    retryable,
+    cause,
+  };
+  if (instrumentName === undefined) {
+    return new MetricsError(options);
+  }
+  return new MetricsError({ ...options, instrumentName });
+};
+
+const parseOptions = (input: MetricsOptions): NormalizedOptions => {
+  let options: typeof MetricsOptionsInput.Type;
+  try {
+    options = decodeMetricsOptions(input);
+  } catch (cause) {
+    throw metricError(
+      "INVALID_CONFIGURATION",
+      "createMetrics",
+      "Metrics configuration is invalid. Provide valid service metadata and an HTTP OTLP endpoint.",
+      undefined,
+      false,
+      cause,
+    );
+  }
+  if (
+    options.serviceName.length === 0 ||
+    options.serviceVersion.length === 0 ||
+    options.environment.length === 0
+  ) {
+    throw metricError(
+      "INVALID_CONFIGURATION",
+      "createMetrics",
+      "Metrics configuration is invalid. Service name, version, and environment must be nonempty.",
+      undefined,
+      false,
+    );
+  }
+  let endpoint: URL;
+  try {
+    endpoint = new URL(options.otlpEndpoint);
+  } catch (cause) {
+    throw metricError(
+      "INVALID_CONFIGURATION",
+      "createMetrics",
+      "Metrics configuration is invalid. Set otlpEndpoint to an HTTP or HTTPS URL without credentials.",
+      undefined,
+      false,
+      cause,
+    );
+  }
+  if (
+    (endpoint.protocol !== "http:" && endpoint.protocol !== "https:") ||
+    endpoint.username.length > 0 ||
+    endpoint.password.length > 0
+  ) {
+    throw metricError(
+      "INVALID_CONFIGURATION",
+      "createMetrics",
+      "Metrics configuration is invalid. Set otlpEndpoint to an HTTP or HTTPS URL without credentials.",
+      undefined,
+      false,
+    );
+  }
+  const exportIntervalMilliseconds = options.exportIntervalMilliseconds ?? 10_000;
+  const flushTimeoutMilliseconds = options.flushTimeoutMilliseconds ?? 3_000;
+  if (
+    !Number.isSafeInteger(exportIntervalMilliseconds) ||
+    exportIntervalMilliseconds < 1 ||
+    !Number.isSafeInteger(flushTimeoutMilliseconds) ||
+    flushTimeoutMilliseconds < 1
+  ) {
+    throw metricError(
+      "INVALID_CONFIGURATION",
+      "createMetrics",
+      "Metrics configuration is invalid. Export and flush intervals must be positive safe integer milliseconds.",
+      undefined,
+      false,
+    );
+  }
+  endpoint.pathname = `${endpoint.pathname.replace(/\/$/, "")}/v1/metrics`;
+  endpoint.search = "";
+  endpoint.hash = "";
+  const enabled = options.enabled ?? true;
+  const poolKey = JSON.stringify([
+    endpoint.toString(),
+    options.serviceName,
+    options.serviceVersion,
+    options.environment,
+    exportIntervalMilliseconds,
+    flushTimeoutMilliseconds,
+  ]);
+  return {
+    enabled,
+    serviceName: options.serviceName,
+    serviceVersion: options.serviceVersion,
+    environment: options.environment,
+    metricsEndpoint: endpoint.toString(),
+    exportIntervalMilliseconds,
+    flushTimeoutMilliseconds,
+    poolKey,
+  };
+};
+
+const parseDefinition = (input: InstrumentDefinition, operation: string): NormalizedDefinition => {
+  let definition: typeof InstrumentDefinitionInput.Type;
+  try {
+    definition = decodeInstrumentDefinition(input);
+  } catch (cause) {
+    throw metricError(
+      "INVALID_INSTRUMENT",
+      operation,
+      "Metric instrument definition is invalid. Provide a valid name, description, and unit.",
+      undefined,
+      false,
+      cause,
+    );
+  }
+  if (
+    !instrumentNamePattern.test(definition.name) ||
+    definition.description.length < 1 ||
+    definition.description.length > 1_024 ||
+    containsControlCharacter(definition.description) ||
+    definition.unit.length > 63 ||
+    !unitPattern.test(definition.unit)
+  ) {
+    throw metricError(
+      "INVALID_INSTRUMENT",
+      operation,
+      `Metric instrument "${definition.name}" is invalid. Check its name, description, and unit.`,
+      definition.name,
+      false,
+    );
+  }
+  return definition;
+};
+
+const parseHistogramDefinition = (input: HistogramDefinition): NormalizedHistogramDefinition => {
+  let definition: typeof HistogramDefinitionInput.Type;
+  try {
+    definition = decodeHistogramDefinition(input);
+  } catch (cause) {
+    throw metricError(
+      "INVALID_INSTRUMENT",
+      "histogram",
+      "Histogram definition is invalid. Provide a valid definition and finite boundaries.",
+      undefined,
+      false,
+      cause,
+    );
+  }
+  const common = parseDefinition(definition, "histogram");
+  if (definition.boundaries.length < 1 || definition.boundaries.length > 50) {
+    throw metricError(
+      "INVALID_INSTRUMENT",
+      "histogram",
+      `Histogram "${definition.name}" must have between 1 and 50 boundaries.`,
+      definition.name,
+      false,
+    );
+  }
+  let previous = Number.NEGATIVE_INFINITY;
+  for (const boundary of definition.boundaries) {
+    if (!Number.isFinite(boundary) || boundary <= previous) {
+      throw metricError(
+        "INVALID_INSTRUMENT",
+        "histogram",
+        `Histogram "${definition.name}" boundaries must be finite and strictly increasing.`,
+        definition.name,
+        false,
+      );
+    }
+    previous = boundary;
+  }
+  return { ...common, boundaries: [...definition.boundaries] };
+};
+
+const attributeIdentity = (value: MetricAttributeValue): string => {
+  if (Predicate.isString(value)) {
+    return `s:${JSON.stringify(value)}`;
+  }
+  if (Predicate.isBoolean(value)) {
+    return value ? "b:1" : "b:0";
+  }
+  return `n:${Object.is(value, -0) ? 0 : value}`;
+};
+
+const parseAttributes = (
+  input: ReadonlyArray<MetricAttribute> | undefined,
+  operation: string,
+  instrumentName: string,
+): NormalizedAttributes => {
+  let attributes: ReadonlyArray<typeof MetricAttributeInput.Type>;
+  try {
+    attributes = decodeMetricAttributes(input ?? []);
+  } catch (cause) {
+    throw metricError(
+      "INVALID_MEASUREMENT",
+      operation,
+      `Metric "${instrumentName}" attributes are invalid. Use bounded scalar attributes.`,
+      instrumentName,
+      false,
+      cause,
+    );
+  }
+  if (attributes.length > maximumAttributes) {
+    throw metricError(
+      "LIMIT_EXCEEDED",
+      operation,
+      `Metric "${instrumentName}" exceeds the ${maximumAttributes}-attribute limit.`,
+      instrumentName,
+      false,
+    );
+  }
+  const keys = new Set<string>();
+  const normalized: Array<NormalizedAttribute> = [];
+  for (const attribute of attributes) {
+    const numberIsInvalid =
+      Predicate.isNumber(attribute.value) && !Number.isFinite(attribute.value);
+    const stringIsInvalid =
+      Predicate.isString(attribute.value) &&
+      (attribute.value.length > 256 || containsControlCharacter(attribute.value));
+    if (
+      attribute.key.length > 128 ||
+      !instrumentNamePattern.test(attribute.key) ||
+      attribute.key === "unit" ||
+      attribute.key === "time_unit" ||
+      keys.has(attribute.key) ||
+      numberIsInvalid ||
+      stringIsInvalid
+    ) {
+      throw metricError(
+        "INVALID_MEASUREMENT",
+        operation,
+        `Metric "${instrumentName}" attributes are invalid. Use unique bounded keys and finite scalar values.`,
+        instrumentName,
+        false,
+      );
+    }
+    keys.add(attribute.key);
+    normalized.push({
+      key: attribute.key,
+      value:
+        Predicate.isNumber(attribute.value) && Object.is(attribute.value, -0) ? 0 : attribute.value,
+    });
+  }
+  normalized.sort((left, right) => left.key.localeCompare(right.key));
+  return {
+    identity: normalized
+      .map((attribute) => `${attribute.key}=${attributeIdentity(attribute.value)}`)
+      .join("|"),
+    values: normalized,
+  };
+};
+
+const attributesToOtlp = (
+  attributes: ReadonlyArray<NormalizedAttribute>,
+): ReadonlyArray<OtlpKeyValue> =>
+  attributes.map((attribute) => {
+    if (Predicate.isString(attribute.value)) {
+      return { key: attribute.key, value: { stringValue: attribute.value } };
+    }
+    if (Predicate.isBoolean(attribute.value)) {
+      return { key: attribute.key, value: { boolValue: attribute.value } };
+    }
+    if (Number.isInteger(attribute.value)) {
+      return { key: attribute.key, value: { intValue: attribute.value } };
+    }
+    return { key: attribute.key, value: { doubleValue: attribute.value } };
+  });
+
+const directAttributesToOtlp = (
+  attributes: Metric.Metric.AttributeSet | undefined,
+): ReadonlyArray<OtlpKeyValue> => {
+  if (attributes === undefined) {
+    return [];
+  }
+  const values: Array<OtlpKeyValue> = [];
+  for (const [key, value] of Object.entries(attributes)) {
+    if (key !== "unit" && key !== "time_unit") {
+      values.push({ key, value: { stringValue: value } });
+    }
+  }
+  return values;
+};
+
+const sameDefinition = (
+  entry: CatalogEntry,
+  kind: CatalogEntry["kind"],
+  definition: NormalizedDefinition,
+  boundaries: ReadonlyArray<number> | undefined,
+): boolean => {
+  if (
+    entry.kind !== kind ||
+    entry.definition.name !== definition.name ||
+    entry.definition.description !== definition.description ||
+    entry.definition.unit !== definition.unit
+  ) {
+    return false;
+  }
+  if (entry.kind !== "histogram") {
+    return boundaries === undefined;
+  }
+  if (boundaries === undefined || entry.definition.boundaries.length !== boundaries.length) {
+    return false;
+  }
+  return entry.definition.boundaries.every((boundary, index) => boundary === boundaries[index]);
+};
+
+const histogramBucketIndex = (boundaries: ReadonlyArray<number>, value: number): number => {
+  for (let index = 0; index < boundaries.length; index++) {
+    const boundary = boundaries[index];
+    if (boundary !== undefined && value <= boundary) {
+      return index;
+    }
+  }
+  return boundaries.length;
+};
+
+const nanosNow = (): string => String(BigInt(Date.now()) * 1_000_000n);
+
+class MetricsRuntimeState {
+  readonly registry = new Map();
+  readonly directContext = Context.make(Metric.MetricRegistry, this.registry);
+  readonly catalog = new Map<string, CatalogEntry>();
+  readonly runtimeLifetimeSeries = new Set<string>();
+  readonly lifetimeSeriesByInstrument = new Map<string, Set<string>>();
+  private readonly leases = new Set<number>();
+  private readonly transport: MetricsTransport;
+  private readonly options: NormalizedOptions;
+  private readonly removeFromPool: () => void;
+  private readonly startTimeUnixNano = nanosNow();
+  private tail: Promise<void> = Promise.resolve();
+  private timer: ReturnType<typeof setInterval> | undefined;
+  private nextLeaseId = 1;
+  private nextCallbackId = 1;
+  private referenceCount = 0;
+  private periodicFailureActive = false;
+
+  constructor(options: NormalizedOptions, transport: MetricsTransport, removeFromPool: () => void) {
+    this.options = options;
+    this.transport = transport;
+    this.removeFromPool = removeFromPool;
+    this.timer = setInterval(() => {
+      this.scheduleExport(this.options.flushTimeoutMilliseconds).then(
+        (result) => this.recordPeriodicOutcome(result.gaugeFailures.length > 0),
+        () => this.recordPeriodicOutcome(true),
+      );
+    }, options.exportIntervalMilliseconds);
+    this.timer.unref?.();
+  }
+
+  acquire(): RuntimeLease {
+    const leaseId = this.nextLeaseId++;
+    this.leases.add(leaseId);
+    this.referenceCount++;
+    return { leaseId, state: this };
+  }
+
+  nextGaugeCallbackId(): number {
+    return this.nextCallbackId++;
+  }
+
+  flush(timeoutMilliseconds: number): Promise<FlushResult> {
+    return this.scheduleExport(timeoutMilliseconds);
+  }
+
+  async closeLease(leaseId: number, timeoutMilliseconds: number): Promise<FlushResult> {
+    let result: FlushResult;
+    let failure: MetricsError | undefined;
+    try {
+      result = await this.scheduleExport(timeoutMilliseconds);
+    } catch (cause) {
+      result = { gaugeFailures: [] };
+      failure =
+        cause instanceof MetricsError
+          ? cause
+          : metricError(
+              "EXPORT_FAILED",
+              "close",
+              "The final metrics export failed. The runtime lease was still released.",
+              undefined,
+              true,
+              cause,
+            );
+    }
+    this.removeLeaseState(leaseId);
+    this.leases.delete(leaseId);
+    this.referenceCount--;
+    if (this.referenceCount === 0) {
+      if (this.timer !== undefined) {
+        clearInterval(this.timer);
+        this.timer = undefined;
+      }
+      this.removeFromPool();
+    }
+    if (failure !== undefined) {
+      throw failure;
+    }
+    return result;
+  }
+
+  registerCounter(leaseId: number, definition: NormalizedDefinition): CounterEntry {
+    const existing = this.catalog.get(definition.name);
+    if (existing !== undefined) {
+      if (
+        existing.kind !== "counter" ||
+        !sameDefinition(existing, "counter", definition, undefined)
+      ) {
+        throw this.instrumentConflict("counter", definition.name);
+      }
+      existing.leases.add(leaseId);
+      return existing;
+    }
+    this.assertInstrumentCapacity(definition.name);
+    const entry: CounterEntry = {
+      kind: "counter",
+      definition,
+      leases: new Set([leaseId]),
+      seriesByLease: new Map(),
+      lifetimeSeries: this.lifetimeSeriesFor(definition.name),
+    };
+    this.catalog.set(definition.name, entry);
+    return entry;
+  }
+
+  registerHistogram(leaseId: number, definition: NormalizedHistogramDefinition): HistogramEntry {
+    const existing = this.catalog.get(definition.name);
+    if (existing !== undefined) {
+      if (
+        existing.kind !== "histogram" ||
+        !sameDefinition(existing, "histogram", definition, definition.boundaries)
+      ) {
+        throw this.instrumentConflict("histogram", definition.name);
+      }
+      existing.leases.add(leaseId);
+      return existing;
+    }
+    this.assertInstrumentCapacity(definition.name);
+    const entry: HistogramEntry = {
+      kind: "histogram",
+      definition,
+      leases: new Set([leaseId]),
+      seriesByLease: new Map(),
+      lifetimeSeries: this.lifetimeSeriesFor(definition.name),
+    };
+    this.catalog.set(definition.name, entry);
+    return entry;
+  }
+
+  registerGauge(
+    leaseId: number,
+    definition: NormalizedDefinition,
+    callback: ObservableGaugeCallback,
+  ): { readonly entry: GaugeEntry; readonly callbackId: number } {
+    const existing = this.catalog.get(definition.name);
+    let entry: GaugeEntry;
+    if (existing !== undefined) {
+      if (!sameDefinition(existing, "gauge", definition, undefined) || existing.kind !== "gauge") {
+        throw this.instrumentConflict("observableGauge", definition.name);
+      }
+      entry = existing;
+    } else {
+      this.assertInstrumentCapacity(definition.name);
+      entry = {
+        kind: "gauge",
+        definition,
+        leases: new Set(),
+        callbacks: new Map(),
+        lifetimeSeries: this.lifetimeSeriesFor(definition.name),
+      };
+      this.catalog.set(definition.name, entry);
+    }
+    if (entry.callbacks.size >= maximumCallbacks) {
+      if (entry.callbacks.size === 0) {
+        this.catalog.delete(definition.name);
+      }
+      throw metricError(
+        "LIMIT_EXCEEDED",
+        "observableGauge",
+        `Observable gauge "${definition.name}" exceeds the ${maximumCallbacks}-callback limit.`,
+        definition.name,
+        false,
+      );
+    }
+    const callbackId = this.nextGaugeCallbackId();
+    entry.leases.add(leaseId);
+    entry.callbacks.set(callbackId, { id: callbackId, leaseId, callback });
+    return { entry, callbackId };
+  }
+
+  unregisterGauge(name: string, callbackId: number): void {
+    const entry = this.catalog.get(name);
+    if (entry === undefined || entry.kind !== "gauge") {
+      return;
+    }
+    const registration = entry.callbacks.get(callbackId);
+    if (registration === undefined) {
+      return;
+    }
+    entry.callbacks.delete(callbackId);
+    const leaseStillRegistered = Array.from(entry.callbacks.values()).some(
+      (candidate) => candidate.leaseId === registration.leaseId,
+    );
+    if (!leaseStillRegistered) {
+      entry.leases.delete(registration.leaseId);
+    }
+    if (entry.callbacks.size === 0) {
+      this.catalog.delete(name);
+    }
+  }
+
+  addCounter(
+    leaseId: number,
+    entry: CounterEntry,
+    value: number,
+    attributes: NormalizedAttributes,
+  ): void {
+    this.assertLease(leaseId, "add", entry.definition.name);
+    if (!Number.isFinite(value) || value < 0) {
+      throw metricError(
+        "INVALID_MEASUREMENT",
+        "add",
+        `Counter "${entry.definition.name}" accepts only finite values greater than or equal to zero.`,
+        entry.definition.name,
+        false,
+      );
+    }
+    this.prepareSeries(entry, attributes, "add");
+    let leaseSeries = entry.seriesByLease.get(leaseId);
+    if (leaseSeries === undefined) {
+      leaseSeries = new Map();
+      entry.seriesByLease.set(leaseId, leaseSeries);
+    }
+    const current = leaseSeries.get(attributes.identity);
+    if (current === undefined) {
+      leaseSeries.set(attributes.identity, { attributes, value });
+      this.commitSeries(entry, attributes.identity);
+    } else {
+      current.value += value;
+    }
+  }
+
+  recordHistogram(
+    leaseId: number,
+    entry: HistogramEntry,
+    value: number,
+    attributes: NormalizedAttributes,
+  ): void {
+    this.assertLease(leaseId, "record", entry.definition.name);
+    if (!Number.isFinite(value)) {
+      throw metricError(
+        "INVALID_MEASUREMENT",
+        "record",
+        `Histogram "${entry.definition.name}" accepts only finite values.`,
+        entry.definition.name,
+        false,
+      );
+    }
+    this.prepareSeries(entry, attributes, "record");
+    let leaseSeries = entry.seriesByLease.get(leaseId);
+    if (leaseSeries === undefined) {
+      leaseSeries = new Map();
+      entry.seriesByLease.set(leaseId, leaseSeries);
+    }
+    const current = leaseSeries.get(attributes.identity);
+    if (current === undefined) {
+      const bucketCounts = Array.from({ length: entry.definition.boundaries.length + 1 }, () => 0);
+      const bucketIndex = histogramBucketIndex(entry.definition.boundaries, value);
+      bucketCounts[bucketIndex] = 1;
+      leaseSeries.set(attributes.identity, {
+        attributes,
+        count: 1,
+        sum: value,
+        min: value,
+        max: value,
+        bucketCounts,
+      });
+      this.commitSeries(entry, attributes.identity);
+    } else {
+      current.count++;
+      current.sum += value;
+      current.min = Math.min(current.min, value);
+      current.max = Math.max(current.max, value);
+      const bucketIndex = histogramBucketIndex(entry.definition.boundaries, value);
+      const count = current.bucketCounts[bucketIndex];
+      current.bucketCounts[bucketIndex] = (count ?? 0) + 1;
+    }
+  }
+
+  private lifetimeSeriesFor(name: string): Set<string> {
+    let series = this.lifetimeSeriesByInstrument.get(name);
+    if (series === undefined) {
+      series = new Set();
+      this.lifetimeSeriesByInstrument.set(name, series);
+    }
+    return series;
+  }
+
+  private recordPeriodicOutcome(failed: boolean): void {
+    if (failed === this.periodicFailureActive) {
+      return;
+    }
+    this.periodicFailureActive = failed;
+    process.emitWarning(
+      failed
+        ? "The periodic metrics export entered a failed state. A later successful export will clear it."
+        : "The periodic metrics export recovered from its failed state.",
+      {
+        code: failed
+          ? "OBS_METRICS_PERIODIC_EXPORT_FAILED"
+          : "OBS_METRICS_PERIODIC_EXPORT_RECOVERED",
+      },
+    );
+  }
+
+  private assertInstrumentCapacity(name: string): void {
+    if (this.catalog.size >= maximumInstruments) {
+      throw metricError(
+        "LIMIT_EXCEEDED",
+        "registerInstrument",
+        `Metric runtime exceeds the ${maximumInstruments}-instrument limit while registering "${name}".`,
+        name,
+        false,
+      );
+    }
+  }
+
+  private instrumentConflict(operation: string, name: string): MetricsError {
+    return metricError(
+      "INSTRUMENT_CONFLICT",
+      operation,
+      `Metric instrument "${name}" conflicts with an existing definition. Reuse the exact kind, unit, description, and boundaries.`,
+      name,
+      false,
+    );
+  }
+
+  private assertLease(leaseId: number, operation: string, name: string): void {
+    if (!this.leases.has(leaseId)) {
+      throw metricError(
+        "CLOSED",
+        operation,
+        `Metrics lifecycle is closed. Create a new lifecycle before using "${name}".`,
+        name,
+        false,
+      );
+    }
+  }
+
+  private prepareSeries(
+    entry: CounterEntry | HistogramEntry,
+    attributes: NormalizedAttributes,
+    operation: string,
+  ): string {
+    const runtimeIdentity = `${entry.definition.name}:${attributes.identity}`;
+    if (
+      !entry.lifetimeSeries.has(attributes.identity) &&
+      entry.lifetimeSeries.size >= maximumInstrumentSeries
+    ) {
+      throw metricError(
+        "LIMIT_EXCEEDED",
+        operation,
+        `Metric "${entry.definition.name}" exceeds the ${maximumInstrumentSeries}-series lifetime limit.`,
+        entry.definition.name,
+        false,
+      );
+    }
+    if (
+      !this.runtimeLifetimeSeries.has(runtimeIdentity) &&
+      this.runtimeLifetimeSeries.size >= maximumRuntimeSeries
+    ) {
+      throw metricError(
+        "LIMIT_EXCEEDED",
+        operation,
+        `Metric runtime exceeds the ${maximumRuntimeSeries}-series lifetime limit.`,
+        entry.definition.name,
+        false,
+      );
+    }
+    return runtimeIdentity;
+  }
+
+  private commitSeries(entry: CatalogEntry, identity: string): void {
+    entry.lifetimeSeries.add(identity);
+    this.runtimeLifetimeSeries.add(`${entry.definition.name}:${identity}`);
+  }
+
+  private scheduleExport(timeoutMilliseconds: number): Promise<FlushResult> {
+    const controller = new AbortController();
+    let timedOut = false;
+    const operation = this.tail.then(async () => {
+      if (controller.signal.aborted) {
+        throw metricError(
+          "FLUSH_TIMED_OUT",
+          "flush",
+          `Metrics flush exceeded ${timeoutMilliseconds} milliseconds. Retry the flush before closing.`,
+          undefined,
+          true,
+        );
+      }
+      const collection = this.collectPayload();
+      try {
+        await this.transport(collection.payload, controller.signal);
+      } catch (cause) {
+        if (timedOut || controller.signal.aborted) {
+          throw metricError(
+            "FLUSH_TIMED_OUT",
+            "flush",
+            `Metrics flush exceeded ${timeoutMilliseconds} milliseconds. Retry the flush before closing.`,
+            undefined,
+            true,
+            cause,
+          );
+        }
+        throw metricError(
+          "EXPORT_FAILED",
+          "flush",
+          "Metrics export failed. Verify the OTLP endpoint and retry the flush.",
+          undefined,
+          true,
+          cause,
+        );
+      }
+      return collection.result;
+    });
+    this.tail = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<FlushResult>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        timedOut = true;
+        controller.abort();
+        reject(
+          metricError(
+            "FLUSH_TIMED_OUT",
+            "flush",
+            `Metrics flush exceeded ${timeoutMilliseconds} milliseconds. Retry the flush before closing.`,
+            undefined,
+            true,
+          ),
+        );
+      }, timeoutMilliseconds);
+    });
+    return Promise.race([operation, timeout]).finally(() => {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
+    });
+  }
+
+  private collectPayload(): { readonly payload: MetricsPayload; readonly result: FlushResult } {
+    const timeUnixNano = nanosNow();
+    const metrics: Array<OtlpMetric> = [];
+    const names = new Map<string, { readonly kind: string; readonly definition: string }>();
+    for (const snapshot of Metric.snapshotUnsafe(this.directContext)) {
+      this.appendDirectMetric(metrics, names, snapshot, timeUnixNano);
+    }
+    const gaugeFailures: Array<GaugeCollectionFailure> = [];
+    for (const entry of this.catalog.values()) {
+      const existing = names.get(entry.definition.name);
+      const definitionIdentity = `${entry.kind}:${entry.definition.unit}:${entry.definition.description}`;
+      if (existing !== undefined && existing.definition !== definitionIdentity) {
+        throw metricError(
+          "EXPORT_FAILED",
+          "flush",
+          `Metric "${entry.definition.name}" conflicts with a direct Effect metric. Rename one instrument before retrying.`,
+          entry.definition.name,
+          false,
+        );
+      }
+      names.set(entry.definition.name, { kind: entry.kind, definition: definitionIdentity });
+      if (entry.kind === "counter") {
+        metrics.push(this.collectCounter(entry, timeUnixNano));
+      } else if (entry.kind === "histogram") {
+        metrics.push(this.collectHistogram(entry, timeUnixNano));
+      } else {
+        const gauge = this.collectGauge(entry, timeUnixNano);
+        gaugeFailures.push(...gauge.failures);
+        if (gauge.metric !== undefined) {
+          metrics.push(gauge.metric);
+        }
+      }
+    }
+    return {
+      payload: {
+        resourceMetrics: [
+          {
+            resource: {
+              attributes: [
+                { key: "service.name", value: { stringValue: this.options.serviceName } },
+                { key: "service.version", value: { stringValue: this.options.serviceVersion } },
+                {
+                  key: "deployment.environment.name",
+                  value: { stringValue: this.options.environment },
+                },
+              ],
+              droppedAttributesCount: 0,
+            },
+            scopeMetrics: [
+              {
+                scope: { name: this.options.serviceName },
+                metrics,
+              },
+            ],
+          },
+        ],
+      },
+      result: { gaugeFailures },
+    };
+  }
+
+  private appendDirectMetric(
+    metrics: Array<OtlpMetric>,
+    names: Map<string, { readonly kind: string; readonly definition: string }>,
+    snapshot: Metric.Metric.Snapshot,
+    timeUnixNano: string,
+  ): void {
+    const unit = snapshot.attributes?.unit ?? snapshot.attributes?.time_unit ?? "1";
+    const description = snapshot.description ?? "";
+    const definitionIdentity = `${snapshot.type}:${unit}:${description}`;
+    const existing = names.get(snapshot.id);
+    if (existing !== undefined && existing.definition !== definitionIdentity) {
+      throw metricError(
+        "EXPORT_FAILED",
+        "flush",
+        `Direct Effect metric "${snapshot.id}" has incompatible definitions. Rename or align the definitions before retrying.`,
+        snapshot.id,
+        false,
+      );
+    }
+    const attributes = directAttributesToOtlp(snapshot.attributes);
+    const previous = metrics.find((metric) => metric.name === snapshot.id);
+    names.set(snapshot.id, { kind: snapshot.type, definition: definitionIdentity });
+    if (snapshot.type === "Counter") {
+      const point = this.numberPoint(snapshot.state.count, attributes, timeUnixNano);
+      if (previous?.sum !== undefined) {
+        previous.sum.dataPoints.push(point);
+      } else {
+        metrics.push({
+          name: snapshot.id,
+          description,
+          unit,
+          sum: {
+            aggregationTemporality: 2,
+            isMonotonic: snapshot.state.incremental,
+            dataPoints: [point],
+          },
+        });
+      }
+    } else if (snapshot.type === "Gauge") {
+      const point = this.numberPoint(snapshot.state.value, attributes, timeUnixNano);
+      if (previous?.gauge !== undefined) {
+        previous.gauge.dataPoints.push(point);
+      } else {
+        metrics.push({ name: snapshot.id, description, unit, gauge: { dataPoints: [point] } });
+      }
+    } else if (snapshot.type === "Histogram") {
+      const buckets: Array<number> = [];
+      const bounds: Array<number> = [];
+      let previousCount = 0;
+      for (let index = 0; index < snapshot.state.buckets.length; index++) {
+        const bucket = snapshot.state.buckets[index];
+        if (bucket !== undefined) {
+          if (index < snapshot.state.buckets.length - 1) {
+            bounds.push(bucket[0]);
+          }
+          buckets.push(bucket[1] - previousCount);
+          previousCount = bucket[1];
+        }
+      }
+      const point: OtlpHistogramDataPoint = {
+        attributes,
+        startTimeUnixNano: this.startTimeUnixNano,
+        timeUnixNano,
+        count: snapshot.state.count,
+        sum: snapshot.state.sum,
+        min: snapshot.state.min,
+        max: snapshot.state.max,
+        explicitBounds: bounds,
+        bucketCounts: buckets,
+      };
+      if (previous?.histogram !== undefined) {
+        previous.histogram.dataPoints.push(point);
+      } else {
+        metrics.push({
+          name: snapshot.id,
+          description,
+          unit,
+          histogram: { aggregationTemporality: 2, dataPoints: [point] },
+        });
+      }
+    } else if (snapshot.type === "Frequency") {
+      const dataPoints: Array<OtlpNumberDataPoint> = [];
+      for (const [key, value] of snapshot.state.occurrences) {
+        dataPoints.push({
+          ...this.numberPoint(value, attributes, timeUnixNano),
+          attributes: [...attributes, { key: "key", value: { stringValue: key } }],
+        });
+      }
+      if (previous?.sum !== undefined) {
+        previous.sum.dataPoints.push(...dataPoints);
+      } else {
+        metrics.push({
+          name: snapshot.id,
+          description,
+          unit,
+          sum: { aggregationTemporality: 2, isMonotonic: true, dataPoints },
+        });
+      }
+    } else {
+      const derivedNames = [
+        `${snapshot.id}_quantiles`,
+        `${snapshot.id}_count`,
+        `${snapshot.id}_sum`,
+      ];
+      for (const derivedName of derivedNames) {
+        const derivedDefinition = `${definitionIdentity}:${derivedName}`;
+        const derivedExisting = names.get(derivedName);
+        if (derivedExisting !== undefined && derivedExisting.definition !== derivedDefinition) {
+          throw metricError(
+            "EXPORT_FAILED",
+            "flush",
+            `Direct Effect summary "${snapshot.id}" conflicts with metric "${derivedName}". Rename one instrument before retrying.`,
+            snapshot.id,
+            false,
+          );
+        }
+        names.set(derivedName, { kind: "Summary", definition: derivedDefinition });
+      }
+      const dataPoints: Array<OtlpNumberDataPoint> = [];
+      dataPoints.push({
+        ...this.numberPoint(snapshot.state.min, attributes, timeUnixNano),
+        attributes: [...attributes, { key: "quantile", value: { stringValue: "min" } }],
+      });
+      for (const [quantile, value] of snapshot.state.quantiles) {
+        dataPoints.push({
+          ...this.numberPoint(value ?? 0, attributes, timeUnixNano),
+          attributes: [
+            ...attributes,
+            { key: "quantile", value: { stringValue: quantile.toString() } },
+          ],
+        });
+      }
+      dataPoints.push({
+        ...this.numberPoint(snapshot.state.max, attributes, timeUnixNano),
+        attributes: [...attributes, { key: "quantile", value: { stringValue: "max" } }],
+      });
+      const countPoint = this.numberPoint(snapshot.state.count, attributes, timeUnixNano);
+      const sumPoint = this.numberPoint(snapshot.state.sum, attributes, timeUnixNano);
+      const existingQuantiles = metrics.find(
+        (metric) => metric.name === `${snapshot.id}_quantiles`,
+      );
+      const existingCount = metrics.find((metric) => metric.name === `${snapshot.id}_count`);
+      const existingSum = metrics.find((metric) => metric.name === `${snapshot.id}_sum`);
+      if (
+        existingQuantiles?.sum !== undefined &&
+        existingCount?.sum !== undefined &&
+        existingSum?.sum !== undefined
+      ) {
+        existingQuantiles.sum.dataPoints.push(...dataPoints);
+        existingCount.sum.dataPoints.push(countPoint);
+        existingSum.sum.dataPoints.push(sumPoint);
+      } else {
+        metrics.push(
+          {
+            name: `${snapshot.id}_quantiles`,
+            description,
+            unit,
+            sum: { aggregationTemporality: 2, isMonotonic: false, dataPoints },
+          },
+          {
+            name: `${snapshot.id}_count`,
+            description,
+            unit: "1",
+            sum: {
+              aggregationTemporality: 2,
+              isMonotonic: true,
+              dataPoints: [countPoint],
+            },
+          },
+          {
+            name: `${snapshot.id}_sum`,
+            description,
+            unit: "1",
+            sum: {
+              aggregationTemporality: 2,
+              isMonotonic: true,
+              dataPoints: [sumPoint],
+            },
+          },
+        );
+      }
+    }
+  }
+
+  private numberPoint(
+    value: number | bigint,
+    attributes: ReadonlyArray<OtlpKeyValue>,
+    timeUnixNano: string,
+  ): OtlpNumberDataPoint {
+    const common = {
+      attributes,
+      startTimeUnixNano: this.startTimeUnixNano,
+      timeUnixNano,
+    };
+    if (Predicate.isBigInt(value)) {
+      return { ...common, asInt: Number(value) };
+    }
+    return { ...common, asDouble: value };
+  }
+
+  private collectCounter(entry: CounterEntry, timeUnixNano: string): OtlpMetric {
+    const combined = new Map<string, CounterSeries>();
+    for (const leaseSeries of entry.seriesByLease.values()) {
+      for (const [identity, series] of leaseSeries) {
+        const current = combined.get(identity);
+        if (current === undefined) {
+          combined.set(identity, { attributes: series.attributes, value: series.value });
+        } else {
+          current.value += series.value;
+        }
+      }
+    }
+    return {
+      name: entry.definition.name,
+      description: entry.definition.description,
+      unit: entry.definition.unit,
+      sum: {
+        aggregationTemporality: 2,
+        isMonotonic: true,
+        dataPoints: Array.from(combined.values()).map((series) => ({
+          attributes: attributesToOtlp(series.attributes.values),
+          startTimeUnixNano: this.startTimeUnixNano,
+          timeUnixNano,
+          asDouble: series.value,
+        })),
+      },
+    };
+  }
+
+  private collectHistogram(entry: HistogramEntry, timeUnixNano: string): OtlpMetric {
+    const combined = new Map<string, HistogramSeries>();
+    for (const leaseSeries of entry.seriesByLease.values()) {
+      for (const [identity, series] of leaseSeries) {
+        const current = combined.get(identity);
+        if (current === undefined) {
+          combined.set(identity, {
+            attributes: series.attributes,
+            count: series.count,
+            sum: series.sum,
+            min: series.min,
+            max: series.max,
+            bucketCounts: [...series.bucketCounts],
+          });
+        } else {
+          current.count += series.count;
+          current.sum += series.sum;
+          current.min = Math.min(current.min, series.min);
+          current.max = Math.max(current.max, series.max);
+          for (let index = 0; index < current.bucketCounts.length; index++) {
+            current.bucketCounts[index] =
+              (current.bucketCounts[index] ?? 0) + (series.bucketCounts[index] ?? 0);
+          }
+        }
+      }
+    }
+    return {
+      name: entry.definition.name,
+      description: entry.definition.description,
+      unit: entry.definition.unit,
+      histogram: {
+        aggregationTemporality: 2,
+        dataPoints: Array.from(combined.values()).map((series) => ({
+          attributes: attributesToOtlp(series.attributes.values),
+          startTimeUnixNano: this.startTimeUnixNano,
+          timeUnixNano,
+          count: series.count,
+          sum: series.sum,
+          min: series.min,
+          max: series.max,
+          explicitBounds: entry.definition.boundaries,
+          bucketCounts: series.bucketCounts,
+        })),
+      },
+    };
+  }
+
+  private collectGauge(
+    entry: GaugeEntry,
+    timeUnixNano: string,
+  ): {
+    readonly metric: OtlpMetric | undefined;
+    readonly failures: ReadonlyArray<GaugeCollectionFailure>;
+  } {
+    const observations: Array<{
+      readonly value: number;
+      readonly attributes: NormalizedAttributes;
+    }> = [];
+    const failures: Array<GaugeCollectionFailure> = [];
+    const proposedIdentities = new Set<string>();
+    for (const registration of entry.callbacks.values()) {
+      let callbackResult: ReadonlyArray<GaugeObservation>;
+      try {
+        callbackResult = registration.callback();
+      } catch {
+        failures.push({
+          instrumentName: entry.definition.name,
+          code: "CALLBACK_FAILED",
+          message: `Observable gauge "${entry.definition.name}" callback failed and was omitted from this export.`,
+        });
+        continue;
+      }
+      let callbackObservations: ReadonlyArray<GaugeObservation>;
+      try {
+        callbackObservations = decodeGaugeObservations(callbackResult);
+      } catch {
+        failures.push({
+          instrumentName: entry.definition.name,
+          code: "INVALID_OBSERVATION",
+          message: `Observable gauge "${entry.definition.name}" returned an invalid synchronous observation batch.`,
+        });
+        continue;
+      }
+      if (callbackObservations.length > maximumObservations) {
+        failures.push({
+          instrumentName: entry.definition.name,
+          code: "SERIES_LIMIT_EXCEEDED",
+          message: `Observable gauge "${entry.definition.name}" exceeds the ${maximumObservations}-observation collection limit.`,
+        });
+        continue;
+      }
+      const callbackBatch: Array<{
+        readonly value: number;
+        readonly attributes: NormalizedAttributes;
+      }> = [];
+      const callbackIdentities = new Set<string>();
+      let callbackFailed = false;
+      for (const observation of callbackObservations) {
+        if (!Number.isFinite(observation.value)) {
+          failures.push({
+            instrumentName: entry.definition.name,
+            code: "INVALID_OBSERVATION",
+            message: `Observable gauge "${entry.definition.name}" produced a non-finite observation.`,
+          });
+          callbackFailed = true;
+          break;
+        }
+        try {
+          const attributes = parseAttributes(
+            observation.attributes,
+            "collectObservableGauge",
+            entry.definition.name,
+          );
+          if (
+            proposedIdentities.has(attributes.identity) ||
+            callbackIdentities.has(attributes.identity)
+          ) {
+            failures.push({
+              instrumentName: entry.definition.name,
+              code: "INVALID_OBSERVATION",
+              message: `Observable gauge "${entry.definition.name}" produced duplicate attribute sets.`,
+            });
+            callbackFailed = true;
+            break;
+          }
+          callbackIdentities.add(attributes.identity);
+          callbackBatch.push({ value: observation.value, attributes });
+        } catch (cause) {
+          const code =
+            cause instanceof MetricsError && cause.code === "LIMIT_EXCEEDED"
+              ? "ATTRIBUTE_LIMIT_EXCEEDED"
+              : "INVALID_OBSERVATION";
+          failures.push({
+            instrumentName: entry.definition.name,
+            code,
+            message: `Observable gauge "${entry.definition.name}" produced invalid bounded attributes.`,
+          });
+          callbackFailed = true;
+          break;
+        }
+      }
+      if (!callbackFailed) {
+        for (const observation of callbackBatch) {
+          proposedIdentities.add(observation.attributes.identity);
+          observations.push(observation);
+        }
+      }
+    }
+    if (failures.length > 0) {
+      return { metric: undefined, failures };
+    }
+    const newIdentities = Array.from(proposedIdentities).filter(
+      (identity) => !entry.lifetimeSeries.has(identity),
+    );
+    const newRuntimeIdentities = newIdentities.filter(
+      (identity) => !this.runtimeLifetimeSeries.has(`${entry.definition.name}:${identity}`),
+    );
+    if (
+      entry.lifetimeSeries.size + newIdentities.length > maximumInstrumentSeries ||
+      this.runtimeLifetimeSeries.size + newRuntimeIdentities.length > maximumRuntimeSeries
+    ) {
+      return {
+        metric: undefined,
+        failures: [
+          {
+            instrumentName: entry.definition.name,
+            code: "SERIES_LIMIT_EXCEEDED",
+            message: `Observable gauge "${entry.definition.name}" exceeds a lifetime series limit.`,
+          },
+        ],
+      };
+    }
+    for (const identity of newIdentities) {
+      this.commitSeries(entry, identity);
+    }
+    return {
+      metric: {
+        name: entry.definition.name,
+        description: entry.definition.description,
+        unit: entry.definition.unit,
+        gauge: {
+          dataPoints: observations.map((observation) => ({
+            attributes: attributesToOtlp(observation.attributes.values),
+            startTimeUnixNano: this.startTimeUnixNano,
+            timeUnixNano,
+            asDouble: observation.value,
+          })),
+        },
+      },
+      failures: [],
+    };
+  }
+
+  private removeLeaseState(leaseId: number): void {
+    for (const [name, entry] of this.catalog) {
+      entry.leases.delete(leaseId);
+      if (entry.kind === "counter" || entry.kind === "histogram") {
+        entry.seriesByLease.delete(leaseId);
+      } else {
+        for (const [callbackId, registration] of entry.callbacks) {
+          if (registration.leaseId === leaseId) {
+            entry.callbacks.delete(callbackId);
+          }
+        }
+      }
+      if (entry.leases.size === 0) {
+        this.catalog.delete(name);
+      }
+    }
+  }
+}
+
+const runtimePool = new Map<string, MetricsRuntimeState>();
+
+const fetchTransport =
+  (endpoint: string): MetricsTransport =>
+  async (payload, signal) => {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+      signal,
+    });
+    if (!response.ok) {
+      throw metricError(
+        "EXPORT_FAILED",
+        "export",
+        `OTLP metrics endpoint returned HTTP ${response.status}. Verify the endpoint and retry.`,
+        undefined,
+        true,
+      );
+    }
+  };
+
+const acquireRuntime = (options: NormalizedOptions, transport: MetricsTransport): RuntimeLease => {
+  let state = runtimePool.get(options.poolKey);
+  if (state === undefined) {
+    state = new MetricsRuntimeState(options, transport, () => {
+      if (runtimePool.get(options.poolKey) === state) {
+        runtimePool.delete(options.poolKey);
+      }
+    });
+    runtimePool.set(options.poolKey, state);
+  }
+  return state.acquire();
+};
+
+class ActiveMetrics implements Metrics {
+  private readonly lease: RuntimeLease;
+  private readonly timeoutMilliseconds: number;
+  private closed = false;
+  private closePromise: Promise<FlushResult> | undefined;
+
+  constructor(lease: RuntimeLease, timeoutMilliseconds: number) {
+    this.lease = lease;
+    this.timeoutMilliseconds = timeoutMilliseconds;
+  }
+
+  counter(definitionInput: CounterDefinition): Counter {
+    this.assertOpen("counter");
+    const definition = parseDefinition(definitionInput, "counter");
+    const entry = this.lease.state.registerCounter(this.lease.leaseId, definition);
+    return {
+      add: (value, attributes) => {
+        this.assertOpen("add", definition.name);
+        const parsedAttributes = parseAttributes(attributes, "add", definition.name);
+        this.lease.state.addCounter(this.lease.leaseId, entry, value, parsedAttributes);
+      },
+    };
+  }
+
+  histogram(definitionInput: HistogramDefinition): Histogram {
+    this.assertOpen("histogram");
+    const definition = parseHistogramDefinition(definitionInput);
+    const entry = this.lease.state.registerHistogram(this.lease.leaseId, definition);
+    return {
+      record: (value, attributes) => {
+        this.assertOpen("record", definition.name);
+        const parsedAttributes = parseAttributes(attributes, "record", definition.name);
+        this.lease.state.recordHistogram(this.lease.leaseId, entry, value, parsedAttributes);
+      },
+    };
+  }
+
+  observableGauge(
+    definitionInput: InstrumentDefinition,
+    callback: ObservableGaugeCallback,
+  ): ObservableGaugeRegistration {
+    this.assertOpen("observableGauge");
+    const definition = parseDefinition(definitionInput, "observableGauge");
+    if (!Predicate.isFunction(callback)) {
+      throw metricError(
+        "INVALID_INSTRUMENT",
+        "observableGauge",
+        `Observable gauge "${definition.name}" requires a synchronous callback.`,
+        definition.name,
+        false,
+      );
+    }
+    const registered = this.lease.state.registerGauge(this.lease.leaseId, definition, callback);
+    let unregistered = false;
+    const unregister = (): void => {
+      if (unregistered) {
+        return;
+      }
+      unregistered = true;
+      this.lease.state.unregisterGauge(definition.name, registered.callbackId);
+    };
+    return { unregister, [Symbol.dispose]: unregister };
+  }
+
+  flush(): Promise<FlushResult> {
+    this.assertOpen("flush");
+    return this.lease.state.flush(this.timeoutMilliseconds);
+  }
+
+  close(): Promise<FlushResult> {
+    if (this.closePromise !== undefined) {
+      return this.closePromise;
+    }
+    this.closed = true;
+    this.closePromise = this.lease.state.closeLease(this.lease.leaseId, this.timeoutMilliseconds);
+    return this.closePromise;
+  }
+
+  private assertOpen(operation: string, instrumentName?: string): void {
+    if (this.closed) {
+      throw metricError(
+        "CLOSED",
+        operation,
+        "Metrics lifecycle is closed. Create a new lifecycle before recording or flushing metrics.",
+        instrumentName,
+        false,
+      );
+    }
+  }
+}
+
+class DisabledMetrics implements Metrics {
+  private closed = false;
+  private closePromise: Promise<FlushResult> | undefined;
+
+  counter(definitionInput: CounterDefinition): Counter {
+    this.assertOpen("counter");
+    const definition = parseDefinition(definitionInput, "counter");
+    return {
+      add: (value, attributes) => {
+        this.assertOpen("add", definition.name);
+        if (!Number.isFinite(value) || value < 0) {
+          throw metricError(
+            "INVALID_MEASUREMENT",
+            "add",
+            `Counter "${definition.name}" accepts only finite values greater than or equal to zero.`,
+            definition.name,
+            false,
+          );
+        }
+        parseAttributes(attributes, "add", definition.name);
+      },
+    };
+  }
+
+  histogram(definitionInput: HistogramDefinition): Histogram {
+    this.assertOpen("histogram");
+    const definition = parseHistogramDefinition(definitionInput);
+    return {
+      record: (value, attributes) => {
+        this.assertOpen("record", definition.name);
+        if (!Number.isFinite(value)) {
+          throw metricError(
+            "INVALID_MEASUREMENT",
+            "record",
+            `Histogram "${definition.name}" accepts only finite values.`,
+            definition.name,
+            false,
+          );
+        }
+        parseAttributes(attributes, "record", definition.name);
+      },
+    };
+  }
+
+  observableGauge(
+    definitionInput: InstrumentDefinition,
+    callback: ObservableGaugeCallback,
+  ): ObservableGaugeRegistration {
+    this.assertOpen("observableGauge");
+    const definition = parseDefinition(definitionInput, "observableGauge");
+    if (!Predicate.isFunction(callback)) {
+      throw metricError(
+        "INVALID_INSTRUMENT",
+        "observableGauge",
+        `Observable gauge "${definition.name}" requires a synchronous callback.`,
+        definition.name,
+        false,
+      );
+    }
+    const unregister = (): void => undefined;
+    return { unregister, [Symbol.dispose]: unregister };
+  }
+
+  flush(): Promise<FlushResult> {
+    this.assertOpen("flush");
+    return Promise.resolve({ gaugeFailures: [] });
+  }
+
+  close(): Promise<FlushResult> {
+    if (this.closePromise !== undefined) {
+      return this.closePromise;
+    }
+    this.closed = true;
+    this.closePromise = Promise.resolve({ gaugeFailures: [] });
+    return this.closePromise;
+  }
+
+  private assertOpen(operation: string, instrumentName?: string): void {
+    if (this.closed) {
+      throw metricError(
+        "CLOSED",
+        operation,
+        "Metrics lifecycle is closed. Create a new lifecycle before recording or flushing metrics.",
+        instrumentName,
+        false,
+      );
+    }
+  }
+}
+
+export const createStandaloneMetrics = async (optionsInput: MetricsOptions): Promise<Metrics> => {
+  const options = parseOptions(optionsInput);
+  if (!options.enabled) {
+    return new DisabledMetrics();
+  }
+  const lease = acquireRuntime(options, fetchTransport(options.metricsEndpoint));
+  return new ActiveMetrics(lease, options.flushTimeoutMilliseconds);
+};
+
+interface LayerMetricsOptions {
+  readonly shutdownTimeoutMilliseconds: number;
+}
+
+const makeEffectTransport = (endpoint: string, client: HttpClient.HttpClient): MetricsTransport => {
+  const request = HttpClientRequest.post(endpoint, {
+    headers: { "content-type": "application/json" },
+  });
+  return async (payload, signal) => {
+    const program = client
+      .execute(HttpClientRequest.setBody(request, HttpBody.jsonUnsafe(payload)))
+      .pipe(
+        Effect.flatMap((response) =>
+          response.status >= 200 && response.status < 300
+            ? Effect.void
+            : Effect.fail(
+                metricError(
+                  "EXPORT_FAILED",
+                  "export",
+                  `OTLP metrics endpoint returned HTTP ${response.status}. Verify the endpoint and retry.`,
+                  undefined,
+                  true,
+                ),
+              ),
+        ),
+        Effect.scoped,
+      );
+    await Effect.runPromise(program, { signal });
+  };
+};
+
+const makeMetricsRuntime = Effect.fn("makeMetricsRuntime")(function* (
+  config: TelemetryConfig,
+  options: LayerMetricsOptions,
+) {
+  const client = yield* HttpClient.HttpClient;
+  const flusher = yield* OtlpExporter.Flusher;
+  const parsed = parseOptions({
+    serviceName: config.serviceName,
+    serviceVersion: config.serviceVersion,
+    environment: config.environment,
+    otlpEndpoint: config.otlpEndpoint.toString(),
+    flushTimeoutMilliseconds: options.shutdownTimeoutMilliseconds,
+  });
+  const lease = acquireRuntime(parsed, makeEffectTransport(parsed.metricsEndpoint, client));
+  yield* flusher.register(
+    Effect.tryPromise(() => lease.state.flush(parsed.flushTimeoutMilliseconds)).pipe(
+      Effect.catch(() => Effect.void),
+      Effect.asVoid,
+    ),
+  );
+  yield* Effect.addFinalizer(() =>
+    Effect.tryPromise(() =>
+      lease.state.closeLease(lease.leaseId, parsed.flushTimeoutMilliseconds),
+    ).pipe(
+      Effect.catch(() => Effect.void),
+      Effect.asVoid,
+    ),
+  );
+  return lease.state.registry;
+});
+
+export const layerMetricsRuntime = (config: TelemetryConfig, options: LayerMetricsOptions) =>
+  Layer.effect(Metric.MetricRegistry, makeMetricsRuntime(config, options)).pipe(
+    Layer.provideMerge(OtlpExporter.layerFlusher),
+  );

--- a/packages/telemetry/src/MetricsRuntime.ts
+++ b/packages/telemetry/src/MetricsRuntime.ts
@@ -200,6 +200,7 @@ interface CounterEntry {
   readonly kind: "counter";
   readonly definition: NormalizedDefinition;
   readonly leases: Set<number>;
+  readonly residualSeries: Map<string, CounterSeries>;
   readonly seriesByLease: Map<number, Map<string, CounterSeries>>;
   readonly lifetimeSeries: Set<string>;
 }
@@ -208,6 +209,7 @@ interface HistogramEntry {
   readonly kind: "histogram";
   readonly definition: NormalizedHistogramDefinition;
   readonly leases: Set<number>;
+  readonly residualSeries: Map<string, HistogramSeries>;
   readonly seriesByLease: Map<number, Map<string, HistogramSeries>>;
   readonly lifetimeSeries: Set<string>;
 }
@@ -223,6 +225,13 @@ interface GaugeEntry {
 type CatalogEntry = CounterEntry | HistogramEntry | GaugeEntry;
 
 type MetricsTransport = (payload: MetricsPayload, signal: AbortSignal) => Promise<void>;
+
+type MetricsTransportKind = "fetch" | "layer";
+
+interface MetricsTransportBinding {
+  readonly kind: MetricsTransportKind;
+  readonly send: MetricsTransport;
+}
 
 interface RuntimeLease {
   readonly leaseId: number;
@@ -566,8 +575,9 @@ class MetricsRuntimeState {
   readonly catalog = new Map<string, CatalogEntry>();
   readonly runtimeLifetimeSeries = new Set<string>();
   readonly lifetimeSeriesByInstrument = new Map<string, Set<string>>();
+  readonly lifetimeInstrumentNames = new Set<string>();
   private readonly leases = new Set<number>();
-  private readonly transport: MetricsTransport;
+  private readonly transports = new Map<number, MetricsTransportBinding>();
   private readonly options: NormalizedOptions;
   private readonly removeFromPool: () => void;
   private readonly startTimeUnixNano = nanosNow();
@@ -578,9 +588,8 @@ class MetricsRuntimeState {
   private referenceCount = 0;
   private periodicFailureActive = false;
 
-  constructor(options: NormalizedOptions, transport: MetricsTransport, removeFromPool: () => void) {
+  constructor(options: NormalizedOptions, removeFromPool: () => void) {
     this.options = options;
-    this.transport = transport;
     this.removeFromPool = removeFromPool;
     this.timer = setInterval(() => {
       this.scheduleExport(this.options.flushTimeoutMilliseconds).then(
@@ -591,9 +600,10 @@ class MetricsRuntimeState {
     this.timer.unref?.();
   }
 
-  acquire(): RuntimeLease {
+  acquire(transport: MetricsTransportBinding): RuntimeLease {
     const leaseId = this.nextLeaseId++;
     this.leases.add(leaseId);
+    this.transports.set(leaseId, transport);
     this.referenceCount++;
     return { leaseId, state: this };
   }
@@ -627,6 +637,7 @@ class MetricsRuntimeState {
     }
     this.removeLeaseState(leaseId);
     this.leases.delete(leaseId);
+    this.transports.delete(leaseId);
     this.referenceCount--;
     if (this.referenceCount === 0) {
       if (this.timer !== undefined) {
@@ -658,6 +669,7 @@ class MetricsRuntimeState {
       kind: "counter",
       definition,
       leases: new Set([leaseId]),
+      residualSeries: new Map(),
       seriesByLease: new Map(),
       lifetimeSeries: this.lifetimeSeriesFor(definition.name),
     };
@@ -682,6 +694,7 @@ class MetricsRuntimeState {
       kind: "histogram",
       definition,
       leases: new Set([leaseId]),
+      residualSeries: new Map(),
       seriesByLease: new Map(),
       lifetimeSeries: this.lifetimeSeriesFor(definition.name),
     };
@@ -713,9 +726,6 @@ class MetricsRuntimeState {
       this.catalog.set(definition.name, entry);
     }
     if (entry.callbacks.size >= maximumCallbacks) {
-      if (entry.callbacks.size === 0) {
-        this.catalog.delete(definition.name);
-      }
       throw metricError(
         "LIMIT_EXCEEDED",
         "observableGauge",
@@ -843,28 +853,27 @@ class MetricsRuntimeState {
       return;
     }
     this.periodicFailureActive = failed;
-    process.emitWarning(
+    console.warn(
       failed
-        ? "The periodic metrics export entered a failed state. A later successful export will clear it."
-        : "The periodic metrics export recovered from its failed state.",
-      {
-        code: failed
-          ? "OBS_METRICS_PERIODIC_EXPORT_FAILED"
-          : "OBS_METRICS_PERIODIC_EXPORT_RECOVERED",
-      },
+        ? "OBS_METRICS_PERIODIC_EXPORT_FAILED: The periodic metrics export entered a failed state."
+        : "OBS_METRICS_PERIODIC_EXPORT_RECOVERED: The periodic metrics export recovered.",
     );
   }
 
   private assertInstrumentCapacity(name: string): void {
-    if (this.catalog.size >= maximumInstruments) {
+    if (this.lifetimeInstrumentNames.has(name)) {
+      return;
+    }
+    if (this.lifetimeInstrumentNames.size >= maximumInstruments) {
       throw metricError(
         "LIMIT_EXCEEDED",
         "registerInstrument",
-        `Metric runtime exceeds the ${maximumInstruments}-instrument limit while registering "${name}".`,
+        `Metric runtime exceeds the ${maximumInstruments}-instrument lifetime limit while registering "${name}".`,
         name,
         false,
       );
     }
+    this.lifetimeInstrumentNames.add(name);
   }
 
   private instrumentConflict(operation: string, name: string): MetricsError {
@@ -927,6 +936,25 @@ class MetricsRuntimeState {
     this.runtimeLifetimeSeries.add(`${entry.definition.name}:${identity}`);
   }
 
+  private transportForExport(): MetricsTransport {
+    let selected: MetricsTransportBinding | undefined;
+    for (const transport of this.transports.values()) {
+      if (selected === undefined || transport.kind === "layer") {
+        selected = transport;
+      }
+    }
+    if (selected === undefined) {
+      throw metricError(
+        "EXPORT_FAILED",
+        "flush",
+        "Metrics export has no active transport. Acquire a runtime lease before flushing.",
+        undefined,
+        false,
+      );
+    }
+    return selected.send;
+  }
+
   private scheduleExport(timeoutMilliseconds: number): Promise<FlushResult> {
     const controller = new AbortController();
     let timedOut = false;
@@ -941,8 +969,9 @@ class MetricsRuntimeState {
         );
       }
       const collection = this.collectPayload();
+      const transport = this.transportForExport();
       try {
-        await this.transport(collection.payload, controller.signal);
+        await transport(collection.payload, controller.signal);
       } catch (cause) {
         if (timedOut || controller.signal.aborted) {
           throw metricError(
@@ -1255,6 +1284,9 @@ class MetricsRuntimeState {
 
   private collectCounter(entry: CounterEntry, timeUnixNano: string): OtlpMetric {
     const combined = new Map<string, CounterSeries>();
+    for (const [identity, series] of entry.residualSeries) {
+      combined.set(identity, { attributes: series.attributes, value: series.value });
+    }
     for (const leaseSeries of entry.seriesByLease.values()) {
       for (const [identity, series] of leaseSeries) {
         const current = combined.get(identity);
@@ -1284,6 +1316,16 @@ class MetricsRuntimeState {
 
   private collectHistogram(entry: HistogramEntry, timeUnixNano: string): OtlpMetric {
     const combined = new Map<string, HistogramSeries>();
+    for (const [identity, series] of entry.residualSeries) {
+      combined.set(identity, {
+        attributes: series.attributes,
+        count: series.count,
+        sum: series.sum,
+        min: series.min,
+        max: series.max,
+        bucketCounts: [...series.bucketCounts],
+      });
+    }
     for (const leaseSeries of entry.seriesByLease.values()) {
       for (const [identity, series] of leaseSeries) {
         const current = combined.get(identity);
@@ -1475,20 +1517,77 @@ class MetricsRuntimeState {
     };
   }
 
+  private foldCounterLease(entry: CounterEntry, leaseId: number): void {
+    const leaseSeries = entry.seriesByLease.get(leaseId);
+    if (leaseSeries === undefined) {
+      return;
+    }
+    for (const [identity, series] of leaseSeries) {
+      const residual = entry.residualSeries.get(identity);
+      if (residual === undefined) {
+        entry.residualSeries.set(identity, {
+          attributes: series.attributes,
+          value: series.value,
+        });
+      } else {
+        residual.value += series.value;
+      }
+    }
+    entry.seriesByLease.delete(leaseId);
+  }
+
+  private foldHistogramLease(entry: HistogramEntry, leaseId: number): void {
+    const leaseSeries = entry.seriesByLease.get(leaseId);
+    if (leaseSeries === undefined) {
+      return;
+    }
+    for (const [identity, series] of leaseSeries) {
+      const residual = entry.residualSeries.get(identity);
+      if (residual === undefined) {
+        entry.residualSeries.set(identity, {
+          attributes: series.attributes,
+          count: series.count,
+          sum: series.sum,
+          min: series.min,
+          max: series.max,
+          bucketCounts: [...series.bucketCounts],
+        });
+      } else {
+        residual.count += series.count;
+        residual.sum += series.sum;
+        residual.min = Math.min(residual.min, series.min);
+        residual.max = Math.max(residual.max, series.max);
+        for (let index = 0; index < residual.bucketCounts.length; index++) {
+          residual.bucketCounts[index] =
+            (residual.bucketCounts[index] ?? 0) + (series.bucketCounts[index] ?? 0);
+        }
+      }
+    }
+    entry.seriesByLease.delete(leaseId);
+  }
+
   private removeLeaseState(leaseId: number): void {
     for (const [name, entry] of this.catalog) {
       entry.leases.delete(leaseId);
-      if (entry.kind === "counter" || entry.kind === "histogram") {
-        entry.seriesByLease.delete(leaseId);
+      if (entry.kind === "counter") {
+        this.foldCounterLease(entry, leaseId);
+        if (entry.leases.size === 0 && entry.residualSeries.size === 0) {
+          this.catalog.delete(name);
+        }
+      } else if (entry.kind === "histogram") {
+        this.foldHistogramLease(entry, leaseId);
+        if (entry.leases.size === 0 && entry.residualSeries.size === 0) {
+          this.catalog.delete(name);
+        }
       } else {
         for (const [callbackId, registration] of entry.callbacks) {
           if (registration.leaseId === leaseId) {
             entry.callbacks.delete(callbackId);
           }
         }
-      }
-      if (entry.leases.size === 0) {
-        this.catalog.delete(name);
+        if (entry.leases.size === 0) {
+          this.catalog.delete(name);
+        }
       }
     }
   }
@@ -1516,17 +1615,20 @@ const fetchTransport =
     }
   };
 
-const acquireRuntime = (options: NormalizedOptions, transport: MetricsTransport): RuntimeLease => {
+const acquireRuntime = (
+  options: NormalizedOptions,
+  transport: MetricsTransportBinding,
+): RuntimeLease => {
   let state = runtimePool.get(options.poolKey);
   if (state === undefined) {
-    state = new MetricsRuntimeState(options, transport, () => {
+    state = new MetricsRuntimeState(options, () => {
       if (runtimePool.get(options.poolKey) === state) {
         runtimePool.delete(options.poolKey);
       }
     });
     runtimePool.set(options.poolKey, state);
   }
-  return state.acquire();
+  return state.acquire(transport);
 };
 
 class ActiveMetrics implements Metrics {
@@ -1715,7 +1817,10 @@ export const createStandaloneMetrics = async (optionsInput: MetricsOptions): Pro
   if (!options.enabled) {
     return new DisabledMetrics();
   }
-  const lease = acquireRuntime(options, fetchTransport(options.metricsEndpoint));
+  const lease = acquireRuntime(options, {
+    kind: "fetch",
+    send: fetchTransport(options.metricsEndpoint),
+  });
   return new ActiveMetrics(lease, options.flushTimeoutMilliseconds);
 };
 
@@ -1763,7 +1868,10 @@ const makeMetricsRuntime = Effect.fn("makeMetricsRuntime")(function* (
     otlpEndpoint: config.otlpEndpoint.toString(),
     flushTimeoutMilliseconds: options.shutdownTimeoutMilliseconds,
   });
-  const lease = acquireRuntime(parsed, makeEffectTransport(parsed.metricsEndpoint, client));
+  const lease = acquireRuntime(parsed, {
+    kind: "layer",
+    send: makeEffectTransport(parsed.metricsEndpoint, client),
+  });
   yield* flusher.register(
     Effect.tryPromise(() => lease.state.flush(parsed.flushTimeoutMilliseconds)).pipe(
       Effect.catch(() => Effect.void),

--- a/packages/telemetry/src/Telemetry.ts
+++ b/packages/telemetry/src/Telemetry.ts
@@ -1,13 +1,9 @@
 import { Duration, Effect, Layer } from "effect";
 import { FetchHttpClient, type HttpClient, HttpClientRequest } from "effect/unstable/http";
-import {
-  OtlpExporter,
-  OtlpLogger,
-  OtlpMetrics,
-  OtlpSerialization,
-} from "effect/unstable/observability";
+import { OtlpExporter, OtlpLogger, OtlpSerialization } from "effect/unstable/observability";
 import type { EnvironmentVariables, InvalidTelemetryEnvironment } from "./TelemetryConfig.ts";
 import { telemetryConfigFromEnv, type TelemetryConfig } from "./TelemetryConfig.ts";
+import { layerMetricsRuntime } from "./MetricsRuntime.ts";
 import { layerHttpServerOtlpTracer } from "./nestjs/HttpServerOtlpTracer.ts";
 
 export type OtlpLayerOptions = {
@@ -27,17 +23,16 @@ export const layerOtlp = (
       "deployment.environment.name": config.environment,
     },
   };
+  const metrics = layerMetricsRuntime(config, {
+    shutdownTimeoutMilliseconds: Duration.toMillis(options.shutdownTimeout ?? "3 seconds"),
+  });
   return Layer.mergeAll(
     OtlpLogger.layer({
       url: url("/v1/logs"),
       resource,
       shutdownTimeout: options.shutdownTimeout,
     }),
-    OtlpMetrics.layer({
-      url: url("/v1/metrics"),
-      resource,
-      shutdownTimeout: options.shutdownTimeout,
-    }),
+    metrics,
     layerHttpServerOtlpTracer({
       url: url("/v1/traces"),
       resource,

--- a/packages/telemetry/src/testing/index.ts
+++ b/packages/telemetry/src/testing/index.ts
@@ -36,11 +36,41 @@ export type CapturedMetricPoint = {
   readonly attributes: CapturedAttributes;
 };
 
-export type CapturedMetric = {
+export type CapturedHistogramPoint = {
+  readonly attributes: CapturedAttributes;
+  readonly count: number;
+  readonly sum: number;
+  readonly min: number;
+  readonly max: number;
+  readonly explicitBounds: ReadonlyArray<number>;
+  readonly bucketCounts: ReadonlyArray<number>;
+};
+
+type CapturedMetricCommon = {
   readonly name: string;
+  readonly description: string;
+  readonly unit: string;
   readonly points: ReadonlyArray<CapturedMetricPoint>;
   readonly resourceAttributes: CapturedAttributes;
 };
+
+export type CapturedMetric =
+  | (CapturedMetricCommon & {
+      readonly kind: "sum";
+      readonly isMonotonic: boolean;
+      readonly aggregationTemporality: number;
+    })
+  | (CapturedMetricCommon & { readonly kind: "gauge" })
+  | (CapturedMetricCommon & {
+      readonly kind: "histogram";
+      readonly aggregationTemporality: number;
+      readonly histogramPoints: ReadonlyArray<CapturedHistogramPoint>;
+    })
+  | (CapturedMetricCommon & {
+      readonly kind: "exponentialHistogram";
+      readonly aggregationTemporality: number;
+    })
+  | (CapturedMetricCommon & { readonly kind: "summary" });
 
 export type CapturedTelemetry = {
   readonly spans: ReadonlyArray<CapturedSpan>;
@@ -124,12 +154,37 @@ const MetricDataPoint = Schema.Struct({
   asInt: Schema.Union([Schema.String, Schema.Number]).pipe(Schema.optionalKey),
 });
 
-const DataPoints = Schema.Struct({ dataPoints: Schema.Array(MetricDataPoint) });
+const NumberDataPoints = Schema.Struct({ dataPoints: Schema.Array(MetricDataPoint) });
+
+const HistogramDataPoint = Schema.Struct({
+  attributes: Attributes,
+  count: Schema.Number,
+  sum: Schema.Number,
+  min: Schema.Number,
+  max: Schema.Number,
+  explicitBounds: Schema.Array(Schema.Number),
+  bucketCounts: Schema.Array(Schema.Number),
+});
 
 const ExportedMetric = Schema.Struct({
   name: Schema.String,
-  sum: DataPoints.pipe(Schema.optionalKey),
-  gauge: DataPoints.pipe(Schema.optionalKey),
+  description: Schema.String.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  unit: Schema.String.pipe(Schema.withDecodingDefault(Effect.succeed("1"))),
+  sum: Schema.Struct({
+    dataPoints: Schema.Array(MetricDataPoint),
+    isMonotonic: Schema.Boolean,
+    aggregationTemporality: Schema.Number,
+  }).pipe(Schema.optionalKey),
+  gauge: NumberDataPoints.pipe(Schema.optionalKey),
+  histogram: Schema.Struct({
+    dataPoints: Schema.Array(HistogramDataPoint),
+    aggregationTemporality: Schema.Number,
+  }).pipe(Schema.optionalKey),
+  exponentialHistogram: Schema.Struct({
+    dataPoints: Schema.Array(MetricDataPoint),
+    aggregationTemporality: Schema.Number,
+  }).pipe(Schema.optionalKey),
+  summary: NumberDataPoints.pipe(Schema.optionalKey),
 });
 
 const MetricExport = Schema.Struct({
@@ -163,6 +218,16 @@ const toAttributes = (attributes: ReadonlyArray<ExportedAttribute>): CapturedAtt
   }
   return converted;
 };
+
+type ExportedMetricDataPoint = typeof MetricDataPoint.Type;
+
+const toCapturedMetricPoints = (
+  dataPoints: ReadonlyArray<ExportedMetricDataPoint>,
+): ReadonlyArray<CapturedMetricPoint> =>
+  dataPoints.map((dataPoint) => ({
+    value: Option.fromNullishOr(dataPoint.asDouble ?? dataPoint.asInt).pipe(Option.map(Number)),
+    attributes: toAttributes(dataPoint.attributes),
+  }));
 
 export const attribute = (
   attributes: CapturedAttributes,
@@ -245,17 +310,59 @@ const decodeCapturedTelemetry = Effect.fn("decodeCapturedTelemetry")(function* (
         const resourceAttributes = toAttributes(resourceMetrics.resource.attributes);
         for (const scopeMetrics of resourceMetrics.scopeMetrics) {
           for (const metric of scopeMetrics.metrics) {
-            const dataPoints = metric.sum?.dataPoints ?? metric.gauge?.dataPoints ?? [];
-            metrics.push({
+            const common = {
               name: metric.name,
-              points: dataPoints.map((dataPoint) => ({
-                value: Option.fromNullishOr(dataPoint.asDouble ?? dataPoint.asInt).pipe(
-                  Option.map(Number),
-                ),
-                attributes: toAttributes(dataPoint.attributes),
-              })),
+              description: metric.description,
+              unit: metric.unit,
               resourceAttributes,
-            });
+            };
+            if (metric.sum !== undefined) {
+              metrics.push({
+                ...common,
+                kind: "sum",
+                points: toCapturedMetricPoints(metric.sum.dataPoints),
+                isMonotonic: metric.sum.isMonotonic,
+                aggregationTemporality: metric.sum.aggregationTemporality,
+              });
+            } else if (metric.gauge !== undefined) {
+              metrics.push({
+                ...common,
+                kind: "gauge",
+                points: toCapturedMetricPoints(metric.gauge.dataPoints),
+              });
+            } else if (metric.histogram !== undefined) {
+              metrics.push({
+                ...common,
+                kind: "histogram",
+                points: metric.histogram.dataPoints.map((dataPoint) => ({
+                  value: Option.none(),
+                  attributes: toAttributes(dataPoint.attributes),
+                })),
+                aggregationTemporality: metric.histogram.aggregationTemporality,
+                histogramPoints: metric.histogram.dataPoints.map((dataPoint) => ({
+                  attributes: toAttributes(dataPoint.attributes),
+                  count: dataPoint.count,
+                  sum: dataPoint.sum,
+                  min: dataPoint.min,
+                  max: dataPoint.max,
+                  explicitBounds: dataPoint.explicitBounds,
+                  bucketCounts: dataPoint.bucketCounts,
+                })),
+              });
+            } else if (metric.exponentialHistogram !== undefined) {
+              metrics.push({
+                ...common,
+                kind: "exponentialHistogram",
+                points: toCapturedMetricPoints(metric.exponentialHistogram.dataPoints),
+                aggregationTemporality: metric.exponentialHistogram.aggregationTemporality,
+              });
+            } else if (metric.summary !== undefined) {
+              metrics.push({
+                ...common,
+                kind: "summary",
+                points: toCapturedMetricPoints(metric.summary.dataPoints),
+              });
+            }
           }
         }
       }

--- a/packages/telemetry/test/metrics.test.ts
+++ b/packages/telemetry/test/metrics.test.ts
@@ -1,0 +1,508 @@
+import { assert, describe, it } from "vite-plus/test";
+import { Predicate, Schema } from "effect";
+import { createServer, type Server } from "node:http";
+import { createMetrics, MetricsError, type MetricAttribute } from "../src/Metrics.ts";
+
+const AttributeValue = Schema.Struct({
+  stringValue: Schema.String.pipe(Schema.optionalKey),
+  boolValue: Schema.Boolean.pipe(Schema.optionalKey),
+  intValue: Schema.Number.pipe(Schema.optionalKey),
+  doubleValue: Schema.Number.pipe(Schema.optionalKey),
+});
+const Attribute = Schema.Struct({ key: Schema.String, value: AttributeValue });
+const NumberPoint = Schema.Struct({
+  attributes: Schema.Array(Attribute),
+  asDouble: Schema.Number.pipe(Schema.optionalKey),
+  asInt: Schema.Number.pipe(Schema.optionalKey),
+});
+const HistogramPoint = Schema.Struct({
+  attributes: Schema.Array(Attribute),
+  count: Schema.Number,
+  sum: Schema.Number,
+  min: Schema.Number,
+  max: Schema.Number,
+  explicitBounds: Schema.Array(Schema.Number),
+  bucketCounts: Schema.Array(Schema.Number),
+});
+const ExportedMetric = Schema.Struct({
+  name: Schema.String,
+  description: Schema.String,
+  unit: Schema.String,
+  sum: Schema.Struct({
+    aggregationTemporality: Schema.Number,
+    isMonotonic: Schema.Boolean,
+    dataPoints: Schema.Array(NumberPoint),
+  }).pipe(Schema.optionalKey),
+  gauge: Schema.Struct({ dataPoints: Schema.Array(NumberPoint) }).pipe(Schema.optionalKey),
+  histogram: Schema.Struct({
+    aggregationTemporality: Schema.Number,
+    dataPoints: Schema.Array(HistogramPoint),
+  }).pipe(Schema.optionalKey),
+});
+const MetricsPayload = Schema.Struct({
+  resourceMetrics: Schema.Array(
+    Schema.Struct({
+      resource: Schema.Struct({ attributes: Schema.Array(Attribute) }),
+      scopeMetrics: Schema.Array(
+        Schema.Struct({
+          scope: Schema.Struct({ name: Schema.String }),
+          metrics: Schema.Array(ExportedMetric),
+        }),
+      ),
+    }),
+  ),
+});
+const decodeMetricsPayload = Schema.decodeUnknownSync(MetricsPayload);
+type CapturedPayload = typeof MetricsPayload.Type;
+
+interface StubControl {
+  status: number;
+  delayMilliseconds: number;
+}
+
+interface StubCollector {
+  readonly endpoint: string;
+  readonly requests: Array<CapturedPayload>;
+  readonly control: StubControl;
+  readonly server: Server;
+}
+
+const startCollector = (): Promise<StubCollector> =>
+  new Promise((resolve, reject) => {
+    const requests: Array<CapturedPayload> = [];
+    const control: StubControl = { status: 200, delayMilliseconds: 0 };
+    const server = createServer((request, response) => {
+      const chunks: Array<Uint8Array> = [];
+      request.on("data", (chunk: Buffer) => chunks.push(chunk));
+      request.on("error", reject);
+      request.on("end", () => {
+        try {
+          requests.push(decodeMetricsPayload(JSON.parse(Buffer.concat(chunks).toString("utf8"))));
+          setTimeout(() => {
+            response.writeHead(control.status, { "content-type": "application/json" });
+            response.end("{}");
+          }, control.delayMilliseconds);
+        } catch (cause) {
+          reject(cause);
+        }
+      });
+    });
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (address === null || Predicate.isString(address)) {
+        reject(new Error("Collector did not bind to a TCP address."));
+        return;
+      }
+      resolve({
+        endpoint: `http://127.0.0.1:${address.port}`,
+        requests,
+        control,
+        server,
+      });
+    });
+  });
+
+const closeServer = (server: Server): Promise<void> =>
+  new Promise((resolve, reject) => {
+    server.close((cause) => {
+      if (cause === undefined) {
+        resolve();
+      } else {
+        reject(cause);
+      }
+    });
+  });
+
+const metricsFrom = (payload: CapturedPayload): ReadonlyArray<typeof ExportedMetric.Type> =>
+  payload.resourceMetrics[0]?.scopeMetrics[0]?.metrics ?? [];
+
+const metricNamed = (
+  payload: CapturedPayload,
+  name: string,
+): typeof ExportedMetric.Type | undefined =>
+  metricsFrom(payload).find((metric) => metric.name === name);
+
+const errorCode = (operation: () => void): string | undefined => {
+  try {
+    operation();
+    return undefined;
+  } catch (cause) {
+    return cause instanceof MetricsError ? cause.code : undefined;
+  }
+};
+
+const asyncErrorCode = async (operation: () => Promise<void>): Promise<string | undefined> => {
+  try {
+    await operation();
+    return undefined;
+  } catch (cause) {
+    return cause instanceof MetricsError ? cause.code : undefined;
+  }
+};
+
+const options = (endpoint: string, flushTimeoutMilliseconds = 1_000) => ({
+  serviceName: "metrics-test",
+  serviceVersion: "1.2.3",
+  environment: "test",
+  otlpEndpoint: endpoint,
+  exportIntervalMilliseconds: 60_000,
+  flushTimeoutMilliseconds,
+});
+
+describe("framework-neutral metrics", () => {
+  it("exports counter, histogram, and immediately collected gauge values through real OTLP", async () => {
+    const collector = await startCollector();
+    try {
+      const metrics = await createMetrics(options(collector.endpoint));
+      const counter = metrics.counter({
+        name: "orders.created",
+        description: "Created orders",
+        unit: "1",
+      });
+      const histogram = metrics.histogram({
+        name: "orders.duration",
+        description: "Order duration",
+        unit: "ms",
+        boundaries: [10, 20],
+      });
+      let gaugeValue = 3;
+      const gauge = metrics.observableGauge(
+        {
+          name: "workers.load",
+          description: "Worker load",
+          unit: "%",
+        },
+        () => [
+          { value: gaugeValue, attributes: [{ key: "worker", value: "alpha" }] },
+          { value: gaugeValue + 1, attributes: [{ key: "worker", value: "beta" }] },
+        ],
+      );
+      counter.add(2, [{ key: "region", value: "south" }]);
+      histogram.record(12, [{ key: "region", value: "south" }]);
+
+      assert.deepEqual(await metrics.flush(), { gaugeFailures: [] });
+      gaugeValue = 8;
+      assert.deepEqual(await metrics.flush(), { gaugeFailures: [] });
+
+      const first = collector.requests[0];
+      const second = collector.requests[1];
+      assert.isDefined(first);
+      assert.isDefined(second);
+      const counterExport = metricNamed(first, "orders.created");
+      const histogramExport = metricNamed(first, "orders.duration");
+      const gaugeExport = metricNamed(first, "workers.load");
+      assert.equal(counterExport?.sum?.isMonotonic, true);
+      assert.equal(counterExport?.sum?.dataPoints[0]?.asDouble, 2);
+      assert.equal(histogramExport?.unit, "ms");
+      assert.deepEqual(histogramExport?.histogram?.dataPoints[0]?.explicitBounds, [10, 20]);
+      assert.deepEqual(histogramExport?.histogram?.dataPoints[0]?.bucketCounts, [0, 1, 0]);
+      assert.equal(histogramExport?.histogram?.dataPoints[0]?.count, 1);
+      assert.equal(histogramExport?.histogram?.dataPoints[0]?.sum, 12);
+      assert.equal(gaugeExport?.unit, "%");
+      assert.deepEqual(
+        gaugeExport?.gauge?.dataPoints.map((point) => point.asDouble),
+        [3, 4],
+      );
+      assert.deepEqual(
+        metricNamed(second, "workers.load")?.gauge?.dataPoints.map((point) => point.asDouble),
+        [8, 9],
+      );
+      for (const metric of metricsFrom(first)) {
+        for (const point of [
+          ...(metric.sum?.dataPoints ?? []),
+          ...(metric.gauge?.dataPoints ?? []),
+          ...(metric.histogram?.dataPoints ?? []),
+        ]) {
+          assert.notInclude(
+            point.attributes.map((attribute) => attribute.key),
+            "unit",
+          );
+          assert.notInclude(
+            point.attributes.map((attribute) => attribute.key),
+            "time_unit",
+          );
+        }
+      }
+
+      gauge.unregister();
+      await metrics.flush();
+      const afterUnregister = collector.requests[2];
+      assert.isDefined(afterUnregister);
+      assert.isUndefined(metricNamed(afterUnregister, "workers.load"));
+      await metrics.close();
+    } finally {
+      await closeServer(collector.server);
+    }
+  });
+
+  it("isolates gauge callback failures and performs final close collection exactly once", async () => {
+    const collector = await startCollector();
+    try {
+      const metrics = await createMetrics(options(collector.endpoint));
+      let goodValue = 1;
+      let goodCalls = 0;
+      let failedCalls = 0;
+      metrics.counter({ name: "alive.total", description: "Alive", unit: "1" }).add(1);
+      metrics.observableGauge({ name: "good.gauge", description: "Good gauge", unit: "1" }, () => {
+        goodCalls++;
+        return [{ value: goodValue }];
+      });
+      metrics.observableGauge(
+        { name: "failed.gauge", description: "Failed gauge", unit: "1" },
+        () => {
+          failedCalls++;
+          throw new Error("callback defect");
+        },
+      );
+
+      const first = await metrics.flush();
+      assert.deepEqual(
+        first.gaugeFailures.map((failure) => failure.code),
+        ["CALLBACK_FAILED"],
+      );
+      const firstPayload = collector.requests[0];
+      assert.isDefined(firstPayload);
+      assert.isDefined(metricNamed(firstPayload, "alive.total"));
+      assert.isDefined(metricNamed(firstPayload, "good.gauge"));
+      assert.isUndefined(metricNamed(firstPayload, "failed.gauge"));
+
+      goodValue = 7;
+      const closePromise = metrics.close();
+      assert.strictEqual(metrics.close(), closePromise);
+      const final = await closePromise;
+      assert.deepEqual(
+        final.gaugeFailures.map((failure) => failure.code),
+        ["CALLBACK_FAILED"],
+      );
+      const finalPayload = collector.requests[1];
+      assert.isDefined(finalPayload);
+      assert.equal(metricNamed(finalPayload, "good.gauge")?.gauge?.dataPoints[0]?.asDouble, 7);
+      const settledCalls = [goodCalls, failedCalls];
+      const settledRequests = collector.requests.length;
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      assert.deepEqual([goodCalls, failedCalls], settledCalls);
+      assert.equal(collector.requests.length, settledRequests);
+      assert.equal(
+        errorCode(() => metrics.flush()),
+        "CLOSED",
+      );
+    } finally {
+      await closeServer(collector.server);
+    }
+  });
+
+  it("rejects incompatible definitions and invalid measurements before mutation", async () => {
+    const collector = await startCollector();
+    try {
+      const metrics = await createMetrics(options(collector.endpoint));
+      const counter = metrics.counter({
+        name: "bounded.counter",
+        description: "Bounded counter",
+        unit: "1",
+      });
+      assert.equal(
+        errorCode(() =>
+          metrics.histogram({
+            name: "bounded.counter",
+            description: "Bounded counter",
+            unit: "1",
+            boundaries: [1],
+          }),
+        ),
+        "INSTRUMENT_CONFLICT",
+      );
+      assert.equal(
+        errorCode(() => counter.add(-1)),
+        "INVALID_MEASUREMENT",
+      );
+      assert.equal(
+        errorCode(() => counter.add(Number.NaN)),
+        "INVALID_MEASUREMENT",
+      );
+      assert.equal(
+        errorCode(() =>
+          counter.add(
+            1,
+            Array.from({ length: 17 }, (_, index): MetricAttribute => ({
+              key: `attribute.${index}`,
+              value: index,
+            })),
+          ),
+        ),
+        "LIMIT_EXCEEDED",
+      );
+      assert.equal(
+        errorCode(() =>
+          metrics.counter({ name: "invalid name", description: "Invalid", unit: "1" }),
+        ),
+        "INVALID_INSTRUMENT",
+      );
+      assert.equal(collector.requests.length, 0);
+      await metrics.close();
+      const closePayload = collector.requests[0];
+      assert.isDefined(closePayload);
+      assert.deepEqual(
+        metricsFrom(closePayload).map((metric) => metric.name),
+        ["bounded.counter"],
+      );
+      assert.equal(metricNamed(closePayload, "bounded.counter")?.sum?.dataPoints.length, 0);
+    } finally {
+      await closeServer(collector.server);
+    }
+  });
+
+  it("shares compatible instruments and enforces lifetime series limits", async () => {
+    const collector = await startCollector();
+    try {
+      const metrics = await createMetrics(options(collector.endpoint));
+      const keeper = await createMetrics(options(collector.endpoint));
+      const first = metrics.counter({
+        name: "cardinality.total",
+        description: "Cardinality total",
+        unit: "1",
+      });
+      const second = metrics.counter({
+        name: "cardinality.total",
+        description: "Cardinality total",
+        unit: "1",
+      });
+      first.add(1, [{ key: "series", value: 0 }]);
+      second.add(2, [{ key: "series", value: 0 }]);
+      for (let index = 1; index < 1_000; index++) {
+        first.add(1, [{ key: "series", value: index }]);
+      }
+      assert.equal(
+        errorCode(() => first.add(1, [{ key: "series", value: 1_000 }])),
+        "LIMIT_EXCEEDED",
+      );
+      await metrics.flush();
+      const payload = collector.requests[0];
+      assert.isDefined(payload);
+      const exported = metricNamed(payload, "cardinality.total");
+      assert.equal(exported?.sum?.dataPoints.length, 1_000);
+      assert.equal(exported?.sum?.dataPoints[0]?.asDouble, 3);
+      await metrics.close();
+      const afterClose = keeper.counter({
+        name: "cardinality.total",
+        description: "Cardinality total",
+        unit: "1",
+      });
+      afterClose.add(1, [{ key: "series", value: 999 }]);
+      assert.equal(
+        errorCode(() => afterClose.add(1, [{ key: "series", value: 1_000 }])),
+        "LIMIT_EXCEEDED",
+      );
+      await keeper.close();
+    } finally {
+      await closeServer(collector.server);
+    }
+  });
+
+  it("reports invalid gauge batches without suppressing other instruments", async () => {
+    const collector = await startCollector();
+    try {
+      const metrics = await createMetrics(options(collector.endpoint));
+      metrics.counter({ name: "valid.total", description: "Valid total", unit: "1" }).add(1);
+      metrics.observableGauge(
+        { name: "bounded.gauge", description: "Bounded gauge", unit: "1" },
+        () => [
+          {
+            value: 1,
+            attributes: Array.from({ length: 17 }, (_, index): MetricAttribute => ({
+              key: `attribute.${index}`,
+              value: index,
+            })),
+          },
+        ],
+      );
+      const result = await metrics.flush();
+      assert.deepEqual(
+        result.gaugeFailures.map((failure) => failure.code),
+        ["ATTRIBUTE_LIMIT_EXCEEDED"],
+      );
+      const payload = collector.requests[0];
+      assert.isDefined(payload);
+      assert.isDefined(metricNamed(payload, "valid.total"));
+      assert.isUndefined(metricNamed(payload, "bounded.gauge"));
+      await metrics.close();
+    } finally {
+      await closeServer(collector.server);
+    }
+  });
+
+  it("surfaces transport failure and timeout through typed errors", async () => {
+    const collector = await startCollector();
+    try {
+      const failed = await createMetrics(options(collector.endpoint));
+      failed.counter({ name: "failed.total", description: "Failed", unit: "1" }).add(1);
+      collector.control.status = 503;
+      assert.equal(
+        await asyncErrorCode(async () => {
+          await failed.flush();
+        }),
+        "EXPORT_FAILED",
+      );
+      collector.control.status = 200;
+      await failed.close();
+
+      const timed = await createMetrics(options(collector.endpoint, 20));
+      timed.counter({ name: "timed.total", description: "Timed", unit: "1" }).add(1);
+      collector.control.delayMilliseconds = 200;
+      assert.equal(
+        await asyncErrorCode(async () => {
+          await timed.flush();
+        }),
+        "FLUSH_TIMED_OUT",
+      );
+      assert.equal(
+        await asyncErrorCode(async () => {
+          await timed.close();
+        }),
+        "FLUSH_TIMED_OUT",
+      );
+      collector.control.delayMilliseconds = 0;
+    } finally {
+      await closeServer(collector.server);
+    }
+  });
+
+  it("keeps disabled mode inert while retaining validation", async () => {
+    const collector = await startCollector();
+    try {
+      let callbackCalls = 0;
+      const metrics = await createMetrics({ ...options(collector.endpoint), enabled: false });
+      const counter = metrics.counter({
+        name: "disabled.counter",
+        description: "Disabled counter",
+        unit: "1",
+      });
+      const histogram = metrics.histogram({
+        name: "disabled.histogram",
+        description: "Disabled histogram",
+        unit: "ms",
+        boundaries: [1, 2],
+      });
+      const gauge = metrics.observableGauge(
+        { name: "disabled.gauge", description: "Disabled gauge", unit: "1" },
+        () => {
+          callbackCalls++;
+          return [{ value: 1 }];
+        },
+      );
+      counter.add(1, [{ key: "safe", value: true }]);
+      histogram.record(1.5);
+      gauge.unregister();
+      assert.deepEqual(await metrics.flush(), { gaugeFailures: [] });
+      assert.deepEqual(await metrics.close(), { gaugeFailures: [] });
+      assert.equal(callbackCalls, 0);
+      assert.equal(collector.requests.length, 0);
+      assert.equal(
+        errorCode(() => counter.add(1)),
+        "CLOSED",
+      );
+    } finally {
+      await closeServer(collector.server);
+    }
+  });
+});

--- a/packages/telemetry/test/metrics.test.ts
+++ b/packages/telemetry/test/metrics.test.ts
@@ -262,7 +262,15 @@ describe("framework-neutral metrics", () => {
       const metrics = await createMetrics(options(collector.endpoint));
       let observationCount = 101;
       let callbackCalls = 0;
+      let validCalls = 0;
       metrics.counter({ name: "series.total", description: "Total", unit: "1" }).add(1);
+      metrics.observableGauge(
+        { name: "series.valid", description: "Valid series", unit: "1" },
+        () => {
+          validCalls++;
+          return [{ value: 9 }];
+        },
+      );
       metrics.observableGauge(
         { name: "series.overflow", description: "Series overflow", unit: "1" },
         () => {
@@ -288,6 +296,7 @@ describe("framework-neutral metrics", () => {
       const failedPayload = collector.requests[0];
       assert.isDefined(failedPayload);
       assert.isDefined(metricNamed(failedPayload, "series.total"));
+      assert.equal(metricNamed(failedPayload, "series.valid")?.gauge?.dataPoints[0]?.asDouble, 9);
       assert.isUndefined(metricNamed(failedPayload, "series.overflow"));
 
       observationCount = 1;
@@ -298,7 +307,12 @@ describe("framework-neutral metrics", () => {
       const recoveredGauge = metricNamed(recoveredPayload, "series.overflow");
       assert.equal(recoveredGauge?.gauge?.dataPoints.length, 1);
       assert.equal(recoveredGauge?.gauge?.dataPoints[0]?.asDouble, 0);
+      assert.equal(
+        metricNamed(recoveredPayload, "series.valid")?.gauge?.dataPoints[0]?.asDouble,
+        9,
+      );
       assert.equal(callbackCalls, 2);
+      assert.equal(validCalls, 2);
       await metrics.close();
     } finally {
       await closeServer(collector.server);

--- a/packages/telemetry/test/metrics.test.ts
+++ b/packages/telemetry/test/metrics.test.ts
@@ -227,7 +227,10 @@ describe("framework-neutral metrics", () => {
       assert.equal(failed.gaugeFailures.length, 1);
       assert.equal(failure.instrumentName, "observation.invalid");
       assert.equal(failure.code, "INVALID_OBSERVATION");
-      assert.include(failure.message, 'Observable gauge "observation.invalid"');
+      assert.equal(
+        failure.message,
+        'Observable gauge "observation.invalid" produced a non-finite observation.',
+      );
       assert.isFalse(Object.hasOwn(failure, "retryable"));
       const failedPayload = collector.requests[0];
       assert.isDefined(failedPayload);

--- a/packages/telemetry/test/metrics.test.ts
+++ b/packages/telemetry/test/metrics.test.ts
@@ -1,7 +1,9 @@
 import { assert, describe, it } from "vite-plus/test";
-import { Predicate, Schema } from "effect";
+import { Effect, ManagedRuntime, Metric, Option, Predicate, Schema } from "effect";
 import { createServer, type Server } from "node:http";
 import { createMetrics, MetricsError, type MetricAttribute } from "../src/Metrics.ts";
+import * as Testing from "../src/testing/index.ts";
+import { TelemetryConfig } from "../src/TelemetryConfig.ts";
 
 const AttributeValue = Schema.Struct({
   stringValue: Schema.String.pipe(Schema.optionalKey),
@@ -12,11 +14,15 @@ const AttributeValue = Schema.Struct({
 const Attribute = Schema.Struct({ key: Schema.String, value: AttributeValue });
 const NumberPoint = Schema.Struct({
   attributes: Schema.Array(Attribute),
+  startTimeUnixNano: Schema.String,
+  timeUnixNano: Schema.String,
   asDouble: Schema.Number.pipe(Schema.optionalKey),
   asInt: Schema.Number.pipe(Schema.optionalKey),
 });
 const HistogramPoint = Schema.Struct({
   attributes: Schema.Array(Attribute),
+  startTimeUnixNano: Schema.String,
+  timeUnixNano: Schema.String,
   count: Schema.Number,
   sum: Schema.Number,
   min: Schema.Number,
@@ -149,6 +155,16 @@ const options = (endpoint: string, flushTimeoutMilliseconds = 1_000) => ({
   exportIntervalMilliseconds: 60_000,
   flushTimeoutMilliseconds,
 });
+
+const waitFor = async (condition: () => boolean, timeoutMilliseconds = 2_000): Promise<void> => {
+  const deadline = Date.now() + timeoutMilliseconds;
+  while (!condition()) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Condition did not become true within ${timeoutMilliseconds} milliseconds.`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+};
 
 describe("framework-neutral metrics", () => {
   it("exports counter, histogram, and immediately collected gauge values through real OTLP", async () => {
@@ -399,6 +415,38 @@ describe("framework-neutral metrics", () => {
     }
   });
 
+  it("enforces the instrument-name limit for the complete runtime lifetime", async () => {
+    const collector = await startCollector();
+    try {
+      const metrics = await createMetrics(options(collector.endpoint));
+      for (let index = 0; index < 100; index++) {
+        metrics
+          .observableGauge(
+            {
+              name: `lifetime.gauge.${index}`,
+              description: "Lifetime gauge",
+              unit: "1",
+            },
+            () => [{ value: index }],
+          )
+          .unregister();
+      }
+      assert.equal(
+        errorCode(() =>
+          metrics.counter({
+            name: "lifetime.counter.overflow",
+            description: "Lifetime overflow",
+            unit: "1",
+          }),
+        ),
+        "LIMIT_EXCEEDED",
+      );
+      await metrics.close();
+    } finally {
+      await closeServer(collector.server);
+    }
+  });
+
   it("reports invalid gauge batches without suppressing other instruments", async () => {
     const collector = await startCollector();
     try {
@@ -427,6 +475,203 @@ describe("framework-neutral metrics", () => {
       assert.isUndefined(metricNamed(payload, "bounded.gauge"));
       await metrics.close();
     } finally {
+      await closeServer(collector.server);
+    }
+  });
+
+  it("keeps shared cumulative counter and histogram values after one lease closes", async () => {
+    const collector = await startCollector();
+    try {
+      const first = await createMetrics(options(collector.endpoint));
+      const second = await createMetrics(options(collector.endpoint));
+      first.counter({ name: "shared.counter", description: "Shared counter", unit: "1" }).add(2);
+      second.counter({ name: "shared.counter", description: "Shared counter", unit: "1" }).add(3);
+      first
+        .histogram({
+          name: "shared.histogram",
+          description: "Shared histogram",
+          unit: "ms",
+          boundaries: [10, 20],
+        })
+        .record(5);
+      const secondHistogram = second.histogram({
+        name: "shared.histogram",
+        description: "Shared histogram",
+        unit: "ms",
+        boundaries: [10, 20],
+      });
+      secondHistogram.record(15);
+
+      await first.flush();
+      await first.close();
+      await second.flush();
+
+      const beforeClose = collector.requests[0];
+      const afterClose = collector.requests[2];
+      assert.isDefined(beforeClose);
+      assert.isDefined(afterClose);
+      const initialCounter = metricNamed(beforeClose, "shared.counter")?.sum?.dataPoints[0];
+      const retainedCounter = metricNamed(afterClose, "shared.counter")?.sum?.dataPoints[0];
+      const initialHistogram = metricNamed(beforeClose, "shared.histogram")?.histogram
+        ?.dataPoints[0];
+      const retainedHistogram = metricNamed(afterClose, "shared.histogram")?.histogram
+        ?.dataPoints[0];
+      assert.equal(initialCounter?.asDouble, 5);
+      assert.equal(retainedCounter?.asDouble, 5);
+      assert.equal(retainedCounter?.startTimeUnixNano, initialCounter?.startTimeUnixNano);
+      assert.equal(initialHistogram?.count, 2);
+      assert.equal(retainedHistogram?.count, 2);
+      assert.equal(initialHistogram?.sum, 20);
+      assert.equal(retainedHistogram?.sum, 20);
+      assert.deepEqual(retainedHistogram?.bucketCounts, [1, 1, 0]);
+      assert.equal(retainedHistogram?.startTimeUnixNano, initialHistogram?.startTimeUnixNano);
+
+      second.counter({ name: "shared.counter", description: "Shared counter", unit: "1" }).add(4);
+      secondHistogram.record(25);
+      await second.flush();
+      const afterMoreMeasurements = collector.requests[3];
+      assert.isDefined(afterMoreMeasurements);
+      assert.equal(
+        metricNamed(afterMoreMeasurements, "shared.counter")?.sum?.dataPoints[0]?.asDouble,
+        9,
+      );
+      assert.equal(
+        metricNamed(afterMoreMeasurements, "shared.histogram")?.histogram?.dataPoints[0]?.count,
+        3,
+      );
+      assert.equal(
+        metricNamed(afterMoreMeasurements, "shared.histogram")?.histogram?.dataPoints[0]?.sum,
+        45,
+      );
+      await second.close();
+    } finally {
+      await closeServer(collector.server);
+    }
+  });
+
+  it("exports facade and direct Effect metrics through the later layer capture transport", async () => {
+    const config = new TelemetryConfig({
+      serviceName: "mixed-metrics-test",
+      serviceVersion: "1.0.0",
+      environment: "test",
+      otlpEndpoint: new URL("http://mixed-metrics.invalid"),
+    });
+    const facade = await createMetrics({
+      serviceName: config.serviceName,
+      serviceVersion: config.serviceVersion,
+      environment: config.environment,
+      otlpEndpoint: config.otlpEndpoint.toString(),
+    });
+    const capture = await Effect.runPromise(Testing.makeCapture({ config }));
+    const runtime = ManagedRuntime.make(capture.layer);
+    try {
+      facade.counter({ name: "mixed.facade", description: "Facade counter", unit: "1" }).add(2);
+      const direct = Metric.counter("mixed.direct", {
+        description: "Direct counter",
+        attributes: { unit: "By" },
+      });
+      await runtime.runPromise(Metric.update(direct, 4));
+      await facade.flush();
+
+      const telemetry = await Effect.runPromise(capture.telemetry);
+      const facadeMetric = telemetry.metrics.find((metric) => metric.name === "mixed.facade");
+      const directMetric = telemetry.metrics.find((metric) => metric.name === "mixed.direct");
+      assert.isDefined(facadeMetric);
+      assert.isDefined(directMetric);
+      const facadePoint = facadeMetric.points[0];
+      const directPoint = directMetric.points[0];
+      assert.isDefined(facadePoint);
+      assert.isDefined(directPoint);
+      assert.equal(Option.getOrUndefined(facadePoint.value), 2);
+      assert.equal(Option.getOrUndefined(directPoint.value), 4);
+      assert.equal(directMetric.unit, "By");
+      assert.isTrue(directMetric.points.every((point) => !point.attributes.has("unit")));
+      await facade.close();
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it("rejects facade and direct Effect name conflicts before sending OTLP", async () => {
+    const config = new TelemetryConfig({
+      serviceName: "mixed-conflict-test",
+      serviceVersion: "1.0.0",
+      environment: "test",
+      otlpEndpoint: new URL("http://mixed-conflict.invalid"),
+    });
+    const facade = await createMetrics({
+      serviceName: config.serviceName,
+      serviceVersion: config.serviceVersion,
+      environment: config.environment,
+      otlpEndpoint: config.otlpEndpoint.toString(),
+    });
+    const capture = await Effect.runPromise(Testing.makeCapture({ config }));
+    const runtime = ManagedRuntime.make(capture.layer);
+    try {
+      facade.counter({ name: "mixed.conflict", description: "Facade counter", unit: "1" }).add(1);
+      const direct = Metric.gauge("mixed.conflict", {
+        description: "Direct gauge",
+      });
+      await runtime.runPromise(Metric.update(direct, 3));
+      let conflict: MetricsError | undefined;
+      try {
+        await facade.flush();
+      } catch (cause) {
+        if (cause instanceof MetricsError) {
+          conflict = cause;
+        }
+      }
+      assert.isDefined(conflict);
+      assert.equal(conflict.code, "EXPORT_FAILED");
+      assert.equal(conflict.instrumentName, "mixed.conflict");
+      assert.isFalse(conflict.retryable);
+      const telemetry = await Effect.runPromise(capture.telemetry);
+      assert.equal(telemetry.metrics.length, 0);
+      assert.equal(
+        await asyncErrorCode(async () => {
+          await facade.close();
+        }),
+        "EXPORT_FAILED",
+      );
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it("emits periodic failed and recovered notices once per transition", async () => {
+    const collector = await startCollector();
+    const notices: Array<string> = [];
+    const previousWarn = console.warn;
+    const captureWarning = (message?: string): void => {
+      if (message !== undefined) {
+        notices.push(message);
+      }
+    };
+    console.warn = captureWarning;
+    try {
+      collector.control.status = 503;
+      const metrics = await createMetrics({
+        ...options(collector.endpoint, 200),
+        exportIntervalMilliseconds: 15,
+      });
+      metrics.counter({ name: "periodic.total", description: "Periodic", unit: "1" }).add(1);
+      await waitFor(() => notices.length === 1 && collector.requests.length >= 1);
+      await waitFor(() => collector.requests.length >= 3);
+      assert.deepEqual(notices, [
+        "OBS_METRICS_PERIODIC_EXPORT_FAILED: The periodic metrics export entered a failed state.",
+      ]);
+
+      collector.control.status = 200;
+      await waitFor(() => notices.length === 2);
+      const recoveredRequestCount = collector.requests.length;
+      await waitFor(() => collector.requests.length >= recoveredRequestCount + 2);
+      assert.deepEqual(notices, [
+        "OBS_METRICS_PERIODIC_EXPORT_FAILED: The periodic metrics export entered a failed state.",
+        "OBS_METRICS_PERIODIC_EXPORT_RECOVERED: The periodic metrics export recovered.",
+      ]);
+      await metrics.close();
+    } finally {
+      console.warn = previousWarn;
       await closeServer(collector.server);
     }
   });

--- a/packages/telemetry/test/metrics.test.ts
+++ b/packages/telemetry/test/metrics.test.ts
@@ -167,6 +167,144 @@ const waitFor = async (condition: () => boolean, timeoutMilliseconds = 2_000): P
 };
 
 describe("framework-neutral metrics", () => {
+  it("rejects a non-HTTP OTLP endpoint with stable public configuration fields", async () => {
+    const collector = await startCollector();
+    try {
+      let failure: MetricsError | undefined;
+      try {
+        await createMetrics({
+          ...options(collector.endpoint),
+          otlpEndpoint: "ftp://collector.invalid",
+        });
+      } catch (cause) {
+        if (cause instanceof MetricsError) {
+          failure = cause;
+        }
+      }
+      assert.isDefined(failure);
+      assert.equal(failure.name, "MetricsError");
+      assert.equal(failure.code, "INVALID_CONFIGURATION");
+      assert.equal(failure.operation, "createMetrics");
+      assert.equal(failure.instrumentName, undefined);
+      assert.isFalse(failure.retryable);
+      assert.equal(failure.cause, undefined);
+      assert.equal(
+        failure.message,
+        "Metrics configuration is invalid. Set otlpEndpoint to an HTTP or HTTPS URL without credentials.",
+      );
+      assert.equal(collector.requests.length, 0);
+    } finally {
+      await closeServer(collector.server);
+    }
+  });
+
+  it("isolates a non-finite gauge observation and recovers on the next collection", async () => {
+    const collector = await startCollector();
+    try {
+      const metrics = await createMetrics(options(collector.endpoint));
+      let invalidValue = Number.NaN;
+      let invalidCalls = 0;
+      let validCalls = 0;
+      metrics.counter({ name: "observation.total", description: "Total", unit: "1" }).add(1);
+      metrics.observableGauge(
+        { name: "observation.invalid", description: "Invalid observation", unit: "1" },
+        () => {
+          invalidCalls++;
+          return [{ value: invalidValue }];
+        },
+      );
+      metrics.observableGauge(
+        { name: "observation.valid", description: "Valid observation", unit: "1" },
+        () => {
+          validCalls++;
+          return [{ value: 7 }];
+        },
+      );
+
+      const failed = await metrics.flush();
+      const failure = failed.gaugeFailures[0];
+      assert.isDefined(failure);
+      assert.equal(failed.gaugeFailures.length, 1);
+      assert.equal(failure.instrumentName, "observation.invalid");
+      assert.equal(failure.code, "INVALID_OBSERVATION");
+      assert.include(failure.message, 'Observable gauge "observation.invalid"');
+      assert.isFalse(Object.hasOwn(failure, "retryable"));
+      const failedPayload = collector.requests[0];
+      assert.isDefined(failedPayload);
+      assert.isDefined(metricNamed(failedPayload, "observation.total"));
+      assert.isDefined(metricNamed(failedPayload, "observation.valid"));
+      assert.isUndefined(metricNamed(failedPayload, "observation.invalid"));
+
+      invalidValue = 5;
+      const recovered = await metrics.flush();
+      assert.deepEqual(recovered.gaugeFailures, []);
+      const recoveredPayload = collector.requests[1];
+      assert.isDefined(recoveredPayload);
+      assert.equal(
+        metricNamed(recoveredPayload, "observation.invalid")?.gauge?.dataPoints[0]?.asDouble,
+        5,
+      );
+      assert.equal(
+        metricNamed(recoveredPayload, "observation.valid")?.gauge?.dataPoints[0]?.asDouble,
+        7,
+      );
+      assert.equal(invalidCalls, 2);
+      assert.equal(validCalls, 2);
+      await metrics.close();
+    } finally {
+      await closeServer(collector.server);
+    }
+  });
+
+  it("rejects 101 gauge observations without a partial series and recovers", async () => {
+    const collector = await startCollector();
+    try {
+      const metrics = await createMetrics(options(collector.endpoint));
+      let observationCount = 101;
+      let callbackCalls = 0;
+      metrics.counter({ name: "series.total", description: "Total", unit: "1" }).add(1);
+      metrics.observableGauge(
+        { name: "series.overflow", description: "Series overflow", unit: "1" },
+        () => {
+          callbackCalls++;
+          return Array.from({ length: observationCount }, (_, index) => ({
+            value: index,
+            attributes: [{ key: "series", value: index }],
+          }));
+        },
+      );
+
+      const failed = await metrics.flush();
+      const failure = failed.gaugeFailures[0];
+      assert.isDefined(failure);
+      assert.equal(failed.gaugeFailures.length, 1);
+      assert.equal(failure.instrumentName, "series.overflow");
+      assert.equal(failure.code, "SERIES_LIMIT_EXCEEDED");
+      assert.equal(
+        failure.message,
+        'Observable gauge "series.overflow" exceeds the 100-observation collection limit.',
+      );
+      assert.isFalse(Object.hasOwn(failure, "retryable"));
+      const failedPayload = collector.requests[0];
+      assert.isDefined(failedPayload);
+      assert.isDefined(metricNamed(failedPayload, "series.total"));
+      assert.isUndefined(metricNamed(failedPayload, "series.overflow"));
+
+      observationCount = 1;
+      const recovered = await metrics.flush();
+      assert.deepEqual(recovered.gaugeFailures, []);
+      const recoveredPayload = collector.requests[1];
+      assert.isDefined(recoveredPayload);
+      const recoveredGauge = metricNamed(recoveredPayload, "series.overflow");
+      assert.equal(recoveredGauge?.gauge?.dataPoints.length, 1);
+      assert.equal(recoveredGauge?.gauge?.dataPoints[0]?.asDouble, 0);
+      assert.equal(callbackCalls, 2);
+      await metrics.close();
+    } finally {
+      await closeServer(collector.server);
+    }
+  });
+
   it("exports counter, histogram, and immediately collected gauge values through real OTLP", async () => {
     const collector = await startCollector();
     try {

--- a/packages/telemetry/test/testing.test.ts
+++ b/packages/telemetry/test/testing.test.ts
@@ -17,11 +17,22 @@ describe("Testing.run", () => {
       const counter = Metric.counter("testing.operations", {
         attributes: { "testing.run_id": runId },
       });
+      const histogram = Metric.histogram("testing.duration", {
+        description: "Testing duration",
+        attributes: { "testing.run_id": runId, unit: "ms" },
+        boundaries: [10, 20],
+      });
+      const gauge = Metric.gauge("testing.load", {
+        description: "Testing load",
+        attributes: { "testing.run_id": runId, unit: "%" },
+      });
       const { exit, telemetry } = yield* Testing.run(
         Effect.gen(function* () {
           yield* Effect.sleep("5 millis").pipe(Effect.withSpan("testing.child"));
           yield* WideEvent.emit("testing.completed", { "testing.run_id": runId });
           yield* Metric.update(counter, 1);
+          yield* Metric.update(histogram, 12);
+          yield* Metric.update(gauge, 7);
           return "done";
         }).pipe(Effect.withSpan("testing.operation")),
         {
@@ -68,6 +79,42 @@ describe("Testing.run", () => {
       );
       assert.isDefined(point);
       assert.deepStrictEqual(point.value, Option.some(1));
+      assert.strictEqual(metric.kind, "sum");
+      if (metric.kind === "sum") {
+        assert.isFalse(metric.isMonotonic);
+        assert.strictEqual(metric.aggregationTemporality, 2);
+      }
+
+      const capturedHistogram = telemetry.metrics.find(
+        (candidate) => candidate.name === "testing.duration",
+      );
+      assert.isDefined(capturedHistogram);
+      assert.strictEqual(capturedHistogram.kind, "histogram");
+      assert.strictEqual(capturedHistogram.unit, "ms");
+      if (capturedHistogram.kind === "histogram") {
+        const histogramPoint = capturedHistogram.histogramPoints[0];
+        assert.isDefined(histogramPoint);
+        assert.strictEqual(histogramPoint.count, 1);
+        assert.strictEqual(histogramPoint.sum, 12);
+        assert.deepStrictEqual(histogramPoint.explicitBounds, [10]);
+        assert.deepStrictEqual(histogramPoint.bucketCounts, [0, 1]);
+        assert.strictEqual(
+          histogramPoint.bucketCounts.length,
+          histogramPoint.explicitBounds.length + 1,
+        );
+        assert.isTrue(Option.isNone(Testing.attribute(histogramPoint.attributes, "unit")));
+      }
+
+      const capturedGauge = telemetry.metrics.find(
+        (candidate) => candidate.name === "testing.load",
+      );
+      assert.isDefined(capturedGauge);
+      assert.strictEqual(capturedGauge.kind, "gauge");
+      assert.strictEqual(capturedGauge.unit, "%");
+      const capturedGaugePoint = capturedGauge.points[0];
+      assert.isDefined(capturedGaugePoint);
+      assert.deepStrictEqual(capturedGaugePoint.value, Option.some(7));
+      assert.isTrue(Option.isNone(Testing.attribute(capturedGaugePoint.attributes, "unit")));
     }),
   );
 

--- a/scripts/package-smoke.ts
+++ b/scripts/package-smoke.ts
@@ -62,6 +62,8 @@ try {
         "package/dist/LICENSE",
         "package/dist/index.js",
         "package/dist/index.d.ts",
+        "package/dist/Metrics.js",
+        "package/dist/Metrics.d.ts",
         "package/dist/node/index.js",
         "package/dist/node/index.d.ts",
         "package/dist/nestjs/index.js",
@@ -140,7 +142,7 @@ try {
       [
         "bun",
         "-e",
-        "import { Telemetry, WideEvent } from '@equipe-tech/observability'; import { runMain, ingestBrowserEvents } from '@equipe-tech/observability/node'; import { BrowserTelemetry } from '@equipe-tech/observability/browser'; import { run } from '@equipe-tech/observability/testing'; if (!Telemetry.layer || !WideEvent.emit || !runMain || !ingestBrowserEvents || !BrowserTelemetry.layer || !run) process.exit(1);",
+        "import { Telemetry, WideEvent } from '@equipe-tech/observability'; import { createMetrics } from '@equipe-tech/observability/metrics'; import { runMain, ingestBrowserEvents } from '@equipe-tech/observability/node'; import { BrowserTelemetry } from '@equipe-tech/observability/browser'; import { run } from '@equipe-tech/observability/testing'; if (!Telemetry.layer || !WideEvent.emit || !createMetrics || !runMain || !ingestBrowserEvents || !BrowserTelemetry.layer || !run) process.exit(1);",
       ],
       consumer,
     ),
@@ -149,6 +151,21 @@ try {
   await writeFile(
     join(consumer, "index.ts"),
     "import { TelemetryConfig } from '@equipe-tech/observability';\nimport { layer } from '@equipe-tech/observability/node';\nimport { BrowserTelemetry } from '@equipe-tech/observability/browser';\nimport { run } from '@equipe-tech/observability/testing';\nconst config = new TelemetryConfig({ serviceName: 'test', serviceVersion: '1.0.0', environment: 'test', otlpEndpoint: new URL('http://localhost:4318') });\nvoid config;\nvoid layer;\nvoid BrowserTelemetry;\nvoid run;\n",
+  );
+  await writeFile(
+    join(consumer, "metrics-consumer.ts"),
+    "import { createMetrics, type MetricAttribute } from '@equipe-tech/observability/metrics';\nconst metrics = await createMetrics({ enabled: false, serviceName: 'packed-consumer', serviceVersion: '1.0.0', environment: 'test', otlpEndpoint: 'http://localhost:4318' });\nconst attributes: ReadonlyArray<MetricAttribute> = [{ key: 'packed', value: true }];\nconst counter = metrics.counter({ name: 'packed.counter', description: 'Packed counter', unit: '1' });\nconst histogram = metrics.histogram({ name: 'packed.histogram', description: 'Packed histogram', unit: 'ms', boundaries: [1, 10] });\nconst gauge = metrics.observableGauge({ name: 'packed.gauge', description: 'Packed gauge', unit: '%' }, () => [{ value: 4, attributes }]);\ncounter.add(1, attributes);\nhistogram.record(5, attributes);\ngauge.unregister();\nawait metrics.flush();\nawait metrics.close();\n",
+  );
+  const metricsDeclaration = await readFile(
+    join(consumer, "node_modules/@equipe-tech/observability/dist/Metrics.d.ts"),
+    "utf8",
+  );
+  if (/from ["']effect(?:\/|["'])|import\(["']effect(?:\/|["'])/.test(metricsDeclaration)) {
+    throw new Error("The metrics facade declaration exposes an Effect module reference.");
+  }
+  requireSuccess(
+    await run(["bun", "metrics-consumer.ts"], consumer),
+    "Executing the packed metrics facade",
   );
   await writeFile(
     join(consumer, "tsconfig.json"),
@@ -160,7 +177,7 @@ try {
         strict: true,
         noEmit: true,
       },
-      include: ["index.ts"],
+      include: ["index.ts", "metrics-consumer.ts"],
     }),
   );
   requireSuccess(


### PR DESCRIPTION
## Summary

- add a framework-neutral counter, histogram, and observable-gauge facade
- replace Effect OtlpMetrics with one package-owned exporter inside the existing shared runtime
- add cumulative lifecycle, cardinality, periodic export, typed failure, and real OTLP coverage

## Verification

- real OTLP payloads for facade and direct Effect metrics
- observable callbacks, unregister, failure isolation, periodic recovery, shared leases, and cumulative stability
- public error-contract and declaration checks
- `bun check`, build, full tests, package smoke, local Collector canary, and independent exact-head review

Linear: OBS-21
