### PR TITLE
feat(telemetry): add lifecycle-safe NestJS module

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,16 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
       },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0",
+        "rxjs": "^7.2.0",
+      },
+      "optionalPeers": [
+        "@nestjs/common",
+        "@nestjs/core",
+        "rxjs",
+      ],
     },
   },
   "packages": {

--- a/docs/nestjs-http-semantics.md
+++ b/docs/nestjs-http-semantics.md
@@ -2,6 +2,14 @@
 
 O adapter segue OpenTelemetry HTTP Semantic Conventions v1.44.0 para spans de servidor.
 
+## Módulo e ciclo de vida
+
+Use `TelemetryModule.forRootAsync` para resolver a configuração pelo container do Nest e registrar o interceptor globalmente. A factory pode ser síncrona ou assíncrona e recebe os tokens declarados em `inject`.
+
+A opção `enabled: false` não exige identidade ou endpoint e não cria runtime, exporter, timer ou requisição de rede. A configuração habilitada é analisada durante o bootstrap. Valores inválidos rejeitam o bootstrap com `InvalidTelemetryModuleOptions`.
+
+No encerramento, o módulo fecha a admissão de spans, aguarda requisições ativas dentro do prazo configurado, faz flush do exporter compartilhado e descarta o runtime uma única vez. O prazo padrão é 5 segundos. Falhas de drain, flush ou descarte são reportadas como `TelemetryShutdownError` depois da tentativa de descarte.
+
 O suporte usa NestJS com Express. O adapter não declara suporte ao Fastify.
 
 ## Nomes e rotas

--- a/docs/nestjs-http-semantics.md
+++ b/docs/nestjs-http-semantics.md
@@ -6,9 +6,11 @@ O adapter segue OpenTelemetry HTTP Semantic Conventions v1.44.0 para spans de se
 
 Use `TelemetryModule.forRootAsync` para resolver a configuração pelo container do Nest e registrar o interceptor globalmente. A factory pode ser síncrona ou assíncrona e recebe os tokens declarados em `inject`.
 
-A opção `enabled: false` não exige identidade ou endpoint e não cria runtime, exporter, timer ou requisição de rede. A configuração habilitada é analisada durante o bootstrap. Valores inválidos rejeitam o bootstrap com `InvalidTelemetryModuleOptions`.
+A opção `enabled: false` não exige identidade ou endpoint e não cria runtime, exporter, timer ou requisição de rede. A configuração habilitada é analisada durante o bootstrap. Valores inválidos e imports duplicados com configurações diferentes rejeitam o bootstrap com `InvalidTelemetryModuleOptions` e código `OBS_TELEMETRY_INVALID_MODULE_OPTIONS`.
 
-No encerramento, o módulo fecha a admissão de spans, aguarda requisições ativas dentro do prazo configurado, faz flush do exporter compartilhado e descarta o runtime uma única vez. O prazo padrão é 5 segundos. Falhas de drain, flush ou descarte são reportadas como `TelemetryShutdownError` depois da tentativa de descarte.
+Uma falha depois da configuração válida, durante a construção ou aquisição do runtime, rejeita o bootstrap com `TelemetryStartupError` e código `OBS_TELEMETRY_STARTUP_FAILED`. O módulo descarta recursos parcialmente adquiridos antes de propagar essa falha. Uma rejeição da factory do chamador é propagada sem conversão.
+
+No encerramento, o módulo fecha a admissão de spans, aguarda ou interrompe requisições ativas e faz flush do exporter compartilhado dentro de um único prazo. O prazo padrão é 5 segundos. O descarte começa depois desse prazo operacional e sempre é aguardado, portanto o tempo total de `app.close()` pode exceder o prazo para garantir a liberação dos recursos. Falhas de drain, interrupção, flush ou descarte são reportadas como `TelemetryShutdownError` com código `OBS_TELEMETRY_SHUTDOWN_FAILED` depois da tentativa de descarte.
 
 O suporte usa NestJS com Express. O adapter não declara suporte ao Fastify.
 
@@ -59,5 +61,3 @@ Mensagens de exceção não entram no status de spans HTTP.
 O adapter exclui `/health` e `/_telemetry/events` por padrão.
 
 A opção `healthRouteTemplates` adiciona templates exatos. Ela não remove as exclusões padrão.
-
-O desligamento futuro do módulo pode fechar a admissão, aguardar requisições ativas e interromper somente os spans restantes.

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -53,10 +53,14 @@
   },
   "peerDependencies": {
     "@nestjs/common": "^10.0.0 || ^11.0.0",
+    "@nestjs/core": "^10.0.0 || ^11.0.0",
     "rxjs": "^7.2.0"
   },
   "peerDependenciesMeta": {
     "@nestjs/common": {
+      "optional": true
+    },
+    "@nestjs/core": {
       "optional": true
     },
     "rxjs": {

--- a/packages/telemetry/src/TelemetryConfig.ts
+++ b/packages/telemetry/src/TelemetryConfig.ts
@@ -1,6 +1,6 @@
 import { Effect, Schema } from "effect";
 
-const OtlpEndpoint = Schema.URLFromString.check(
+export const OtlpEndpoint = Schema.URLFromString.check(
   Schema.makeFilter(
     (url) =>
       (url.protocol === "http:" || url.protocol === "https:") &&

--- a/packages/telemetry/src/nestjs/TelemetryInterceptor.ts
+++ b/packages/telemetry/src/nestjs/TelemetryInterceptor.ts
@@ -144,6 +144,9 @@ export class TelemetryInterceptor<RuntimeError> implements NestInterceptor {
   #instrument(context: ExecutionContext, next: CallHandler): Observable<unknown> {
     const httpContext = context.switchToHttp();
     const request = httpContext.getRequest<RequestReference>();
+    if (requestSpans.has(request)) {
+      return next.handle();
+    }
     const requestDetails = this.#routePolicy.inspect(request);
     if (Option.isNone(requestDetails)) {
       return next.handle();

--- a/packages/telemetry/src/nestjs/TelemetryModule.ts
+++ b/packages/telemetry/src/nestjs/TelemetryModule.ts
@@ -7,12 +7,13 @@ import type {
   ModuleMetadata,
   NestInterceptor,
   OnApplicationShutdown,
+  OnModuleInit,
   OptionalFactoryDependency,
   Provider,
 } from "@nestjs/common";
 import { Module } from "@nestjs/common";
 import { APP_INTERCEPTOR, HttpAdapterHost } from "@nestjs/core";
-import { Duration, Effect, ManagedRuntime, Option, Schema } from "effect";
+import { Duration, Effect, Layer, ManagedRuntime, Option, Schema } from "effect";
 import type { OtlpExporter } from "effect/unstable/observability";
 import { OtlpExporter as Otlp } from "effect/unstable/observability";
 import type { Observable } from "rxjs";
@@ -301,6 +302,67 @@ class EnabledTelemetryIntegration implements TelemetryIntegration {
   }
 }
 
+class DeferredTelemetryInterceptor implements NestInterceptor {
+  #target: NestInterceptor | undefined;
+
+  setTarget(target: NestInterceptor): void {
+    this.#target = target;
+  }
+
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Observable<unknown> | Promise<Observable<unknown>> {
+    return this.#target?.intercept(context, next) ?? next.handle();
+  }
+}
+
+class PendingTelemetryIntegration implements TelemetryIntegration, OnModuleInit {
+  readonly interceptor = new DeferredTelemetryInterceptor();
+  readonly #application: WeakKey;
+  readonly #options: EnabledNormalizedOptions;
+  readonly #state: ApplicationRuntimeState;
+  readonly #overrides: TelemetryModuleTestingOverrides;
+  #integration: EnabledTelemetryIntegration | undefined;
+
+  constructor(
+    application: WeakKey,
+    options: EnabledNormalizedOptions,
+    state: ApplicationRuntimeState,
+    overrides: TelemetryModuleTestingOverrides,
+  ) {
+    this.#application = application;
+    this.#options = options;
+    this.#state = state;
+    this.#overrides = overrides;
+  }
+
+  async onModuleInit(): Promise<void> {
+    const lease = await acquireApplicationRuntime(
+      this.#application,
+      this.#state,
+      this.#options,
+      this.#overrides,
+    );
+    this.#integration = new EnabledTelemetryIntegration(
+      lease.runtime,
+      lease.flusher,
+      this.#options,
+      lease.release,
+      this.#overrides.beforeRequestDrain ?? (() => undefined),
+    );
+    this.interceptor.setTarget(this.#integration.interceptor);
+  }
+
+  beforeApplicationShutdown(): void | Promise<void> {
+    return this.#integration?.beforeApplicationShutdown();
+  }
+
+  onApplicationShutdown(): void | Promise<void> {
+    return this.#integration?.onApplicationShutdown();
+  }
+}
+
 const ASYNC_OPTIONS = Symbol("TelemetryModuleAsyncOptions");
 const NORMALIZED_OPTIONS = Symbol("TelemetryModuleNormalizedOptions");
 const TELEMETRY_INTEGRATION = Symbol("TelemetryModuleIntegration");
@@ -323,6 +385,12 @@ interface RuntimeLease {
 }
 
 export interface TelemetryModuleTestingOverrides {
+  readonly scopedResource?:
+    | {
+        readonly acquire: () => void | Promise<void>;
+        readonly release: () => void | Promise<void>;
+      }
+    | undefined;
   readonly startupProbe?: (() => void | Promise<void>) | undefined;
   readonly beforeRequestDrain?: (() => void | Promise<void>) | undefined;
   readonly beforeRuntimeDispose?: (() => void | Promise<void>) | undefined;
@@ -354,13 +422,22 @@ const createSharedRuntime = async (
 ): Promise<SharedRuntime> => {
   let runtime: ManagedRuntime.ManagedRuntime<OtlpExporter.Flusher, never> | undefined;
   try {
-    runtime = ManagedRuntime.make(
-      layer(options.config, {
-        shutdownTimeout: Duration.millis(options.shutdownTimeoutMilliseconds),
-      }),
-    );
-    await (overrides.startupProbe ?? (() => undefined))();
+    let runtimeLayer = layer(options.config, {
+      shutdownTimeout: Duration.millis(options.shutdownTimeoutMilliseconds),
+    });
+    if (overrides.scopedResource !== undefined) {
+      const resource = overrides.scopedResource;
+      const resourceLayer = Layer.effectDiscard(
+        Effect.acquireRelease(
+          Effect.promise(() => Promise.resolve(resource.acquire())),
+          () => Effect.promise(() => Promise.resolve(resource.release())),
+        ),
+      );
+      runtimeLayer = Layer.merge(runtimeLayer, resourceLayer);
+    }
+    runtime = ManagedRuntime.make(runtimeLayer);
     await runtime.context();
+    await (overrides.startupProbe ?? (() => undefined))();
     const flusher = await runtime.runPromise(Otlp.Flusher);
     return { runtime, flusher };
   } catch (cause) {
@@ -445,38 +522,36 @@ const acquireRuntime = async (
   return { runtime: shared.runtime, flusher: shared.flusher, release };
 };
 
+const registerApplicationRuntime = (
+  application: WeakKey,
+  options: EnabledNormalizedOptions,
+): ApplicationRuntimeState => {
+  const key = runtimeKey(options);
+  const state = applicationRuntimes.get(application);
+  if (state === undefined) {
+    const registered = { key, releases: new Set<() => Promise<void>>(), failed: false };
+    applicationRuntimes.set(application, registered);
+    return registered;
+  }
+  if (state.key !== key) {
+    state.failed = true;
+  }
+  return state;
+};
+
 const acquireApplicationRuntime = async (
   application: WeakKey,
+  state: ApplicationRuntimeState,
   options: EnabledNormalizedOptions,
   overrides: TelemetryModuleTestingOverrides,
 ): Promise<RuntimeLease> => {
-  const key = runtimeKey(options);
-  let state = applicationRuntimes.get(application);
-  if (state !== undefined && state.key !== key) {
-    state.failed = true;
-    await Promise.all(Array.from(state.releases, (release) => release()));
+  if (state.failed) {
     applicationRuntimes.delete(application);
     throw new InvalidTelemetryModuleOptions(
       new Error("TelemetryModule imports in one application must use one runtime configuration."),
     );
   }
-  if (state === undefined) {
-    state = { key, releases: new Set(), failed: false };
-    applicationRuntimes.set(application, state);
-  }
-  await Promise.resolve();
-  if (state.failed) {
-    throw new InvalidTelemetryModuleOptions(
-      new Error("TelemetryModule imports in one application must use one runtime configuration."),
-    );
-  }
   const lease = await acquireRuntime(options, overrides);
-  if (state.failed) {
-    await lease.release();
-    throw new InvalidTelemetryModuleOptions(
-      new Error("TelemetryModule imports in one application must use one runtime configuration."),
-    );
-  }
   const release = (): Promise<void> => {
     state.releases.delete(release);
     if (state.releases.size === 0) {
@@ -488,21 +563,19 @@ const acquireApplicationRuntime = async (
   return { runtime: lease.runtime, flusher: lease.flusher, release };
 };
 
-const makeIntegration = async (
+const makeIntegration = (
   options: NormalizedOptions,
   application: WeakKey,
   overrides: TelemetryModuleTestingOverrides,
-): Promise<TelemetryIntegration> => {
+): TelemetryIntegration => {
   if (!options.enabled) {
     return new DisabledTelemetryIntegration();
   }
-  const lease = await acquireApplicationRuntime(application, options, overrides);
-  return new EnabledTelemetryIntegration(
-    lease.runtime,
-    lease.flusher,
+  return new PendingTelemetryIntegration(
+    application,
     options,
-    lease.release,
-    overrides.beforeRequestDrain ?? (() => undefined),
+    registerApplicationRuntime(application, options),
+    overrides,
   );
 };
 

--- a/packages/telemetry/src/nestjs/TelemetryModule.ts
+++ b/packages/telemetry/src/nestjs/TelemetryModule.ts
@@ -11,13 +11,13 @@ import type {
   Provider,
 } from "@nestjs/common";
 import { Module } from "@nestjs/common";
-import { APP_INTERCEPTOR } from "@nestjs/core";
+import { APP_INTERCEPTOR, HttpAdapterHost } from "@nestjs/core";
 import { Duration, Effect, ManagedRuntime, Option, Schema } from "effect";
 import type { OtlpExporter } from "effect/unstable/observability";
 import { OtlpExporter as Otlp } from "effect/unstable/observability";
 import type { Observable } from "rxjs";
 import { layer } from "../Telemetry.ts";
-import { TelemetryConfig } from "../TelemetryConfig.ts";
+import { OtlpEndpoint, TelemetryConfig } from "../TelemetryConfig.ts";
 import { telemetryRoutePolicy, type ProxyPolicy } from "./HttpRoutePolicy.ts";
 import { TelemetryInterceptor, TelemetryRequestTracker } from "./TelemetryInterceptor.ts";
 
@@ -34,7 +34,8 @@ export type TelemetryModuleOptions =
       readonly shutdownTimeoutMilliseconds?: number | undefined;
     };
 
-export interface TelemetryModuleAsyncOptions extends Pick<ModuleMetadata, "imports"> {
+export interface TelemetryModuleAsyncOptions {
+  readonly imports?: ModuleMetadata["imports"] | undefined;
   readonly inject?: Array<InjectionToken | OptionalFactoryDependency> | undefined;
   readonly useFactory: (
     ...dependencies: Array<never>
@@ -89,15 +90,6 @@ export class TelemetryShutdownError extends Error {
 const Identity = Schema.NonEmptyString.check(
   Schema.makeFilter((value) => value.trim() === value, { expected: "a nonempty trimmed string" }),
 );
-const Endpoint = Schema.URLFromString.check(
-  Schema.makeFilter(
-    (url) =>
-      (url.protocol === "http:" || url.protocol === "https:") &&
-      url.username === "" &&
-      url.password === "",
-    { expected: "an HTTP or HTTPS URL without credentials" },
-  ),
-);
 const ShutdownTimeout = Schema.Number.check(
   Schema.isInt(),
   Schema.makeFilter((value) => Number.isSafeInteger(value) && value > 0, {
@@ -109,10 +101,16 @@ const EnabledOptions = Schema.Struct({
   serviceName: Identity,
   serviceVersion: Identity,
   environment: Identity,
-  otlpEndpoint: Endpoint,
-  healthRouteTemplates: Schema.Array(Schema.String).pipe(Schema.optionalKey),
-  proxyPolicy: Schema.Literals(["direct", "framework"]).pipe(Schema.optionalKey),
-  shutdownTimeoutMilliseconds: ShutdownTimeout.pipe(Schema.optionalKey),
+  otlpEndpoint: OtlpEndpoint,
+  healthRouteTemplates: Schema.Union([Schema.Array(Schema.String), Schema.Undefined]).pipe(
+    Schema.optionalKey,
+  ),
+  proxyPolicy: Schema.Union([Schema.Literals(["direct", "framework"]), Schema.Undefined]).pipe(
+    Schema.optionalKey,
+  ),
+  shutdownTimeoutMilliseconds: Schema.Union([ShutdownTimeout, Schema.Undefined]).pipe(
+    Schema.optionalKey,
+  ),
 });
 const DisabledOptions = Schema.Struct({ enabled: Schema.Literal(false) });
 const ModuleOptions = Schema.Union([DisabledOptions, EnabledOptions]);
@@ -184,6 +182,7 @@ class EnabledTelemetryIntegration implements TelemetryIntegration {
   readonly #requestTracker: TelemetryRequestTracker;
   readonly #shutdownTimeoutMilliseconds: number;
   readonly #releaseRuntime: () => Promise<void>;
+  readonly #beforeRequestDrain: () => void | Promise<void>;
   #shutdownPromise: Promise<void> | undefined;
   #disposePromise: Promise<void> | undefined;
   #shutdownError: TelemetryShutdownError | undefined;
@@ -193,10 +192,12 @@ class EnabledTelemetryIntegration implements TelemetryIntegration {
     flusher: OtlpExporter.Flusher["Service"],
     options: EnabledNormalizedOptions,
     releaseRuntime: () => Promise<void>,
+    beforeRequestDrain: () => void | Promise<void>,
   ) {
     this.#runtime = runtime;
     this.#flusher = flusher;
     this.#releaseRuntime = releaseRuntime;
+    this.#beforeRequestDrain = beforeRequestDrain;
     this.#requestTracker = new TelemetryRequestTracker();
     this.#shutdownTimeoutMilliseconds = options.shutdownTimeoutMilliseconds;
     this.interceptor = new TelemetryInterceptor(runtime, {
@@ -212,12 +213,17 @@ class EnabledTelemetryIntegration implements TelemetryIntegration {
   }
 
   async onApplicationShutdown(): Promise<void> {
-    await this.beforeApplicationShutdown();
-    this.#disposePromise ??= this.#releaseRuntime();
     try {
-      await this.#disposePromise;
+      await this.beforeApplicationShutdown();
     } catch (cause) {
-      this.#shutdownError ??= new TelemetryShutdownError(cause);
+      this.#recordShutdownError(cause);
+    } finally {
+      this.#disposePromise ??= this.#releaseRuntime();
+      try {
+        await this.#disposePromise;
+      } catch (cause) {
+        this.#recordShutdownError(cause);
+      }
     }
     if (this.#shutdownError !== undefined) {
       throw this.#shutdownError;
@@ -226,15 +232,28 @@ class EnabledTelemetryIntegration implements TelemetryIntegration {
 
   async #shutdown(): Promise<void> {
     const deadline = Date.now() + this.#shutdownTimeoutMilliseconds;
-    this.#requestTracker.closeAdmission();
-    const idle = await this.#withinDeadline(this.#requestTracker.waitForIdle(), deadline);
-    if (!idle) {
-      this.#requestTracker.interruptActive();
-      await this.#requestTracker.waitForIdle();
+    try {
+      this.#requestTracker.closeAdmission();
+      await this.#beforeRequestDrain();
+      const idle = await this.#withinDeadline(this.#requestTracker.waitForIdle(), deadline);
+      if (!idle) {
+        this.#requestTracker.interruptActive();
+        const interrupted = await this.#withinDeadline(
+          this.#requestTracker.waitForIdle(),
+          deadline,
+        );
+        if (!interrupted) {
+          this.#recordShutdownError(
+            new Error("The telemetry request interruption exhausted the shutdown deadline."),
+          );
+        }
+      }
+    } catch (cause) {
+      this.#recordShutdownError(cause);
     }
     const remaining = Math.max(0, deadline - Date.now());
     if (remaining === 0) {
-      this.#shutdownError = new TelemetryShutdownError(
+      this.#recordShutdownError(
         new Error("The telemetry request drain exhausted the shutdown deadline."),
       );
       return;
@@ -244,13 +263,22 @@ class EnabledTelemetryIntegration implements TelemetryIntegration {
         this.#flusher.flush.pipe(Effect.timeoutOption(Duration.millis(remaining))),
       );
       if (Option.isNone(flushed)) {
-        this.#shutdownError = new TelemetryShutdownError(
-          new Error("The telemetry flush exceeded the shutdown deadline."),
-        );
+        this.#recordShutdownError(new Error("The telemetry flush exceeded the shutdown deadline."));
       }
     } catch (cause) {
-      this.#shutdownError = new TelemetryShutdownError(cause);
+      this.#recordShutdownError(cause);
     }
+  }
+
+  #recordShutdownError(cause: unknown): void {
+    if (this.#shutdownError === undefined) {
+      this.#shutdownError =
+        cause instanceof TelemetryShutdownError ? cause : new TelemetryShutdownError(cause);
+      return;
+    }
+    this.#shutdownError = new TelemetryShutdownError(
+      new AggregateError([this.#shutdownError.cause, cause]),
+    );
   }
 
   async #withinDeadline(operation: Promise<void>, deadline: number): Promise<boolean> {
@@ -280,7 +308,12 @@ const TELEMETRY_INTEGRATION = Symbol("TelemetryModuleIntegration");
 interface SharedRuntime {
   readonly runtime: ManagedRuntime.ManagedRuntime<OtlpExporter.Flusher, never>;
   readonly flusher: OtlpExporter.Flusher["Service"];
+}
+
+interface RuntimePoolEntry {
+  readonly shared: Promise<SharedRuntime>;
   references: number;
+  closing: Promise<void> | undefined;
 }
 
 interface RuntimeLease {
@@ -289,7 +322,22 @@ interface RuntimeLease {
   readonly release: () => Promise<void>;
 }
 
-const runtimePool = new Map<string, Promise<SharedRuntime>>();
+export interface TelemetryModuleTestingOverrides {
+  readonly startupProbe?: (() => void | Promise<void>) | undefined;
+  readonly beforeRequestDrain?: (() => void | Promise<void>) | undefined;
+  readonly beforeRuntimeDispose?: (() => void | Promise<void>) | undefined;
+  readonly onRuntimeDisposed?: (() => void) | undefined;
+}
+
+const runtimePool = new Map<string, RuntimePoolEntry>();
+
+interface ApplicationRuntimeState {
+  readonly key: string;
+  readonly releases: Set<() => Promise<void>>;
+  failed: boolean;
+}
+
+const applicationRuntimes = new WeakMap<WeakKey, ApplicationRuntimeState>();
 
 const runtimeKey = (options: EnabledNormalizedOptions): string =>
   JSON.stringify([
@@ -300,95 +348,205 @@ const runtimeKey = (options: EnabledNormalizedOptions): string =>
     options.shutdownTimeoutMilliseconds,
   ]);
 
-const createSharedRuntime = async (options: EnabledNormalizedOptions): Promise<SharedRuntime> => {
-  const runtime = ManagedRuntime.make(
-    layer(options.config, {
-      shutdownTimeout: Duration.millis(options.shutdownTimeoutMilliseconds),
-    }),
-  );
+const createSharedRuntime = async (
+  options: EnabledNormalizedOptions,
+  overrides: TelemetryModuleTestingOverrides,
+): Promise<SharedRuntime> => {
+  let runtime: ManagedRuntime.ManagedRuntime<OtlpExporter.Flusher, never> | undefined;
   try {
+    runtime = ManagedRuntime.make(
+      layer(options.config, {
+        shutdownTimeout: Duration.millis(options.shutdownTimeoutMilliseconds),
+      }),
+    );
+    await (overrides.startupProbe ?? (() => undefined))();
     await runtime.context();
     const flusher = await runtime.runPromise(Otlp.Flusher);
-    return { runtime, flusher, references: 0 };
+    return { runtime, flusher };
   } catch (cause) {
-    try {
-      await runtime.dispose();
-    } catch (disposeCause) {
-      throw new TelemetryStartupError(new AggregateError([cause, disposeCause]));
+    if (runtime !== undefined) {
+      try {
+        await runtime.dispose();
+        overrides.onRuntimeDisposed?.();
+      } catch (disposeCause) {
+        throw new TelemetryStartupError(new AggregateError([cause, disposeCause]));
+      }
     }
     throw new TelemetryStartupError(cause);
   }
 };
 
-const acquireRuntime = async (options: EnabledNormalizedOptions): Promise<RuntimeLease> => {
+const acquireRuntime = async (
+  options: EnabledNormalizedOptions,
+  overrides: TelemetryModuleTestingOverrides,
+): Promise<RuntimeLease> => {
   const key = runtimeKey(options);
-  let sharedPromise = runtimePool.get(key);
-  if (sharedPromise === undefined) {
-    sharedPromise = createSharedRuntime(options);
-    runtimePool.set(key, sharedPromise);
-    sharedPromise.catch(() => {
-      if (runtimePool.get(key) === sharedPromise) {
+  let entry = runtimePool.get(key);
+  if (entry?.closing !== undefined) {
+    try {
+      await entry.closing;
+    } catch (cause) {
+      throw new TelemetryStartupError(cause);
+    }
+    entry = runtimePool.get(key);
+  }
+  if (entry === undefined) {
+    const shared = createSharedRuntime(options, overrides);
+    entry = { shared, references: 0, closing: undefined };
+    runtimePool.set(key, entry);
+    try {
+      await shared;
+    } catch (cause) {
+      if (runtimePool.get(key) === entry) {
         runtimePool.delete(key);
       }
-    });
+      throw cause;
+    }
   }
-  const shared = await sharedPromise;
-  shared.references++;
+  const shared = await entry.shared;
+  entry.references++;
   let releasePromise: Promise<void> | undefined;
   const release = (): Promise<void> => {
     if (releasePromise !== undefined) {
       return releasePromise;
     }
-    shared.references--;
-    if (shared.references > 0) {
+    entry.references--;
+    if (entry.references > 0) {
       releasePromise = Promise.resolve();
       return releasePromise;
     }
-    if (runtimePool.get(key) === sharedPromise) {
-      runtimePool.delete(key);
-    }
-    releasePromise = shared.runtime.dispose();
+    entry.closing = (async () => {
+      let failure: Error | undefined;
+      try {
+        await overrides.beforeRuntimeDispose?.();
+      } catch (cause) {
+        failure = new Error("Telemetry runtime disposal preparation failed.", { cause });
+      }
+      try {
+        await shared.runtime.dispose();
+        overrides.onRuntimeDisposed?.();
+      } catch (cause) {
+        failure =
+          failure === undefined
+            ? new Error("Telemetry runtime disposal failed.", { cause })
+            : new AggregateError([failure, cause]);
+      }
+      if (failure !== undefined) {
+        throw failure;
+      }
+    })().finally(() => {
+      if (runtimePool.get(key) === entry) {
+        runtimePool.delete(key);
+      }
+    });
+    releasePromise = entry.closing;
     return releasePromise;
   };
   return { runtime: shared.runtime, flusher: shared.flusher, release };
 };
 
-const makeIntegration = async (options: NormalizedOptions): Promise<TelemetryIntegration> => {
+const acquireApplicationRuntime = async (
+  application: WeakKey,
+  options: EnabledNormalizedOptions,
+  overrides: TelemetryModuleTestingOverrides,
+): Promise<RuntimeLease> => {
+  const key = runtimeKey(options);
+  let state = applicationRuntimes.get(application);
+  if (state !== undefined && state.key !== key) {
+    state.failed = true;
+    await Promise.all(Array.from(state.releases, (release) => release()));
+    applicationRuntimes.delete(application);
+    throw new InvalidTelemetryModuleOptions(
+      new Error("TelemetryModule imports in one application must use one runtime configuration."),
+    );
+  }
+  if (state === undefined) {
+    state = { key, releases: new Set(), failed: false };
+    applicationRuntimes.set(application, state);
+  }
+  await Promise.resolve();
+  if (state.failed) {
+    throw new InvalidTelemetryModuleOptions(
+      new Error("TelemetryModule imports in one application must use one runtime configuration."),
+    );
+  }
+  const lease = await acquireRuntime(options, overrides);
+  if (state.failed) {
+    await lease.release();
+    throw new InvalidTelemetryModuleOptions(
+      new Error("TelemetryModule imports in one application must use one runtime configuration."),
+    );
+  }
+  const release = (): Promise<void> => {
+    state.releases.delete(release);
+    if (state.releases.size === 0) {
+      applicationRuntimes.delete(application);
+    }
+    return lease.release();
+  };
+  state.releases.add(release);
+  return { runtime: lease.runtime, flusher: lease.flusher, release };
+};
+
+const makeIntegration = async (
+  options: NormalizedOptions,
+  application: WeakKey,
+  overrides: TelemetryModuleTestingOverrides,
+): Promise<TelemetryIntegration> => {
   if (!options.enabled) {
     return new DisabledTelemetryIntegration();
   }
-  const lease = await acquireRuntime(options);
-  return new EnabledTelemetryIntegration(lease.runtime, lease.flusher, options, lease.release);
+  const lease = await acquireApplicationRuntime(application, options, overrides);
+  return new EnabledTelemetryIntegration(
+    lease.runtime,
+    lease.flusher,
+    options,
+    lease.release,
+    overrides.beforeRequestDrain ?? (() => undefined),
+  );
 };
+
+const makeTelemetryModule = (
+  options: TelemetryModuleAsyncOptions,
+  overrides: TelemetryModuleTestingOverrides = {},
+): DynamicModule => {
+  const providers: Array<Provider> = [
+    {
+      provide: ASYNC_OPTIONS,
+      inject: options.inject ?? [],
+      useFactory: options.useFactory,
+    },
+    {
+      provide: NORMALIZED_OPTIONS,
+      inject: [ASYNC_OPTIONS],
+      useFactory: parseModuleOptions,
+    },
+    {
+      provide: TELEMETRY_INTEGRATION,
+      inject: [NORMALIZED_OPTIONS, HttpAdapterHost],
+      useFactory: (normalized: NormalizedOptions, application: HttpAdapterHost) =>
+        makeIntegration(normalized, application, overrides),
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      inject: [TELEMETRY_INTEGRATION],
+      useFactory: (integration: TelemetryIntegration) => integration.interceptor,
+    },
+  ];
+  if (options.imports === undefined) {
+    return { module: TelemetryModule, providers };
+  }
+  return { module: TelemetryModule, imports: options.imports, providers };
+};
+
+export const telemetryModuleForTesting = (
+  options: TelemetryModuleAsyncOptions,
+  overrides: TelemetryModuleTestingOverrides,
+): DynamicModule => makeTelemetryModule(options, overrides);
 
 export class TelemetryModule {
   static forRootAsync(options: TelemetryModuleAsyncOptions): DynamicModule {
-    const providers: Array<Provider> = [
-      {
-        provide: ASYNC_OPTIONS,
-        inject: options.inject ?? [],
-        useFactory: options.useFactory,
-      },
-      {
-        provide: NORMALIZED_OPTIONS,
-        inject: [ASYNC_OPTIONS],
-        useFactory: parseModuleOptions,
-      },
-      {
-        provide: TELEMETRY_INTEGRATION,
-        inject: [NORMALIZED_OPTIONS],
-        useFactory: makeIntegration,
-      },
-      {
-        provide: APP_INTERCEPTOR,
-        inject: [TELEMETRY_INTEGRATION],
-        useFactory: (integration: TelemetryIntegration) => integration.interceptor,
-      },
-    ];
-    if (options.imports === undefined) {
-      return { module: TelemetryModule, providers };
-    }
-    return { module: TelemetryModule, imports: options.imports, providers };
+    return makeTelemetryModule(options);
   }
 }
 

--- a/packages/telemetry/src/nestjs/TelemetryModule.ts
+++ b/packages/telemetry/src/nestjs/TelemetryModule.ts
@@ -1,0 +1,395 @@
+import type {
+  BeforeApplicationShutdown,
+  CallHandler,
+  DynamicModule,
+  ExecutionContext,
+  InjectionToken,
+  ModuleMetadata,
+  NestInterceptor,
+  OnApplicationShutdown,
+  OptionalFactoryDependency,
+  Provider,
+} from "@nestjs/common";
+import { Module } from "@nestjs/common";
+import { APP_INTERCEPTOR } from "@nestjs/core";
+import { Duration, Effect, ManagedRuntime, Option, Schema } from "effect";
+import type { OtlpExporter } from "effect/unstable/observability";
+import { OtlpExporter as Otlp } from "effect/unstable/observability";
+import type { Observable } from "rxjs";
+import { layer } from "../Telemetry.ts";
+import { TelemetryConfig } from "../TelemetryConfig.ts";
+import { telemetryRoutePolicy, type ProxyPolicy } from "./HttpRoutePolicy.ts";
+import { TelemetryInterceptor, TelemetryRequestTracker } from "./TelemetryInterceptor.ts";
+
+export type TelemetryModuleOptions =
+  | { readonly enabled: false }
+  | {
+      readonly enabled: true;
+      readonly serviceName: string;
+      readonly serviceVersion: string;
+      readonly environment: string;
+      readonly otlpEndpoint: string;
+      readonly healthRouteTemplates?: ReadonlyArray<string> | undefined;
+      readonly proxyPolicy?: ProxyPolicy | undefined;
+      readonly shutdownTimeoutMilliseconds?: number | undefined;
+    };
+
+export interface TelemetryModuleAsyncOptions extends Pick<ModuleMetadata, "imports"> {
+  readonly inject?: Array<InjectionToken | OptionalFactoryDependency> | undefined;
+  readonly useFactory: (
+    ...dependencies: Array<never>
+  ) => TelemetryModuleOptions | Promise<TelemetryModuleOptions>;
+}
+
+export class InvalidTelemetryModuleOptions extends Error {
+  readonly _tag = "InvalidTelemetryModuleOptions";
+  readonly code = "OBS_TELEMETRY_INVALID_MODULE_OPTIONS";
+  override readonly cause: unknown;
+
+  constructor(cause: unknown) {
+    super(
+      "Telemetry module options are invalid. Provide valid service identity, HTTP OTLP endpoint, route templates, proxy policy, and shutdown timeout.",
+      { cause },
+    );
+    this.name = "InvalidTelemetryModuleOptions";
+    this.cause = cause;
+  }
+}
+
+export class TelemetryStartupError extends Error {
+  readonly _tag = "TelemetryStartupError";
+  readonly code = "OBS_TELEMETRY_STARTUP_FAILED";
+  override readonly cause: unknown;
+
+  constructor(cause: unknown) {
+    super(
+      "Telemetry startup failed. Verify the OTLP transport and runtime configuration before restarting the application.",
+      { cause },
+    );
+    this.name = "TelemetryStartupError";
+    this.cause = cause;
+  }
+}
+
+export class TelemetryShutdownError extends Error {
+  readonly _tag = "TelemetryShutdownError";
+  readonly code = "OBS_TELEMETRY_SHUTDOWN_FAILED";
+  override readonly cause: unknown;
+
+  constructor(cause: unknown) {
+    super(
+      "Telemetry shutdown failed. Telemetry resources were disposed, but the final drain or flush did not complete.",
+      { cause },
+    );
+    this.name = "TelemetryShutdownError";
+    this.cause = cause;
+  }
+}
+
+const Identity = Schema.NonEmptyString.check(
+  Schema.makeFilter((value) => value.trim() === value, { expected: "a nonempty trimmed string" }),
+);
+const Endpoint = Schema.URLFromString.check(
+  Schema.makeFilter(
+    (url) =>
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      url.username === "" &&
+      url.password === "",
+    { expected: "an HTTP or HTTPS URL without credentials" },
+  ),
+);
+const ShutdownTimeout = Schema.Number.check(
+  Schema.isInt(),
+  Schema.makeFilter((value) => Number.isSafeInteger(value) && value > 0, {
+    expected: "a positive safe integer",
+  }),
+);
+const EnabledOptions = Schema.Struct({
+  enabled: Schema.Literal(true),
+  serviceName: Identity,
+  serviceVersion: Identity,
+  environment: Identity,
+  otlpEndpoint: Endpoint,
+  healthRouteTemplates: Schema.Array(Schema.String).pipe(Schema.optionalKey),
+  proxyPolicy: Schema.Literals(["direct", "framework"]).pipe(Schema.optionalKey),
+  shutdownTimeoutMilliseconds: ShutdownTimeout.pipe(Schema.optionalKey),
+});
+const DisabledOptions = Schema.Struct({ enabled: Schema.Literal(false) });
+const ModuleOptions = Schema.Union([DisabledOptions, EnabledOptions]);
+const decodeModuleOptions = Schema.decodeUnknownSync(ModuleOptions);
+
+interface DisabledNormalizedOptions {
+  readonly enabled: false;
+}
+
+interface EnabledNormalizedOptions {
+  readonly enabled: true;
+  readonly config: TelemetryConfig;
+  readonly healthRouteTemplates: ReadonlyArray<string> | undefined;
+  readonly proxyPolicy: ProxyPolicy;
+  readonly shutdownTimeoutMilliseconds: number;
+}
+
+type NormalizedOptions = DisabledNormalizedOptions | EnabledNormalizedOptions;
+
+const parseModuleOptions = (input: TelemetryModuleOptions): NormalizedOptions => {
+  try {
+    const options = decodeModuleOptions(input);
+    if (!options.enabled) {
+      return { enabled: false };
+    }
+    telemetryRoutePolicy({
+      healthRouteTemplates: options.healthRouteTemplates,
+      proxyPolicy: options.proxyPolicy,
+    });
+    return {
+      enabled: true,
+      config: new TelemetryConfig({
+        serviceName: options.serviceName,
+        serviceVersion: options.serviceVersion,
+        environment: options.environment,
+        otlpEndpoint: options.otlpEndpoint,
+      }),
+      healthRouteTemplates: options.healthRouteTemplates,
+      proxyPolicy: options.proxyPolicy ?? "direct",
+      shutdownTimeoutMilliseconds: options.shutdownTimeoutMilliseconds ?? 5_000,
+    };
+  } catch (cause) {
+    throw new InvalidTelemetryModuleOptions(cause);
+  }
+};
+
+class DisabledTelemetryInterceptor implements NestInterceptor {
+  intercept(_context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    return next.handle();
+  }
+}
+
+interface TelemetryIntegration extends BeforeApplicationShutdown, OnApplicationShutdown {
+  readonly interceptor: NestInterceptor;
+}
+
+class DisabledTelemetryIntegration implements TelemetryIntegration {
+  readonly interceptor = new DisabledTelemetryInterceptor();
+
+  beforeApplicationShutdown(): void {}
+
+  onApplicationShutdown(): void {}
+}
+
+class EnabledTelemetryIntegration implements TelemetryIntegration {
+  readonly interceptor: NestInterceptor;
+  readonly #runtime: ManagedRuntime.ManagedRuntime<OtlpExporter.Flusher, never>;
+  readonly #flusher: OtlpExporter.Flusher["Service"];
+  readonly #requestTracker: TelemetryRequestTracker;
+  readonly #shutdownTimeoutMilliseconds: number;
+  readonly #releaseRuntime: () => Promise<void>;
+  #shutdownPromise: Promise<void> | undefined;
+  #disposePromise: Promise<void> | undefined;
+  #shutdownError: TelemetryShutdownError | undefined;
+
+  constructor(
+    runtime: ManagedRuntime.ManagedRuntime<OtlpExporter.Flusher, never>,
+    flusher: OtlpExporter.Flusher["Service"],
+    options: EnabledNormalizedOptions,
+    releaseRuntime: () => Promise<void>,
+  ) {
+    this.#runtime = runtime;
+    this.#flusher = flusher;
+    this.#releaseRuntime = releaseRuntime;
+    this.#requestTracker = new TelemetryRequestTracker();
+    this.#shutdownTimeoutMilliseconds = options.shutdownTimeoutMilliseconds;
+    this.interceptor = new TelemetryInterceptor(runtime, {
+      healthRouteTemplates: options.healthRouteTemplates,
+      proxyPolicy: options.proxyPolicy,
+      requestTracker: this.#requestTracker,
+    });
+  }
+
+  beforeApplicationShutdown(): Promise<void> {
+    this.#shutdownPromise ??= this.#shutdown();
+    return this.#shutdownPromise;
+  }
+
+  async onApplicationShutdown(): Promise<void> {
+    await this.beforeApplicationShutdown();
+    this.#disposePromise ??= this.#releaseRuntime();
+    try {
+      await this.#disposePromise;
+    } catch (cause) {
+      this.#shutdownError ??= new TelemetryShutdownError(cause);
+    }
+    if (this.#shutdownError !== undefined) {
+      throw this.#shutdownError;
+    }
+  }
+
+  async #shutdown(): Promise<void> {
+    const deadline = Date.now() + this.#shutdownTimeoutMilliseconds;
+    this.#requestTracker.closeAdmission();
+    const idle = await this.#withinDeadline(this.#requestTracker.waitForIdle(), deadline);
+    if (!idle) {
+      this.#requestTracker.interruptActive();
+      await this.#requestTracker.waitForIdle();
+    }
+    const remaining = Math.max(0, deadline - Date.now());
+    if (remaining === 0) {
+      this.#shutdownError = new TelemetryShutdownError(
+        new Error("The telemetry request drain exhausted the shutdown deadline."),
+      );
+      return;
+    }
+    try {
+      const flushed = await this.#runtime.runPromise(
+        this.#flusher.flush.pipe(Effect.timeoutOption(Duration.millis(remaining))),
+      );
+      if (Option.isNone(flushed)) {
+        this.#shutdownError = new TelemetryShutdownError(
+          new Error("The telemetry flush exceeded the shutdown deadline."),
+        );
+      }
+    } catch (cause) {
+      this.#shutdownError = new TelemetryShutdownError(cause);
+    }
+  }
+
+  async #withinDeadline(operation: Promise<void>, deadline: number): Promise<boolean> {
+    const remaining = Math.max(0, deadline - Date.now());
+    if (remaining === 0) {
+      return false;
+    }
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<boolean>((resolve) => {
+      timer = setTimeout(() => resolve(false), remaining);
+    });
+    const completed = operation.then(() => true);
+    try {
+      return await Promise.race([completed, timeout]);
+    } finally {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
+    }
+  }
+}
+
+const ASYNC_OPTIONS = Symbol("TelemetryModuleAsyncOptions");
+const NORMALIZED_OPTIONS = Symbol("TelemetryModuleNormalizedOptions");
+const TELEMETRY_INTEGRATION = Symbol("TelemetryModuleIntegration");
+
+interface SharedRuntime {
+  readonly runtime: ManagedRuntime.ManagedRuntime<OtlpExporter.Flusher, never>;
+  readonly flusher: OtlpExporter.Flusher["Service"];
+  references: number;
+}
+
+interface RuntimeLease {
+  readonly runtime: ManagedRuntime.ManagedRuntime<OtlpExporter.Flusher, never>;
+  readonly flusher: OtlpExporter.Flusher["Service"];
+  readonly release: () => Promise<void>;
+}
+
+const runtimePool = new Map<string, Promise<SharedRuntime>>();
+
+const runtimeKey = (options: EnabledNormalizedOptions): string =>
+  JSON.stringify([
+    options.config.otlpEndpoint.toString(),
+    options.config.serviceName,
+    options.config.serviceVersion,
+    options.config.environment,
+    options.shutdownTimeoutMilliseconds,
+  ]);
+
+const createSharedRuntime = async (options: EnabledNormalizedOptions): Promise<SharedRuntime> => {
+  const runtime = ManagedRuntime.make(
+    layer(options.config, {
+      shutdownTimeout: Duration.millis(options.shutdownTimeoutMilliseconds),
+    }),
+  );
+  try {
+    await runtime.context();
+    const flusher = await runtime.runPromise(Otlp.Flusher);
+    return { runtime, flusher, references: 0 };
+  } catch (cause) {
+    try {
+      await runtime.dispose();
+    } catch (disposeCause) {
+      throw new TelemetryStartupError(new AggregateError([cause, disposeCause]));
+    }
+    throw new TelemetryStartupError(cause);
+  }
+};
+
+const acquireRuntime = async (options: EnabledNormalizedOptions): Promise<RuntimeLease> => {
+  const key = runtimeKey(options);
+  let sharedPromise = runtimePool.get(key);
+  if (sharedPromise === undefined) {
+    sharedPromise = createSharedRuntime(options);
+    runtimePool.set(key, sharedPromise);
+    sharedPromise.catch(() => {
+      if (runtimePool.get(key) === sharedPromise) {
+        runtimePool.delete(key);
+      }
+    });
+  }
+  const shared = await sharedPromise;
+  shared.references++;
+  let releasePromise: Promise<void> | undefined;
+  const release = (): Promise<void> => {
+    if (releasePromise !== undefined) {
+      return releasePromise;
+    }
+    shared.references--;
+    if (shared.references > 0) {
+      releasePromise = Promise.resolve();
+      return releasePromise;
+    }
+    if (runtimePool.get(key) === sharedPromise) {
+      runtimePool.delete(key);
+    }
+    releasePromise = shared.runtime.dispose();
+    return releasePromise;
+  };
+  return { runtime: shared.runtime, flusher: shared.flusher, release };
+};
+
+const makeIntegration = async (options: NormalizedOptions): Promise<TelemetryIntegration> => {
+  if (!options.enabled) {
+    return new DisabledTelemetryIntegration();
+  }
+  const lease = await acquireRuntime(options);
+  return new EnabledTelemetryIntegration(lease.runtime, lease.flusher, options, lease.release);
+};
+
+export class TelemetryModule {
+  static forRootAsync(options: TelemetryModuleAsyncOptions): DynamicModule {
+    const providers: Array<Provider> = [
+      {
+        provide: ASYNC_OPTIONS,
+        inject: options.inject ?? [],
+        useFactory: options.useFactory,
+      },
+      {
+        provide: NORMALIZED_OPTIONS,
+        inject: [ASYNC_OPTIONS],
+        useFactory: parseModuleOptions,
+      },
+      {
+        provide: TELEMETRY_INTEGRATION,
+        inject: [NORMALIZED_OPTIONS],
+        useFactory: makeIntegration,
+      },
+      {
+        provide: APP_INTERCEPTOR,
+        inject: [TELEMETRY_INTEGRATION],
+        useFactory: (integration: TelemetryIntegration) => integration.interceptor,
+      },
+    ];
+    if (options.imports === undefined) {
+      return { module: TelemetryModule, providers };
+    }
+    return { module: TelemetryModule, imports: options.imports, providers };
+  }
+}
+
+Module({})(TelemetryModule);

--- a/packages/telemetry/src/nestjs/index.ts
+++ b/packages/telemetry/src/nestjs/index.ts
@@ -13,3 +13,11 @@ export {
   type TelemetryInterceptorOptions,
 } from "./TelemetryInterceptor.ts";
 export type { ProxyPolicy, TelemetryRoutePolicyOptions } from "./HttpRoutePolicy.ts";
+export {
+  InvalidTelemetryModuleOptions,
+  TelemetryModule,
+  TelemetryShutdownError,
+  TelemetryStartupError,
+  type TelemetryModuleAsyncOptions,
+  type TelemetryModuleOptions,
+} from "./TelemetryModule.ts";

--- a/packages/telemetry/test/nestjs-module.test.ts
+++ b/packages/telemetry/test/nestjs-module.test.ts
@@ -265,7 +265,7 @@ describe("TelemetryModule", () => {
   it("wraps startup failure, disposes partial runtime resources, and preserves its cause", async () => {
     const capture = await makeOtlpCapture();
     const startupCause = new Error("startup probe failed");
-    let disposals = 0;
+    const lifecycle: Array<string> = [];
 
     class AppModule {}
     Module({
@@ -273,28 +273,43 @@ describe("TelemetryModule", () => {
         telemetryModuleForTesting(
           { useFactory: () => enabledOptions(capture.endpoint) },
           {
+            scopedResource: {
+              acquire: () => {
+                lifecycle.push("resource-acquired");
+              },
+              release: () => {
+                lifecycle.push("resource-finalized");
+              },
+            },
             startupProbe: () => {
+              lifecycle.push("startup-probe");
+              assert.deepStrictEqual(lifecycle, ["resource-acquired", "startup-probe"]);
               throw startupCause;
             },
-            onRuntimeDisposed: () => disposals++,
           },
         ),
       ],
     })(AppModule);
 
+    const app = await NestFactory.create(AppModule, {
+      logger: false,
+      abortOnError: false,
+    });
     try {
-      const failure = await NestFactory.create(AppModule, {
-        logger: false,
-        abortOnError: false,
-      }).then(
+      const failure = await app.init().then(
         () => undefined,
         (cause) => cause,
       );
       assert.instanceOf(failure, TelemetryStartupError);
       assert.strictEqual(failure?.code, "OBS_TELEMETRY_STARTUP_FAILED");
       assert.strictEqual(failure?.cause, startupCause);
-      assert.strictEqual(disposals, 1);
+      assert.deepStrictEqual(lifecycle, [
+        "resource-acquired",
+        "startup-probe",
+        "resource-finalized",
+      ]);
     } finally {
+      await app.close().catch(() => undefined);
       await capture.close();
     }
   });
@@ -354,34 +369,47 @@ describe("TelemetryModule", () => {
 
   it("rejects duplicate imports with different runtime configurations", async () => {
     const capture = await makeOtlpCapture();
-    let disposals = 0;
+    let resourceAcquisitions = 0;
+    const acquisitionResource = {
+      acquire: () => {
+        resourceAcquisitions++;
+      },
+      release: () => undefined,
+    };
 
     class AppModule {}
     Module({
       imports: [
         telemetryModuleForTesting(
           { useFactory: () => enabledOptions(capture.endpoint) },
-          { onRuntimeDisposed: () => disposals++ },
+          { scopedResource: acquisitionResource },
         ),
         telemetryModuleForTesting(
-          { useFactory: () => enabledOptions(`${capture.endpoint}/alternate`) },
-          { onRuntimeDisposed: () => disposals++ },
+          {
+            useFactory: async () => {
+              await new Promise((resolve) => setTimeout(resolve, 50));
+              return enabledOptions(`${capture.endpoint}/alternate`);
+            },
+          },
+          { scopedResource: acquisitionResource },
         ),
       ],
     })(AppModule);
 
+    const app = await NestFactory.create(AppModule, {
+      logger: false,
+      abortOnError: false,
+    });
     try {
-      const failure = await NestFactory.create(AppModule, {
-        logger: false,
-        abortOnError: false,
-      }).then(
+      const failure = await app.init().then(
         () => undefined,
         (cause) => cause,
       );
       assert.instanceOf(failure, InvalidTelemetryModuleOptions);
       assert.strictEqual(failure?.code, "OBS_TELEMETRY_INVALID_MODULE_OPTIONS");
-      assert.strictEqual(disposals, 0);
+      assert.strictEqual(resourceAcquisitions, 0);
     } finally {
+      await app.close().catch(() => undefined);
       await capture.close();
     }
   });
@@ -412,6 +440,7 @@ describe("TelemetryModule", () => {
       ],
     })(FirstModule);
     const first = await NestFactory.create(FirstModule, { logger: false });
+    await first.init();
     const firstClose = first.close();
     await disposalStarted;
 
@@ -422,7 +451,8 @@ describe("TelemetryModule", () => {
       ],
     })(SecondModule);
     let secondStarted = false;
-    const secondCreation = NestFactory.create(SecondModule, { logger: false }).then((app) => {
+    const secondCreation = NestFactory.create(SecondModule, { logger: false }).then(async (app) => {
+      await app.init();
       secondStarted = true;
       return app;
     });
@@ -456,6 +486,7 @@ describe("TelemetryModule", () => {
     })(AppModule);
 
     const app = await NestFactory.create(AppModule, { logger: false });
+    await app.init();
     try {
       const failure = await app.close().then(
         () => undefined,
@@ -490,6 +521,7 @@ describe("TelemetryModule", () => {
     })(AppModule);
 
     const app = await NestFactory.create(AppModule, { logger: false });
+    await app.init();
     try {
       const failure = await app.close().then(
         () => undefined,

--- a/packages/telemetry/test/nestjs-module.test.ts
+++ b/packages/telemetry/test/nestjs-module.test.ts
@@ -9,8 +9,10 @@ import {
   InvalidTelemetryModuleOptions,
   TelemetryModule,
   TelemetryShutdownError,
+  TelemetryStartupError,
   type TelemetryModuleOptions,
 } from "../src/nestjs/index.ts";
+import { telemetryModuleForTesting } from "../src/nestjs/TelemetryModule.ts";
 
 const AddressBoundary = Schema.Struct({ port: Schema.Number });
 const decodeAddress = Schema.decodeUnknownSync(AddressBoundary);
@@ -163,6 +165,47 @@ describe("TelemetryModule", () => {
     }
   }, 30_000);
 
+  it("accepts explicit undefined optional configuration and applies defaults", async () => {
+    const capture = await makeOtlpCapture();
+    const ModuleController = makeController();
+
+    class AppModule {}
+    Module({
+      imports: [
+        TelemetryModule.forRootAsync({
+          imports: undefined,
+          inject: undefined,
+          useFactory: () => ({
+            enabled: true,
+            serviceName: "nestjs-undefined-test",
+            serviceVersion: "1.0.0",
+            environment: "test",
+            otlpEndpoint: capture.endpoint,
+            healthRouteTemplates: undefined,
+            proxyPolicy: undefined,
+            shutdownTimeoutMilliseconds: undefined,
+          }),
+        }),
+      ],
+      controllers: [ModuleController],
+    })(AppModule);
+
+    const app = await NestFactory.create(AppModule, { logger: false });
+    await app.listen(0, "127.0.0.1");
+    try {
+      const response = await fetch(`${applicationBaseUrl(app.getHttpServer().address())}/ping`);
+      assert.strictEqual(response.status, 200);
+      await app.close();
+      assert.lengthOf(
+        capture.requests.filter((request) => request.path === "/v1/traces"),
+        1,
+      );
+    } finally {
+      await app.close().catch(() => undefined);
+      await capture.close();
+    }
+  });
+
   it("keeps disabled mode inert without identity, timers, or network requests", async () => {
     const capture = await makeOtlpCapture();
     const ModuleController = makeController();
@@ -219,6 +262,43 @@ describe("TelemetryModule", () => {
     assert.strictEqual(failure?.code, "OBS_TELEMETRY_INVALID_MODULE_OPTIONS");
   });
 
+  it("wraps startup failure, disposes partial runtime resources, and preserves its cause", async () => {
+    const capture = await makeOtlpCapture();
+    const startupCause = new Error("startup probe failed");
+    let disposals = 0;
+
+    class AppModule {}
+    Module({
+      imports: [
+        telemetryModuleForTesting(
+          { useFactory: () => enabledOptions(capture.endpoint) },
+          {
+            startupProbe: () => {
+              throw startupCause;
+            },
+            onRuntimeDisposed: () => disposals++,
+          },
+        ),
+      ],
+    })(AppModule);
+
+    try {
+      const failure = await NestFactory.create(AppModule, {
+        logger: false,
+        abortOnError: false,
+      }).then(
+        () => undefined,
+        (cause) => cause,
+      );
+      assert.instanceOf(failure, TelemetryStartupError);
+      assert.strictEqual(failure?.code, "OBS_TELEMETRY_STARTUP_FAILED");
+      assert.strictEqual(failure?.cause, startupCause);
+      assert.strictEqual(disposals, 1);
+    } finally {
+      await capture.close();
+    }
+  });
+
   it("propagates an async configuration factory rejection unchanged", async () => {
     const factoryFailure = new Error("configuration service unavailable");
 
@@ -272,19 +352,175 @@ describe("TelemetryModule", () => {
     }
   }, 30_000);
 
+  it("rejects duplicate imports with different runtime configurations", async () => {
+    const capture = await makeOtlpCapture();
+    let disposals = 0;
+
+    class AppModule {}
+    Module({
+      imports: [
+        telemetryModuleForTesting(
+          { useFactory: () => enabledOptions(capture.endpoint) },
+          { onRuntimeDisposed: () => disposals++ },
+        ),
+        telemetryModuleForTesting(
+          { useFactory: () => enabledOptions(`${capture.endpoint}/alternate`) },
+          { onRuntimeDisposed: () => disposals++ },
+        ),
+      ],
+    })(AppModule);
+
+    try {
+      const failure = await NestFactory.create(AppModule, {
+        logger: false,
+        abortOnError: false,
+      }).then(
+        () => undefined,
+        (cause) => cause,
+      );
+      assert.instanceOf(failure, InvalidTelemetryModuleOptions);
+      assert.strictEqual(failure?.code, "OBS_TELEMETRY_INVALID_MODULE_OPTIONS");
+      assert.strictEqual(disposals, 0);
+    } finally {
+      await capture.close();
+    }
+  });
+
+  it("fences runtime acquisition until the last release finishes", async () => {
+    const capture = await makeOtlpCapture();
+    let beginDisposal: (() => void) | undefined;
+    const disposalStarted = new Promise<void>((resolve) => {
+      beginDisposal = resolve;
+    });
+    let finishDisposal: (() => void) | undefined;
+    const disposalGate = new Promise<void>((resolve) => {
+      finishDisposal = resolve;
+    });
+
+    class FirstModule {}
+    Module({
+      imports: [
+        telemetryModuleForTesting(
+          { useFactory: () => enabledOptions(capture.endpoint) },
+          {
+            beforeRuntimeDispose: async () => {
+              beginDisposal?.();
+              await disposalGate;
+            },
+          },
+        ),
+      ],
+    })(FirstModule);
+    const first = await NestFactory.create(FirstModule, { logger: false });
+    const firstClose = first.close();
+    await disposalStarted;
+
+    class SecondModule {}
+    Module({
+      imports: [
+        TelemetryModule.forRootAsync({ useFactory: () => enabledOptions(capture.endpoint) }),
+      ],
+    })(SecondModule);
+    let secondStarted = false;
+    const secondCreation = NestFactory.create(SecondModule, { logger: false }).then((app) => {
+      secondStarted = true;
+      return app;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.isFalse(secondStarted);
+    finishDisposal?.();
+    await firstClose;
+    const second = await secondCreation;
+    assert.isTrue(secondStarted);
+    await second.close();
+    await capture.close();
+  });
+
+  it("disposes the runtime after a drain failure and reports a typed shutdown failure", async () => {
+    const capture = await makeOtlpCapture();
+    let disposals = 0;
+
+    class AppModule {}
+    Module({
+      imports: [
+        telemetryModuleForTesting(
+          { useFactory: () => enabledOptions(capture.endpoint) },
+          {
+            beforeRequestDrain: () => {
+              throw new Error("request drain failed");
+            },
+            onRuntimeDisposed: () => disposals++,
+          },
+        ),
+      ],
+    })(AppModule);
+
+    const app = await NestFactory.create(AppModule, { logger: false });
+    try {
+      const failure = await app.close().then(
+        () => undefined,
+        (cause) => cause,
+      );
+      assert.instanceOf(failure, TelemetryShutdownError);
+      assert.strictEqual(failure?.code, "OBS_TELEMETRY_SHUTDOWN_FAILED");
+      assert.strictEqual(disposals, 1);
+    } finally {
+      await app.close().catch(() => undefined);
+      await capture.close();
+    }
+  });
+
+  it("reports disposal preparation failure only after runtime disposal completes", async () => {
+    const capture = await makeOtlpCapture();
+    let disposals = 0;
+
+    class AppModule {}
+    Module({
+      imports: [
+        telemetryModuleForTesting(
+          { useFactory: () => enabledOptions(capture.endpoint) },
+          {
+            beforeRuntimeDispose: () => {
+              throw new Error("disposal preparation failed");
+            },
+            onRuntimeDisposed: () => disposals++,
+          },
+        ),
+      ],
+    })(AppModule);
+
+    const app = await NestFactory.create(AppModule, { logger: false });
+    try {
+      const failure = await app.close().then(
+        () => undefined,
+        (cause) => cause,
+      );
+      assert.instanceOf(failure, TelemetryShutdownError);
+      assert.strictEqual(failure?.code, "OBS_TELEMETRY_SHUTDOWN_FAILED");
+      assert.strictEqual(disposals, 1);
+    } finally {
+      await app.close().catch(() => undefined);
+      await capture.close();
+    }
+  });
+
   it("bounds a stalled flush, disposes the runtime, and reports a typed shutdown failure", async () => {
     const capture = await makeOtlpCapture(1_000);
+    let disposals = 0;
     const ModuleController = makeController();
 
     class AppModule {}
     Module({
       imports: [
-        TelemetryModule.forRootAsync({
-          useFactory: () => ({
-            ...enabledOptions(capture.endpoint),
-            shutdownTimeoutMilliseconds: 25,
-          }),
-        }),
+        telemetryModuleForTesting(
+          {
+            useFactory: () => ({
+              ...enabledOptions(capture.endpoint),
+              shutdownTimeoutMilliseconds: 25,
+            }),
+          },
+          { onRuntimeDisposed: () => disposals++ },
+        ),
       ],
       controllers: [ModuleController],
     })(AppModule);
@@ -300,6 +536,7 @@ describe("TelemetryModule", () => {
       );
       assert.instanceOf(failure, TelemetryShutdownError);
       assert.strictEqual(failure?.code, "OBS_TELEMETRY_SHUTDOWN_FAILED");
+      assert.strictEqual(disposals, 1);
     } finally {
       await app.close().catch(() => undefined);
       await capture.close();

--- a/packages/telemetry/test/nestjs-module.test.ts
+++ b/packages/telemetry/test/nestjs-module.test.ts
@@ -1,0 +1,308 @@
+import "reflect-metadata";
+import { Controller, Get, Module } from "@nestjs/common";
+import { NestFactory } from "@nestjs/core";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { Schema } from "effect";
+import { assert, describe, it } from "vite-plus/test";
+import {
+  InvalidTelemetryModuleOptions,
+  TelemetryModule,
+  TelemetryShutdownError,
+  type TelemetryModuleOptions,
+} from "../src/nestjs/index.ts";
+
+const AddressBoundary = Schema.Struct({ port: Schema.Number });
+const decodeAddress = Schema.decodeUnknownSync(AddressBoundary);
+
+const methodDescriptor = <Prototype extends WeakKey>(
+  prototype: Prototype,
+  method: string,
+): PropertyDescriptor => {
+  const descriptor = Object.getOwnPropertyDescriptor(prototype, method);
+  if (descriptor === undefined) {
+    throw new Error(`The method ${method} does not exist on the controller.`);
+  }
+  return descriptor;
+};
+
+const applicationBaseUrl = (address: string | AddressInfo | null): string =>
+  `http://127.0.0.1:${decodeAddress(address).port}`;
+
+interface OtlpRequest {
+  readonly path: string;
+  readonly body: string;
+}
+
+interface OtlpCapture {
+  readonly endpoint: string;
+  readonly requests: Array<OtlpRequest>;
+  readonly close: () => Promise<void>;
+}
+
+const makeOtlpCapture = async (delayMilliseconds = 0): Promise<OtlpCapture> => {
+  const requests: Array<OtlpRequest> = [];
+  const server = createServer((request, response) => {
+    const chunks: Array<Buffer> = [];
+    request.on("data", (chunk: Buffer) => chunks.push(chunk));
+    request.on("end", () => {
+      requests.push({ path: request.url ?? "", body: Buffer.concat(chunks).toString("utf8") });
+      setTimeout(() => {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end("{}");
+      }, delayMilliseconds);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = decodeAddress(server.address());
+  return {
+    endpoint: `http://127.0.0.1:${address.port}`,
+    requests,
+    close: () =>
+      new Promise((resolve, reject) =>
+        server.close((cause) => (cause === undefined ? resolve() : reject(cause))),
+      ),
+  };
+};
+
+const makeController = () => {
+  class ModuleController {
+    ping(): { readonly ok: boolean } {
+      return { ok: true };
+    }
+
+    health(): { readonly ok: boolean } {
+      return { ok: true };
+    }
+
+    ready(): { readonly ok: boolean } {
+      return { ok: true };
+    }
+
+    telemetry(): { readonly accepted: boolean } {
+      return { accepted: true };
+    }
+  }
+  Controller()(ModuleController);
+  for (const method of ["ping", "health", "ready"] as const) {
+    Get(method)(
+      ModuleController.prototype,
+      method,
+      methodDescriptor(ModuleController.prototype, method),
+    );
+  }
+  Get("_telemetry/events")(
+    ModuleController.prototype,
+    "telemetry",
+    methodDescriptor(ModuleController.prototype, "telemetry"),
+  );
+  return ModuleController;
+};
+
+const enabledOptions = (endpoint: string): TelemetryModuleOptions => ({
+  enabled: true,
+  serviceName: "nestjs-module-test",
+  serviceVersion: "1.0.0",
+  environment: "test",
+  otlpEndpoint: endpoint,
+  healthRouteTemplates: ["/ready/"],
+  shutdownTimeoutMilliseconds: 2_000,
+});
+
+describe("TelemetryModule", () => {
+  it("uses async dependency injection, registers globally, excludes health traffic, and flushes on close", async () => {
+    const capture = await makeOtlpCapture();
+    const CONFIG = Symbol("TelemetryConfig");
+    const ModuleController = makeController();
+
+    class ConfigModule {}
+    Module({
+      providers: [{ provide: CONFIG, useValue: enabledOptions(capture.endpoint) }],
+      exports: [CONFIG],
+    })(ConfigModule);
+
+    class AppModule {}
+    Module({
+      imports: [
+        TelemetryModule.forRootAsync({
+          imports: [ConfigModule],
+          inject: [CONFIG],
+          useFactory: async (options: TelemetryModuleOptions) => options,
+        }),
+      ],
+      controllers: [ModuleController],
+    })(AppModule);
+
+    const app = await NestFactory.create(AppModule, { logger: false });
+    await app.listen(0, "127.0.0.1");
+    const baseUrl = applicationBaseUrl(app.getHttpServer().address());
+    try {
+      for (const path of ["/ping", "/health", "/ready", "/_telemetry/events"]) {
+        const response = await fetch(`${baseUrl}${path}`);
+        assert.strictEqual(response.status, 200);
+      }
+      assert.lengthOf(
+        capture.requests.filter((request) => request.path === "/v1/traces"),
+        0,
+      );
+      await app.close();
+
+      const traceRequests = capture.requests.filter((request) => request.path === "/v1/traces");
+      assert.lengthOf(traceRequests, 1);
+      assert.include(traceRequests[0]?.body, '"name":"GET /ping"');
+      assert.notInclude(traceRequests[0]?.body, "GET /health");
+      assert.notInclude(traceRequests[0]?.body, "GET /ready");
+      assert.notInclude(traceRequests[0]?.body, "GET /_telemetry/events");
+      assert.include(
+        traceRequests[0]?.body,
+        '"service.name","value":{"stringValue":"nestjs-module-test"}',
+      );
+    } finally {
+      await app.close().catch(() => undefined);
+      await capture.close();
+    }
+  }, 30_000);
+
+  it("keeps disabled mode inert without identity, timers, or network requests", async () => {
+    const capture = await makeOtlpCapture();
+    const ModuleController = makeController();
+
+    class AppModule {}
+    Module({
+      imports: [
+        TelemetryModule.forRootAsync({
+          useFactory: () => ({ enabled: false }),
+        }),
+      ],
+      controllers: [ModuleController],
+    })(AppModule);
+
+    const app = await NestFactory.create(AppModule, { logger: false });
+    await app.listen(0, "127.0.0.1");
+    try {
+      const response = await fetch(`${applicationBaseUrl(app.getHttpServer().address())}/ping`);
+      assert.strictEqual(response.status, 200);
+      await app.close();
+      assert.lengthOf(capture.requests, 0);
+    } finally {
+      await app.close().catch(() => undefined);
+      await capture.close();
+    }
+  });
+
+  it("rejects invalid configuration during bootstrap with the public typed error", async () => {
+    class AppModule {}
+    Module({
+      imports: [
+        TelemetryModule.forRootAsync({
+          useFactory: () => ({
+            enabled: true,
+            serviceName: "",
+            serviceVersion: "1.0.0",
+            environment: "test",
+            otlpEndpoint: "https://user:secret@example.test",
+            healthRouteTemplates: ["health?token=secret"],
+            shutdownTimeoutMilliseconds: 0,
+          }),
+        }),
+      ],
+    })(AppModule);
+
+    const failure = await NestFactory.create(AppModule, {
+      logger: false,
+      abortOnError: false,
+    }).then(
+      () => undefined,
+      (cause) => cause,
+    );
+    assert.instanceOf(failure, InvalidTelemetryModuleOptions);
+    assert.strictEqual(failure?.code, "OBS_TELEMETRY_INVALID_MODULE_OPTIONS");
+  });
+
+  it("propagates an async configuration factory rejection unchanged", async () => {
+    const factoryFailure = new Error("configuration service unavailable");
+
+    class AppModule {}
+    Module({
+      imports: [
+        TelemetryModule.forRootAsync({
+          useFactory: async () => Promise.reject(factoryFailure),
+        }),
+      ],
+    })(AppModule);
+
+    const failure = await NestFactory.create(AppModule, {
+      logger: false,
+      abortOnError: false,
+    }).then(
+      () => undefined,
+      (cause) => cause,
+    );
+    assert.strictEqual(failure, factoryFailure);
+  });
+
+  it("deduplicates repeated module imports and tolerates concurrent shutdown", async () => {
+    const capture = await makeOtlpCapture();
+    const ModuleController = makeController();
+    const firstTelemetryModule = TelemetryModule.forRootAsync({
+      useFactory: () => enabledOptions(capture.endpoint),
+    });
+    const secondTelemetryModule = TelemetryModule.forRootAsync({
+      useFactory: async () => enabledOptions(capture.endpoint),
+    });
+
+    class AppModule {}
+    Module({
+      imports: [firstTelemetryModule, secondTelemetryModule],
+      controllers: [ModuleController],
+    })(AppModule);
+
+    const app = await NestFactory.create(AppModule, { logger: false });
+    await app.listen(0, "127.0.0.1");
+    try {
+      const response = await fetch(`${applicationBaseUrl(app.getHttpServer().address())}/ping`);
+      assert.strictEqual(response.status, 200);
+      await Promise.all([app.close(), app.close()]);
+      const traceRequests = capture.requests.filter((request) => request.path === "/v1/traces");
+      assert.lengthOf(traceRequests, 1);
+      assert.strictEqual(traceRequests[0]?.body.split('"name":"GET /ping"').length, 2);
+    } finally {
+      await app.close().catch(() => undefined);
+      await capture.close();
+    }
+  }, 30_000);
+
+  it("bounds a stalled flush, disposes the runtime, and reports a typed shutdown failure", async () => {
+    const capture = await makeOtlpCapture(1_000);
+    const ModuleController = makeController();
+
+    class AppModule {}
+    Module({
+      imports: [
+        TelemetryModule.forRootAsync({
+          useFactory: () => ({
+            ...enabledOptions(capture.endpoint),
+            shutdownTimeoutMilliseconds: 25,
+          }),
+        }),
+      ],
+      controllers: [ModuleController],
+    })(AppModule);
+
+    const app = await NestFactory.create(AppModule, { logger: false });
+    await app.listen(0, "127.0.0.1");
+    try {
+      const response = await fetch(`${applicationBaseUrl(app.getHttpServer().address())}/ping`);
+      assert.strictEqual(response.status, 200);
+      const failure = await app.close().then(
+        () => undefined,
+        (cause) => cause,
+      );
+      assert.instanceOf(failure, TelemetryShutdownError);
+      assert.strictEqual(failure?.code, "OBS_TELEMETRY_SHUTDOWN_FAILED");
+    } finally {
+      await app.close().catch(() => undefined);
+      await capture.close();
+    }
+  }, 30_000);
+});

--- a/scripts/package-smoke.ts
+++ b/scripts/package-smoke.ts
@@ -115,6 +115,54 @@ try {
     assertArchive(listing.stdout, packageSpec.required, ["package/src/", "package/test/"]);
   }
 
+  for (const nestMajor of [10, 11]) {
+    const nestConsumer = join(temporaryDirectory, `nestjs-${nestMajor}-consumer`);
+    await mkdir(nestConsumer, { recursive: true });
+    await writeFile(
+      join(nestConsumer, "package.json"),
+      JSON.stringify({
+        private: true,
+        type: "module",
+        dependencies: {
+          "@equipe-tech/observability": `file:${join(temporaryDirectory, "telemetry.tgz")}`,
+          "@nestjs/common": `^${nestMajor}.0.0`,
+          "@nestjs/core": `^${nestMajor}.0.0`,
+          "@nestjs/platform-express": `^${nestMajor}.0.0`,
+          "reflect-metadata": "^0.2.2",
+          rxjs: "^7.8.2",
+        },
+      }),
+    );
+    requireSuccess(
+      await run(["bun", "install"], nestConsumer),
+      `Installing the Nest ${nestMajor} packed consumer`,
+    );
+    for (const nestPackage of ["common", "core", "platform-express"]) {
+      const manifest: unknown = JSON.parse(
+        await readFile(
+          join(nestConsumer, "node_modules/@nestjs", nestPackage, "package.json"),
+          "utf8",
+        ),
+      );
+      const version = Schema.decodeUnknownSync(Schema.Struct({ version: Schema.NonEmptyString }))(
+        manifest,
+      ).version;
+      if (!version.startsWith(`${nestMajor}.`)) {
+        throw new Error(
+          `The Nest ${nestMajor} matrix installed @nestjs/${nestPackage} ${version}.`,
+        );
+      }
+    }
+    await writeFile(
+      join(nestConsumer, "app.ts"),
+      "import 'reflect-metadata';\nimport { Controller, Get, Module } from '@nestjs/common';\nimport { NestFactory } from '@nestjs/core';\nimport { TelemetryModule } from '@equipe-tech/observability/nestjs';\nclass AppController { ping() { return { ok: true }; } }\nController()(AppController);\nconst descriptor = Object.getOwnPropertyDescriptor(AppController.prototype, 'ping');\nif (!descriptor) throw new Error('Missing ping descriptor.');\nGet('ping')(AppController.prototype, 'ping', descriptor);\nclass AppModule {}\nModule({ imports: [TelemetryModule.forRootAsync({ useFactory: async () => ({ enabled: false }) })], controllers: [AppController] })(AppModule);\nconst app = await NestFactory.create(AppModule, { logger: false });\nawait app.listen(0, '127.0.0.1');\nconst address = app.getHttpServer().address();\nif (!address || typeof address === 'string') throw new Error('Missing server address.');\nconst response = await fetch(`http://127.0.0.1:${address.port}/ping`);\nif (response.status !== 200 || (await response.json()).ok !== true) throw new Error('Packed Nest request failed.');\nawait app.close();\n",
+    );
+    requireSuccess(
+      await run(["bun", "app.ts"], nestConsumer),
+      `Executing the Nest ${nestMajor} packed consumer`,
+    );
+  }
+
   const consumer = join(temporaryDirectory, "consumer outside repository");
   await mkdir(consumer, { recursive: true });
   await writeFile(

--- a/scripts/package-smoke.ts
+++ b/scripts/package-smoke.ts
@@ -128,6 +128,7 @@ try {
           "@nestjs/common": `^${nestMajor}.0.0`,
           "@nestjs/core": `^${nestMajor}.0.0`,
           "@nestjs/platform-express": `^${nestMajor}.0.0`,
+          "@types/node": "^22.0.0",
           "reflect-metadata": "^0.2.2",
           rxjs: "^7.8.2",
         },
@@ -155,7 +156,28 @@ try {
     }
     await writeFile(
       join(nestConsumer, "app.ts"),
-      "import 'reflect-metadata';\nimport { Controller, Get, Module } from '@nestjs/common';\nimport { NestFactory } from '@nestjs/core';\nimport { TelemetryModule } from '@equipe-tech/observability/nestjs';\nclass AppController { ping() { return { ok: true }; } }\nController()(AppController);\nconst descriptor = Object.getOwnPropertyDescriptor(AppController.prototype, 'ping');\nif (!descriptor) throw new Error('Missing ping descriptor.');\nGet('ping')(AppController.prototype, 'ping', descriptor);\nclass AppModule {}\nModule({ imports: [TelemetryModule.forRootAsync({ useFactory: async () => ({ enabled: false }) })], controllers: [AppController] })(AppModule);\nconst app = await NestFactory.create(AppModule, { logger: false });\nawait app.listen(0, '127.0.0.1');\nconst address = app.getHttpServer().address();\nif (!address || typeof address === 'string') throw new Error('Missing server address.');\nconst response = await fetch(`http://127.0.0.1:${address.port}/ping`);\nif (response.status !== 200 || (await response.json()).ok !== true) throw new Error('Packed Nest request failed.');\nawait app.close();\n",
+      "import 'reflect-metadata';\nimport { Controller, Get, Module } from '@nestjs/common';\nimport { NestFactory } from '@nestjs/core';\nimport { TelemetryModule } from '@equipe-tech/observability/nestjs';\nclass AppController { ping() { return { ok: true }; } }\nController()(AppController);\nconst descriptor = Object.getOwnPropertyDescriptor(AppController.prototype, 'ping');\nif (!descriptor) throw new Error('Missing ping descriptor.');\nGet('ping')(AppController.prototype, 'ping', descriptor);\nclass AppModule {}\nModule({ imports: [TelemetryModule.forRootAsync({ imports: undefined, inject: undefined, useFactory: async () => ({ enabled: false }) })], controllers: [AppController] })(AppModule);\nconst app = await NestFactory.create(AppModule, { logger: false });\nawait app.listen(0, '127.0.0.1');\nconst address = app.getHttpServer().address();\nif (!address || typeof address === 'string') throw new Error('Missing server address.');\nconst response = await fetch(`http://127.0.0.1:${address.port}/ping`);\nif (response.status !== 200 || (await response.json()).ok !== true) throw new Error('Packed Nest request failed.');\nawait app.close();\n",
+    );
+    await writeFile(
+      join(nestConsumer, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          target: "ESNext",
+          module: "Preserve",
+          moduleResolution: "Bundler",
+          strict: true,
+          noEmit: true,
+          types: ["node"],
+        },
+        include: ["app.ts"],
+      }),
+    );
+    requireSuccess(
+      await run(
+        ["bun", join(root, "node_modules/typescript/bin/tsc"), "-p", "tsconfig.json"],
+        nestConsumer,
+      ),
+      `Type-checking the Nest ${nestMajor} packed consumer`,
     );
     requireSuccess(
       await run(["bun", "app.ts"], nestConsumer),


### PR DESCRIPTION
## Summary

- add `TelemetryModule.forRootAsync` with DI, eager typed validation, and global HTTP instrumentation
- use one shared package runtime with coordinated startup, bounded shutdown, and exactly-once disposal
- prove disabled mode, duplicate configuration handling, and packed Nest 10/11 consumers

## Verification

- real Nest startup, request, exclusion, failure, duplicate import, and shutdown tests
- packed Nest 10 and 11 type-check and runtime matrix
- metrics/browser package gates and Effect-free declarations
- `bun check`, build, full tests, package smoke, local Collector canary, and independent exact-head review

Linear: OBS-6
