### PR TITLE
chore(release): prepare v0.2.0 packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
     branches:
       - master
   workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+    secrets:
+      AXIOM_TOKEN:
+        required: false
 
 permissions:
   contents: read
@@ -16,6 +23,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
       - name: Configure the observability state directory
         run: echo "OBSERVABILITY_HOME=${RUNNER_TEMP}/observability" >> "$GITHUB_ENV"
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,6 @@ jobs:
           OBSERVABILITY_E2E_DEPLOYED=1 OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:24318 bun test:canary:deployed
       - if: always()
         run: docker rm -f otel-production 2>/dev/null || true
+      - name: Clean runner observability state
+        if: always()
+        run: rm -rf "$OBSERVABILITY_HOME" "${RUNNER_TEMP}/collector-recovery"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
       ref:
         required: false
         type: string
+      run_deployed_canary:
+        default: true
+        required: false
+        type: boolean
     secrets:
       AXIOM_TOKEN:
         required: false
@@ -49,6 +53,7 @@ jobs:
       - if: always()
         run: bun packages/cli/src/main.ts dev down
       - name: deployed canary
+        if: ${{ github.event_name != 'workflow_call' || inputs.run_deployed_canary }}
         env:
           AXIOM_TOKEN: ${{ secrets.AXIOM_TOKEN }}
           AXIOM_DATASET_TRACES: ${{ vars.AXIOM_DATASET_TRACES }}

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -39,11 +39,22 @@ jobs:
           bun run test:package
           version="$(jq -r .version packages/telemetry/package.json)"
           tag="v$version"
-          mkdir -p dist-release
-          (cd packages/telemetry && bun pm pack --ignore-scripts --quiet \
-            --filename "$PWD/../../dist-release/equipe-tech-observability-${version}.tgz")
-          (cd packages/cli && bun pm pack --ignore-scripts --quiet \
-            --filename "$PWD/../../dist-release/equipe-tech-observability-cli-${version}.tgz")
+          rm -rf .release-pack
+          trap 'rm -rf .release-pack' EXIT
+          for pack_set in pack-1 pack-2 pack-3; do
+            destination="$PWD/.release-pack/$pack_set"
+            mkdir -p "$destination"
+            (cd packages/telemetry && bun pm pack --ignore-scripts --quiet \
+              --filename "$destination/equipe-tech-observability-${version}.tgz")
+            (cd packages/cli && bun pm pack --ignore-scripts --quiet \
+              --filename "$destination/equipe-tech-observability-cli-${version}.tgz")
+          done
+          for pack_set in pack-2 pack-3; do
+            cmp ".release-pack/pack-1/equipe-tech-observability-${version}.tgz" \
+              ".release-pack/$pack_set/equipe-tech-observability-${version}.tgz"
+            cmp ".release-pack/pack-1/equipe-tech-observability-cli-${version}.tgz" \
+              ".release-pack/$pack_set/equipe-tech-observability-cli-${version}.tgz"
+          done
           sha256sum --check "docs/releases/${tag}.sha256"
       - name: Query current npm versions
         run: |

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -28,20 +28,33 @@ jobs:
           cli_version="$(jq -r .version packages/cli/package.json)"
           [[ "$telemetry_version" == "$cli_version" ]] \
             || { echo "The package versions diverge: $telemetry_version vs $cli_version."; exit 1; }
-          bun scripts/release.ts patch --dry-run
-          bun scripts/release-notes.ts --tag "v$telemetry_version" > release-notes.md
-          test -s release-notes.md
-          cat release-notes.md
+          tag="v$telemetry_version"
+          bun scripts/release.ts "$telemetry_version" --dry-run
+          test -s "docs/releases/${tag}.md"
+          test -s "docs/releases/${tag}.sha256"
+          cat "docs/releases/${tag}.md"
       - name: Validate the packed artifacts
-        run: bun run test:package
-      - name: Validate npm credentials
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
-          if [[ -z "$NODE_AUTH_TOKEN" ]]; then
-            echo "The NPM_TOKEN secret is not configured. The release will skip the npm publish."
-            exit 0
-          fi
-          npm config set //registry.npmjs.org/:_authToken '${NODE_AUTH_TOKEN}'
-          npm whoami --registry https://registry.npmjs.org
+          bun run test:package
+          version="$(jq -r .version packages/telemetry/package.json)"
+          tag="v$version"
+          mkdir -p dist-release
+          (cd packages/telemetry && bun pm pack --ignore-scripts --quiet \
+            --filename "$PWD/../../dist-release/equipe-tech-observability-${version}.tgz")
+          (cd packages/cli && bun pm pack --ignore-scripts --quiet \
+            --filename "$PWD/../../dist-release/equipe-tech-observability-cli-${version}.tgz")
+          sha256sum --check "docs/releases/${tag}.sha256"
+      - name: Query current npm versions
+        run: |
+          set -euo pipefail
+          for package in @equipe-tech/observability @equipe-tech/observability-cli; do
+            if output="$(npm view "$package" version dist-tags versions --json 2>&1)"; then
+              echo "$output"
+            elif grep -qiE "E404|is not in this registry" <<< "$output"; then
+              echo "$package has not been published yet."
+            else
+              echo "$output" >&2
+              exit 1
+            fi
+          done

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -69,3 +69,6 @@ jobs:
               exit 1
             fi
           done
+      - name: Clean preflight temporary paths
+        if: always()
+        run: rm -rf .release-pack dist-release .verification

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,14 @@ jobs:
       - name: Generate release notes
         env:
           TAG: ${{ needs.tag-check.outputs.tag }}
-        run: bun scripts/release-notes.ts --tag "$TAG" > release-notes.md
+        run: |
+          set -euo pipefail
+          source_notes="docs/releases/${TAG}.md"
+          if [[ -f "$source_notes" ]]; then
+            cp "$source_notes" release-notes.md
+          else
+            bun scripts/release-notes.ts --tag "$TAG" > release-notes.md
+          fi
       - name: Create the GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -134,6 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/setup-node@v4
         with:
@@ -164,7 +172,7 @@ jobs:
             "./dist-release/equipe-tech-observability-cli-${VERSION}.tgz"; do
             [[ -f "$tarball" ]] || { echo "Missing tarball: $tarball"; exit 1; }
             set +e
-            output="$(npm publish "$tarball" --access public --tag "$NPM_TAG" 2>&1)"
+            output="$(npm publish "$tarball" --access public --tag "$NPM_TAG" --provenance 2>&1)"
             status=$?
             set -e
             echo "$output"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,9 @@ jobs:
             grep -qx "$expected" <<< "$assets" \
               || { echo "The release is missing the asset $expected."; exit 1; }
           done
+      - name: Clean release temporary paths
+        if: always()
+        run: rm -rf .release-pack dist-release release-notes.md
 
   publish-npm:
     needs:
@@ -252,3 +255,6 @@ jobs:
               exit $status
             fi
           done
+      - name: Clean npm publication temporary paths
+        if: always()
+        run: rm -rf .release-pack dist-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,7 @@ jobs:
     uses: ./.github/workflows/ci.yml
     with:
       ref: ${{ needs.tag-check.outputs.tag }}
-    secrets:
-      AXIOM_TOKEN: ${{ secrets.AXIOM_TOKEN }}
+      run_deployed_canary: false
 
   release:
     needs:
@@ -87,15 +86,29 @@ jobs:
           VERSION: ${{ needs.tag-check.outputs.version }}
         run: |
           set -euo pipefail
-          mkdir -p dist-release
-          (cd packages/telemetry && bun pm pack --ignore-scripts --quiet \
-            --filename "$PWD/../../dist-release/equipe-tech-observability-${VERSION}.tgz")
-          (cd packages/cli && bun pm pack --ignore-scripts --quiet \
-            --filename "$PWD/../../dist-release/equipe-tech-observability-cli-${VERSION}.tgz")
+          rm -rf .release-pack dist-release
+          trap 'rm -rf .release-pack' EXIT
+          for pack_set in pack-1 pack-2 pack-3; do
+            destination="$PWD/.release-pack/$pack_set"
+            mkdir -p "$destination"
+            (cd packages/telemetry && bun pm pack --ignore-scripts --quiet \
+              --filename "$destination/equipe-tech-observability-${VERSION}.tgz")
+            (cd packages/cli && bun pm pack --ignore-scripts --quiet \
+              --filename "$destination/equipe-tech-observability-cli-${VERSION}.tgz")
+          done
+          for pack_set in pack-2 pack-3; do
+            cmp ".release-pack/pack-1/equipe-tech-observability-${VERSION}.tgz" \
+              ".release-pack/$pack_set/equipe-tech-observability-${VERSION}.tgz"
+            cmp ".release-pack/pack-1/equipe-tech-observability-cli-${VERSION}.tgz" \
+              ".release-pack/$pack_set/equipe-tech-observability-cli-${VERSION}.tgz"
+          done
           checksum_file="docs/releases/${TAG}.sha256"
           [[ -f "$checksum_file" ]] \
             || { echo "The release checksum file is missing: $checksum_file"; exit 1; }
           sha256sum --check "$checksum_file"
+          mkdir dist-release
+          cp .release-pack/pack-1/*.tgz dist-release/
+          rm -rf .release-pack
           ls -l dist-release
       - name: Generate release notes
         env:
@@ -153,23 +166,62 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.tag-check.outputs.tag }}
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.4.0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
-      - name: Download and verify the release tarballs
+      - run: bun install --frozen-lockfile
+      - run: bun run build
+      - name: Download, rebuild, and verify the release tarballs
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.tag-check.outputs.tag }}
+          VERSION: ${{ needs.tag-check.outputs.version }}
         run: |
           set -euo pipefail
-          mkdir -p dist-release
+          rm -rf .release-pack dist-release
+          trap 'rm -rf .release-pack' EXIT
+          mkdir dist-release
           gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
             --pattern "*.tgz" --dir dist-release
+          for pack_set in pack-1 pack-2 pack-3; do
+            destination="$PWD/.release-pack/$pack_set"
+            mkdir -p "$destination"
+            (cd packages/telemetry && bun pm pack --ignore-scripts --quiet \
+              --filename "$destination/equipe-tech-observability-${VERSION}.tgz")
+            (cd packages/cli && bun pm pack --ignore-scripts --quiet \
+              --filename "$destination/equipe-tech-observability-cli-${VERSION}.tgz")
+          done
+          for pack_set in pack-2 pack-3; do
+            cmp ".release-pack/pack-1/equipe-tech-observability-${VERSION}.tgz" \
+              ".release-pack/$pack_set/equipe-tech-observability-${VERSION}.tgz"
+            cmp ".release-pack/pack-1/equipe-tech-observability-cli-${VERSION}.tgz" \
+              ".release-pack/$pack_set/equipe-tech-observability-cli-${VERSION}.tgz"
+          done
           checksum_file="docs/releases/${TAG}.sha256"
           [[ -f "$checksum_file" ]] \
             || { echo "The release checksum file is missing: $checksum_file"; exit 1; }
           sha256sum --check "$checksum_file"
+          cmp ".release-pack/pack-1/equipe-tech-observability-${VERSION}.tgz" \
+            "dist-release/equipe-tech-observability-${VERSION}.tgz"
+          cmp ".release-pack/pack-1/equipe-tech-observability-cli-${VERSION}.tgz" \
+            "dist-release/equipe-tech-observability-cli-${VERSION}.tgz"
+          rm -rf .release-pack
+      - name: Validate npm authentication and trusted publishing
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          [[ -n "$NODE_AUTH_TOKEN" ]] \
+            || { echo "NPM_TOKEN is required for publication."; exit 1; }
+          [[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]] \
+            || { echo "GitHub OIDC request URL is unavailable."; exit 1; }
+          [[ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]] \
+            || { echo "GitHub OIDC request token is unavailable."; exit 1; }
+          npm whoami --registry https://registry.npmjs.org
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -177,10 +229,12 @@ jobs:
           NPM_TAG: ${{ needs.tag-check.outputs.npm_tag }}
         run: |
           set -euo pipefail
-          if [[ -z "$NODE_AUTH_TOKEN" ]]; then
-            echo "npm publish skipped: the NPM_TOKEN secret is not configured."
-            exit 0
-          fi
+          [[ -n "$NODE_AUTH_TOKEN" ]] \
+            || { echo "NPM_TOKEN is required for publication."; exit 1; }
+          [[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]] \
+            || { echo "GitHub OIDC request URL is unavailable."; exit 1; }
+          [[ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]] \
+            || { echo "GitHub OIDC request token is unavailable."; exit 1; }
           for tarball in \
             "./dist-release/equipe-tech-observability-${VERSION}.tgz" \
             "./dist-release/equipe-tech-observability-cli-${VERSION}.tgz"; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag existente para reprocessar (exemplo: v0.2.0)"
+        description: "Tag existente ainda não publicada (exemplo: v0.2.0)"
         required: true
         type: string
 
@@ -59,7 +59,10 @@ jobs:
   verify:
     needs: tag-check
     uses: ./.github/workflows/ci.yml
-    secrets: inherit
+    with:
+      ref: ${{ needs.tag-check.outputs.tag }}
+    secrets:
+      AXIOM_TOKEN: ${{ secrets.AXIOM_TOKEN }}
 
   release:
     needs:
@@ -78,8 +81,9 @@ jobs:
           bun-version: 1.4.0
       - run: bun install --frozen-lockfile
       - run: bun run build
-      - name: Pack release tarballs
+      - name: Pack and verify release tarballs
         env:
+          TAG: ${{ needs.tag-check.outputs.tag }}
           VERSION: ${{ needs.tag-check.outputs.version }}
         run: |
           set -euo pipefail
@@ -88,6 +92,10 @@ jobs:
             --filename "$PWD/../../dist-release/equipe-tech-observability-${VERSION}.tgz")
           (cd packages/cli && bun pm pack --ignore-scripts --quiet \
             --filename "$PWD/../../dist-release/equipe-tech-observability-cli-${VERSION}.tgz")
+          checksum_file="docs/releases/${TAG}.sha256"
+          [[ -f "$checksum_file" ]] \
+            || { echo "The release checksum file is missing: $checksum_file"; exit 1; }
+          sha256sum --check "$checksum_file"
           ls -l dist-release
       - name: Generate release notes
         env:
@@ -107,9 +115,8 @@ jobs:
           PRERELEASE: ${{ needs.tag-check.outputs.prerelease }}
         run: |
           set -euo pipefail
-          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft \
-            | grep -q false; then
-            echo "The release $TAG is already published. Assets are re-uploaded with --clobber only."
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "The release $TAG already exists. Existing assets will not be replaced."
           else
             create_args=(release create "$TAG" --repo "$GITHUB_REPOSITORY" \
               --title "$TAG" --notes-file release-notes.md --verify-tag)
@@ -117,8 +124,8 @@ jobs:
               create_args+=(--prerelease)
             fi
             gh "${create_args[@]}"
+            gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" dist-release/*
           fi
-          gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" dist-release/* --clobber
       - name: Verify the release assets
         env:
           GH_TOKEN: ${{ github.token }}
@@ -143,11 +150,14 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.tag-check.outputs.tag }}
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
-      - name: Download the release tarballs
+      - name: Download and verify the release tarballs
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.tag-check.outputs.tag }}
@@ -156,6 +166,10 @@ jobs:
           mkdir -p dist-release
           gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
             --pattern "*.tgz" --dir dist-release
+          checksum_file="docs/releases/${TAG}.sha256"
+          [[ -f "$checksum_file" ]] \
+            || { echo "The release checksum file is missing: $checksum_file"; exit 1; }
+          sha256sum --check "$checksum_file"
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -159,19 +159,7 @@ O projeto usa [Effect](https://effect.website) v4 e conventional commits.
 
 ### Release
 
-```sh
-bun scripts/release.ts patch          # ou minor, major, x.y.z, x.y.z-rc.1
-git push origin master --follow-tags
-```
-
-O script alinha as versões dos dois pacotes, cria o commit `chore: release vX.Y.Z` e a tag anotada. O push da tag dispara o workflow `release`:
-
-1. `tag-check` valida o formato da tag e a igualdade com os manifests.
-2. `verify` roda o CI completo, incluindo o canário local e, com secrets, o deployed.
-3. `release` empacota os tarballs, gera as notas a partir dos conventional commits e cria o GitHub Release com os assets.
-4. `publish-npm` baixa os tarballs do release e publica no npm com o dist-tag correto (`latest`, ou `alpha`/`beta`/`rc` para pré-releases). Sem o secret `NPM_TOKEN`, o passo é pulado com aviso.
-
-O workflow `release-preflight` (manual) valida a configuração antes de criar a tag: versões alinhadas, notas, empacotamento e credenciais npm.
+Toda preparação e publicação segue exclusivamente o [runbook de publicação coordenada](docs/release-publication-runbook.md). As notas aprovadas de `v0.2.0` são o arquivo manuscrito [docs/releases/v0.2.0.md](docs/releases/v0.2.0.md). Não crie tags, releases, assets ou publicações npm por comandos fora do gate humano documentado no runbook.
 
 ## Propriedade e transferência
 

--- a/bun.lock
+++ b/bun.lock
@@ -20,18 +20,19 @@
     },
     "packages/cli": {
       "name": "@equipe-tech/observability-cli",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "bin": {
-        "observability": "./src/main.ts",
+        "observability": "./dist/main.js",
       },
       "dependencies": {
         "@effect/platform-bun": "4.0.0-rc.111",
+        "@effect/platform-node-shared": "4.0.0-rc.111",
         "effect": "4.0.0-rc.111",
       },
     },
     "packages/telemetry": {
       "name": "@equipe-tech/observability",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "effect": "4.0.0-rc.111",
       },

--- a/docs/release-publication-runbook.md
+++ b/docs/release-publication-runbook.md
@@ -1,0 +1,150 @@
+# Publicação coordenada dos pacotes
+
+Este runbook prepara uma publicação, mas separa todas as mutações por um gate humano explícito. Os comandos usam `0.2.0` e `v0.2.0`; substitua ambos somente depois de uma nova análise semver e revisão dos manifests.
+
+## Invariantes
+
+- `@equipe-tech/observability` e `@equipe-tech/observability-cli` usam exatamente a mesma versão.
+- Um único tag anotado `v0.2.0` aponta para o commit aprovado que contém os dois manifests e as notas.
+- O commit aprovado está no histórico de `origin/master` antes da criação do tag.
+- Os tarballs aprovados contêm READMEs, licença Apache-2.0, declarações, entrypoints e assets esperados.
+- O workflow usa OpenID Connect com `id-token: write` e `npm publish --provenance`.
+- Nenhum comando de mutação desta página roda sem aprovação do responsável pela release.
+
+## Preflight sem mutação externa
+
+```sh
+set -euo pipefail
+git fetch origin --tags --prune
+git status --short --branch
+test -z "$(git status --porcelain)"
+test "$(jq -r .version packages/telemetry/package.json)" = "0.2.0"
+test "$(jq -r .version packages/cli/package.json)" = "0.2.0"
+test -z "$(git tag --list v0.2.0)"
+npm view @equipe-tech/observability version dist-tags versions --json
+npm view @equipe-tech/observability-cli version dist-tags versions --json
+bun scripts/release.ts 0.2.0 --dry-run
+bun check
+bun run build
+bun run test
+bun run test:package
+```
+
+Valide os assets no Collector 0.159.0:
+
+```sh
+docker run --rm \
+  -v "$PWD/packages/cli/src/assets/local.yaml:/etc/otelcol/config.yaml:ro" \
+  otel/opentelemetry-collector-contrib:0.159.0 \
+  validate --config=/etc/otelcol/config.yaml
+
+docker run --rm \
+  -e AXIOM_TOKEN=test \
+  -e AXIOM_DATASET_TRACES=traces \
+  -e AXIOM_DATASET_LOGS=logs \
+  -e AXIOM_DATASET_METRICS=metrics \
+  -v "$PWD/packages/cli/src/assets/production.yaml:/etc/otelcol/config.yaml:ro" \
+  otel/opentelemetry-collector-contrib:0.159.0 \
+  validate --config=/etc/otelcol/config.yaml
+
+recovery_root="$(mktemp -d)"
+OBSERVABILITY_COLLECTOR_RECOVERY=1 \
+OBSERVABILITY_COLLECTOR_RECOVERY_ARTIFACT_ROOT="$recovery_root" \
+  bun test packages/cli/test/CollectorRecovery.bun.test.ts --timeout 120000
+```
+
+Rode o canário local sem credenciais com um único diretório de estado:
+
+```sh
+state="$(mktemp -d)"
+OBSERVABILITY_HOME="$state" bun packages/cli/src/main.ts dev up
+trap 'OBSERVABILITY_HOME="$state" bun packages/cli/src/main.ts dev down' EXIT
+curl --fail --silent --show-error --retry 10 --retry-all-errors --retry-delay 1 \
+  http://localhost:8000/ >/dev/null
+OBSERVABILITY_HOME="$state" OBSERVABILITY_E2E=1 bun test:canary
+OBSERVABILITY_HOME="$state" bun packages/cli/src/main.ts dev down
+trap - EXIT
+```
+
+## Tarballs aprováveis
+
+```sh
+set -euo pipefail
+artifact_dir="$(mktemp -d)"
+bun run build
+(
+  cd packages/telemetry
+  bun pm pack --ignore-scripts --quiet \
+    --filename "$artifact_dir/equipe-tech-observability-0.2.0.tgz"
+)
+(
+  cd packages/cli
+  bun pm pack --ignore-scripts --quiet \
+    --filename "$artifact_dir/equipe-tech-observability-cli-0.2.0.tgz"
+)
+tar -tzf "$artifact_dir/equipe-tech-observability-0.2.0.tgz" | sort
+tar -tzf "$artifact_dir/equipe-tech-observability-cli-0.2.0.tgz" | sort
+shasum -a 256 "$artifact_dir"/*.tgz
+npm publish "$artifact_dir/equipe-tech-observability-0.2.0.tgz" \
+  --access public --tag latest --provenance --dry-run
+npm publish "$artifact_dir/equipe-tech-observability-cli-0.2.0.tgz" \
+  --access public --tag latest --provenance --dry-run
+```
+
+Registre os SHA-256. Confira nomes e versões dos manifests empacotados, export maps, todos os `.d.ts`, modo executável da CLI, assets do Collector e Kamal, READMEs, licenças, dependency ranges e ausência de `workspace:`, fontes, testes, credenciais e arquivos alheios.
+
+Instale esses mesmos tarballs em diretórios temporários Node e Bun. Importe raiz, metrics, node, nestjs, browser, browser/client e testing. Compile consumidores NestJS 10 e 11, execute o cliente de browser empacotado e confirme o gate gzip. Execute `observability --help`, `dev status` e provisionamento local. `bun run test:package` automatiza essa matriz; uma instalação Node separada confirma a resolução fora do Bun.
+
+## Evidência para aprovação
+
+Entregue ao responsável:
+
+- SHA completo do commit candidato e confirmação de que ele pertence a `origin/master`;
+- diff desde `v0.1.0` e notas `docs/releases/v0.2.0.md`;
+- saídas de check, build, testes, smoke, Collector, recovery e canário local;
+- listagens e SHA-256 dos dois tarballs;
+- saídas dos dois `npm publish --dry-run`;
+- resultado das instalações externas Node, Bun, NestJS 10 e NestJS 11;
+- resultado das consultas read-only de versões e dist-tags;
+- revisão das permissões OIDC e do comando `--provenance`.
+
+## Gate humano de publicação
+
+Pare aqui. Os comandos abaixo criam ou propagam estado externo. Execute somente depois que o responsável aprovar por escrito o SHA, a versão, as notas, os hashes, a conta npm, o dist-tag `latest` e a configuração de proveniência.
+
+```sh
+set -euo pipefail
+git fetch origin --tags --prune
+approved_sha="<SHA_APROVADO>"
+test "$(git rev-parse "$approved_sha")" = "$approved_sha"
+git merge-base --is-ancestor "$approved_sha" origin/master
+test "$(git show "$approved_sha:packages/telemetry/package.json" | jq -r .version)" = "0.2.0"
+test "$(git show "$approved_sha:packages/cli/package.json" | jq -r .version)" = "0.2.0"
+test -z "$(git ls-remote --tags origin refs/tags/v0.2.0 refs/tags/v0.2.0^{})"
+git tag -a v0.2.0 "$approved_sha" -m "Release 0.2.0"
+git push origin v0.2.0
+```
+
+O push do tag aciona o workflow. Não rode `npm publish`, `gh release create`, upload de asset ou alteração de dist-tag manual em paralelo.
+
+## Verificação após publicação
+
+```sh
+git ls-remote --tags origin refs/tags/v0.2.0 refs/tags/v0.2.0^{}
+gh release view v0.2.0 --json tagName,isDraft,isPrerelease,assets,url
+npm view @equipe-tech/observability@0.2.0 version dist.integrity dist.shasum --json
+npm view @equipe-tech/observability-cli@0.2.0 version dist.integrity dist.shasum --json
+npm view @equipe-tech/observability dist-tags --json
+npm view @equipe-tech/observability-cli dist-tags --json
+```
+
+Confirme dois assets no GitHub Release, proveniência nos dois pacotes npm, `latest: 0.2.0` em ambos e instalação limpa por versão em Node e Bun.
+
+## Falha e rollback
+
+- Antes do tag, corrija no branch, repita toda a validação, gere novos hashes e peça nova aprovação do SHA.
+- Se o tag remoto existir mas o GitHub Release e os dois pacotes ainda não tiverem sido publicados, cancele o workflow. Remova eventual draft e o tag somente com aprovação explícita. Nunca mova um tag de release publicado.
+- Se somente um pacote for publicado, preserve a versão publicada. Corrija a causa e reexecute o workflow por `workflow_dispatch` com o tag existente para publicar o pacote ausente. O workflow ignora de forma idempotente uma versão já publicada.
+- Se um pacote publicado tiver defeito, faça uma correção coordenada com nova versão patch nos dois pacotes. Não reutilize `0.2.0`.
+- Não use `npm unpublish` como rollback normal. `npm deprecate` ou mudança manual de dist-tag exigem aprovação explícita, mensagem de substituição e verificação dos dois pacotes.
+- Preserve logs do workflow, SHA aprovado, hashes locais, integrities npm e URL do release como evidência do incidente.

--- a/docs/release-publication-runbook.md
+++ b/docs/release-publication-runbook.md
@@ -21,8 +21,16 @@ test -z "$(git status --porcelain)"
 test "$(jq -r .version packages/telemetry/package.json)" = "0.2.0"
 test "$(jq -r .version packages/cli/package.json)" = "0.2.0"
 test -z "$(git tag --list v0.2.0)"
-npm view @equipe-tech/observability version dist-tags versions --json
-npm view @equipe-tech/observability-cli version dist-tags versions --json
+for package in @equipe-tech/observability @equipe-tech/observability-cli; do
+  if output="$(npm view "$package" version dist-tags versions --json 2>&1)"; then
+    echo "$output"
+  elif grep -qiE "E404|is not in this registry" <<< "$output"; then
+    echo "$package has not been published yet."
+  else
+    echo "$output" >&2
+    exit 1
+  fi
+done
 bun scripts/release.ts 0.2.0 --dry-run
 bun check
 bun run build
@@ -71,27 +79,42 @@ trap - EXIT
 ```sh
 set -euo pipefail
 artifact_dir="$(mktemp -d)"
+reproduction_dir="$(mktemp -d)"
 bun run build
-(
-  cd packages/telemetry
-  bun pm pack --ignore-scripts --quiet \
-    --filename "$artifact_dir/equipe-tech-observability-0.2.0.tgz"
-)
-(
-  cd packages/cli
-  bun pm pack --ignore-scripts --quiet \
-    --filename "$artifact_dir/equipe-tech-observability-cli-0.2.0.tgz"
-)
+for destination in "$artifact_dir" "$reproduction_dir"; do
+  (
+    cd packages/telemetry
+    bun pm pack --ignore-scripts --quiet \
+      --filename "$destination/equipe-tech-observability-0.2.0.tgz"
+  )
+  (
+    cd packages/cli
+    bun pm pack --ignore-scripts --quiet \
+      --filename "$destination/equipe-tech-observability-cli-0.2.0.tgz"
+  )
+done
+cmp "$artifact_dir/equipe-tech-observability-0.2.0.tgz" \
+  "$reproduction_dir/equipe-tech-observability-0.2.0.tgz"
+cmp "$artifact_dir/equipe-tech-observability-cli-0.2.0.tgz" \
+  "$reproduction_dir/equipe-tech-observability-cli-0.2.0.tgz"
 tar -tzf "$artifact_dir/equipe-tech-observability-0.2.0.tgz" | sort
 tar -tzf "$artifact_dir/equipe-tech-observability-cli-0.2.0.tgz" | sort
 shasum -a 256 "$artifact_dir"/*.tgz
+(
+  cd "$PWD"
+  rm -rf dist-release
+  mkdir dist-release
+  cp "$artifact_dir"/*.tgz dist-release/
+  shasum -a 256 -c docs/releases/v0.2.0.sha256
+  rm -rf dist-release
+)
 npm publish "$artifact_dir/equipe-tech-observability-0.2.0.tgz" \
   --access public --tag latest --provenance --dry-run
 npm publish "$artifact_dir/equipe-tech-observability-cli-0.2.0.tgz" \
   --access public --tag latest --provenance --dry-run
 ```
 
-Registre os SHA-256. Confira nomes e versões dos manifests empacotados, export maps, todos os `.d.ts`, modo executável da CLI, assets do Collector e Kamal, READMEs, licenças, dependency ranges e ausência de `workspace:`, fontes, testes, credenciais e arquivos alheios.
+Os SHA-256 devem coincidir exatamente com `docs/releases/v0.2.0.sha256`. Empacote duas vezes em diretórios vazios e use `cmp` nos pares antes da aprovação. Confira nomes, versões, repository, homepage, bugs e engines dos manifests empacotados, export maps, todos os `.d.ts`, modo executável da CLI, assets do Collector e Kamal, READMEs, licenças na raiz e em `dist`, dependency ranges e ausência de `workspace:`, fontes, testes, credenciais e arquivos alheios.
 
 Instale esses mesmos tarballs em diretórios temporários Node e Bun. Importe raiz, metrics, node, nestjs, browser, browser/client e testing. Compile consumidores NestJS 10 e 11, execute o cliente de browser empacotado e confirme o gate gzip. Execute `observability --help`, `dev status` e provisionamento local. `bun run test:package` automatiza essa matriz; uma instalação Node separada confirma a resolução fora do Bun.
 
@@ -106,7 +129,8 @@ Entregue ao responsável:
 - saídas dos dois `npm publish --dry-run`;
 - resultado das instalações externas Node, Bun, NestJS 10 e NestJS 11;
 - resultado das consultas read-only de versões e dist-tags;
-- revisão das permissões OIDC e do comando `--provenance`.
+- revisão das permissões OIDC, do comando `--provenance` e do checkout exato do tag na CI reutilizável;
+- confirmação de que `effect@4.0.0-rc.111` continua dependência obrigatória nesta versão e que qualquer mudança desse contrato ficou adiada para análise futura.
 
 ## Gate humano de publicação
 
@@ -144,7 +168,7 @@ Confirme dois assets no GitHub Release, proveniência nos dois pacotes npm, `lat
 
 - Antes do tag, corrija no branch, repita toda a validação, gere novos hashes e peça nova aprovação do SHA.
 - Se o tag remoto existir mas o GitHub Release e os dois pacotes ainda não tiverem sido publicados, cancele o workflow. Remova eventual draft e o tag somente com aprovação explícita. Nunca mova um tag de release publicado.
-- Se somente um pacote for publicado, preserve a versão publicada. Corrija a causa e reexecute o workflow por `workflow_dispatch` com o tag existente para publicar o pacote ausente. O workflow ignora de forma idempotente uma versão já publicada.
+- Se somente um pacote for publicado, preserve a versão publicada. Corrija a causa e reexecute o workflow por `workflow_dispatch` com o tag existente. A release e os assets existentes não são sobrescritos, os checksums são revalidados e a versão já publicada é ignorada de forma idempotente.
 - Se um pacote publicado tiver defeito, faça uma correção coordenada com nova versão patch nos dois pacotes. Não reutilize `0.2.0`.
 - Não use `npm unpublish` como rollback normal. `npm deprecate` ou mudança manual de dist-tag exigem aprovação explícita, mensagem de substituição e verificação dos dois pacotes.
 - Preserve logs do workflow, SHA aprovado, hashes locais, integrities npm e URL do release como evidência do incidente.

--- a/docs/release-publication-runbook.md
+++ b/docs/release-publication-runbook.md
@@ -58,22 +58,40 @@ docker run --rm \
   validate --config=/etc/otelcol/config.yaml
 
 recovery_root="$(mktemp -d)"
+cleanup_recovery() {
+  rm -rf "$recovery_root"
+}
+trap cleanup_recovery EXIT
+trap 'exit 128' HUP INT TERM
 OBSERVABILITY_COLLECTOR_RECOVERY=1 \
 OBSERVABILITY_COLLECTOR_RECOVERY_ARTIFACT_ROOT="$recovery_root" \
   bun test packages/cli/test/CollectorRecovery.bun.test.ts --timeout 120000
+cleanup_recovery
+trap - EXIT HUP INT TERM
 ```
 
 Rode o canário local sem credenciais com um único diretório de estado:
 
 ```sh
 state="$(mktemp -d)"
+stack_started=false
+cleanup_stack() {
+  if [[ "$stack_started" == "true" ]]; then
+    OBSERVABILITY_HOME="$state" bun packages/cli/src/main.ts dev down || true
+  fi
+  rm -rf "$state"
+}
+trap cleanup_stack EXIT
+trap 'exit 128' HUP INT TERM
+stack_started=true
 OBSERVABILITY_HOME="$state" bun packages/cli/src/main.ts dev up
-trap 'OBSERVABILITY_HOME="$state" bun packages/cli/src/main.ts dev down' EXIT
 curl --fail --silent --show-error --retry 10 --retry-all-errors --retry-delay 1 \
   http://localhost:8000/ >/dev/null
 OBSERVABILITY_HOME="$state" OBSERVABILITY_E2E=1 bun test:canary
 OBSERVABILITY_HOME="$state" bun packages/cli/src/main.ts dev down
-trap - EXIT
+stack_started=false
+rm -rf "$state"
+trap - EXIT HUP INT TERM
 ```
 
 ## Tarballs aprováveis
@@ -88,6 +106,7 @@ cleanup() {
   rm -rf "$pack_root" dist-release
 }
 trap cleanup EXIT
+trap 'exit 128' HUP INT TERM
 bun run build
 for pack_set in pack-1 pack-2 pack-3; do
   destination="$pack_root/$pack_set"
@@ -126,7 +145,7 @@ npm publish "./dist-release/equipe-tech-observability-0.2.0.tgz" \
 npm publish "./dist-release/equipe-tech-observability-cli-0.2.0.tgz" \
   --access public --tag latest --provenance --dry-run
 cleanup
-trap - EXIT
+trap - EXIT HUP INT TERM
 ```
 
 Os seis SHA-256 devem coincidir exatamente com `docs/releases/v0.2.0.sha256`. Os três conjuntos usam diretórios vazios e nomes determinísticos; compare `pack-1` com `pack-2` e `pack-3` antes da aprovação. Confira nomes, versões, repository, homepage, bugs e engines dos manifests empacotados, export maps, todos os `.d.ts`, modo executável da CLI, assets do Collector e Kamal, READMEs, licenças na raiz e em `dist`, dependency ranges e ausência de `workspace:`, fontes, testes, credenciais e arquivos alheios.

--- a/docs/release-publication-runbook.md
+++ b/docs/release-publication-runbook.md
@@ -9,6 +9,8 @@ Este runbook prepara uma publicação, mas separa todas as mutações por um gat
 - O commit aprovado está no histórico de `origin/master` antes da criação do tag.
 - Os tarballs aprovados contêm READMEs, licença Apache-2.0, declarações, entrypoints e assets esperados.
 - O workflow usa OpenID Connect com `id-token: write` e `npm publish --provenance`.
+- A publicação exige `NPM_TOKEN`, autenticação confirmada por `npm whoami` e as variáveis de requisição OIDC do GitHub. A ausência de qualquer requisito falha o job.
+- A verificação acionada pela release não recebe AXIOM_TOKEN nem outro secret de provider e não executa o canário deployed.
 - Nenhum comando de mutação desta página roda sem aprovação do responsável pela release.
 
 ## Preflight sem mutação externa
@@ -78,10 +80,18 @@ trap - EXIT
 
 ```sh
 set -euo pipefail
-artifact_dir="$(mktemp -d)"
-reproduction_dir="$(mktemp -d)"
+pack_root="$PWD/.release-pack"
+evidence_root="$PWD/.verification/observability/obs-9-release"
+rm -rf "$pack_root" "$evidence_root" dist-release
+mkdir -p "$evidence_root"
+cleanup() {
+  rm -rf "$pack_root" dist-release
+}
+trap cleanup EXIT
 bun run build
-for destination in "$artifact_dir" "$reproduction_dir"; do
+for pack_set in pack-1 pack-2 pack-3; do
+  destination="$pack_root/$pack_set"
+  mkdir -p "$destination"
   (
     cd packages/telemetry
     bun pm pack --ignore-scripts --quiet \
@@ -93,28 +103,33 @@ for destination in "$artifact_dir" "$reproduction_dir"; do
       --filename "$destination/equipe-tech-observability-cli-0.2.0.tgz"
   )
 done
-cmp "$artifact_dir/equipe-tech-observability-0.2.0.tgz" \
-  "$reproduction_dir/equipe-tech-observability-0.2.0.tgz"
-cmp "$artifact_dir/equipe-tech-observability-cli-0.2.0.tgz" \
-  "$reproduction_dir/equipe-tech-observability-cli-0.2.0.tgz"
-tar -tzf "$artifact_dir/equipe-tech-observability-0.2.0.tgz" | sort
-tar -tzf "$artifact_dir/equipe-tech-observability-cli-0.2.0.tgz" | sort
-shasum -a 256 "$artifact_dir"/*.tgz
-(
-  cd "$PWD"
-  rm -rf dist-release
-  mkdir dist-release
-  cp "$artifact_dir"/*.tgz dist-release/
-  shasum -a 256 -c docs/releases/v0.2.0.sha256
-  rm -rf dist-release
-)
-npm publish "$artifact_dir/equipe-tech-observability-0.2.0.tgz" \
+{
+  for pack_set in pack-2 pack-3; do
+    cmp "$pack_root/pack-1/equipe-tech-observability-0.2.0.tgz" \
+      "$pack_root/$pack_set/equipe-tech-observability-0.2.0.tgz"
+    echo "observability pack-1 and $pack_set are byte-identical"
+    cmp "$pack_root/pack-1/equipe-tech-observability-cli-0.2.0.tgz" \
+      "$pack_root/$pack_set/equipe-tech-observability-cli-0.2.0.tgz"
+    echo "observability-cli pack-1 and $pack_set are byte-identical"
+  done
+  sha256sum .release-pack/pack-*/*.tgz
+  sha256sum --check docs/releases/v0.2.0.sha256
+} | tee "$evidence_root/triple-pack.txt"
+tar -tzf "$pack_root/pack-1/equipe-tech-observability-0.2.0.tgz" | sort \
+  > "$evidence_root/observability-files.txt"
+tar -tzf "$pack_root/pack-1/equipe-tech-observability-cli-0.2.0.tgz" | sort \
+  > "$evidence_root/observability-cli-files.txt"
+mkdir dist-release
+cp "$pack_root/pack-1"/*.tgz dist-release/
+npm publish "./dist-release/equipe-tech-observability-0.2.0.tgz" \
   --access public --tag latest --provenance --dry-run
-npm publish "$artifact_dir/equipe-tech-observability-cli-0.2.0.tgz" \
+npm publish "./dist-release/equipe-tech-observability-cli-0.2.0.tgz" \
   --access public --tag latest --provenance --dry-run
+cleanup
+trap - EXIT
 ```
 
-Os SHA-256 devem coincidir exatamente com `docs/releases/v0.2.0.sha256`. Empacote duas vezes em diretórios vazios e use `cmp` nos pares antes da aprovação. Confira nomes, versões, repository, homepage, bugs e engines dos manifests empacotados, export maps, todos os `.d.ts`, modo executável da CLI, assets do Collector e Kamal, READMEs, licenças na raiz e em `dist`, dependency ranges e ausência de `workspace:`, fontes, testes, credenciais e arquivos alheios.
+Os seis SHA-256 devem coincidir exatamente com `docs/releases/v0.2.0.sha256`. Os três conjuntos usam diretórios vazios e nomes determinísticos; compare `pack-1` com `pack-2` e `pack-3` antes da aprovação. Confira nomes, versões, repository, homepage, bugs e engines dos manifests empacotados, export maps, todos os `.d.ts`, modo executável da CLI, assets do Collector e Kamal, READMEs, licenças na raiz e em `dist`, dependency ranges e ausência de `workspace:`, fontes, testes, credenciais e arquivos alheios.
 
 Instale esses mesmos tarballs em diretórios temporários Node e Bun. Importe raiz, metrics, node, nestjs, browser, browser/client e testing. Compile consumidores NestJS 10 e 11, execute o cliente de browser empacotado e confirme o gate gzip. Execute `observability --help`, `dev status` e provisionamento local. `bun run test:package` automatiza essa matriz; uma instalação Node separada confirma a resolução fora do Bun.
 

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -31,6 +31,7 @@ Esta versão amplia a biblioteca e a CLI com APIs públicas compatíveis, refor�
 - Armazena credenciais locais com modo `0600`, seleciona provedores explicitamente e cobre idempotência, conflitos, retry, interrupção, retomada e rollback de provisionamento parcial.
 - Mantém o provisionamento local de assets idempotente e inclui as novas filas, políticas de proteção, health check e métricas na configuração de produção e no accessory Kamal.
 - Exibe a saída do Docker Compose quando um comando da stack falha.
+- Move o diretório ativo da stack local de `<OBSERVABILITY_HOME>/0.1.0` para `<OBSERVABILITY_HOME>/0.2.0`. Derrube a stack 0.1.0 antes da atualização; a nova CLI não reutiliza nem remove o diretório antigo.
 
 ### Entrega e verificação
 
@@ -38,4 +39,9 @@ Esta versão amplia a biblioteca e a CLI com APIs públicas compatíveis, refor�
 - Amplia canários locais e deployed para traces, logs e métricas, incluindo recursos, ambiente normalizado, relações de spans e exportação completa.
 - Corrige o workflow de CI para configurar o diretório de estado em runtime.
 - Corrige a publicação npm para tratar tarballs como caminhos relativos explícitos.
-- Adiciona READMEs aos dois pacotes e proveniência npm emitida pelo GitHub Actions.
+- Adiciona READMEs e licenças Apache-2.0 na raiz dos dois pacotes e proveniência npm emitida pelo GitHub Actions.
+- Fixa `@effect/platform-node-shared@4.0.0-rc.111` na CLI para impedir que npm combine `@effect/platform-bun@4.0.0-rc.111` com uma release candidate incompatível.
+
+### Compatibilidade futura
+
+`effect@4.0.0-rc.111` permanece uma dependência direta e obrigatória em 0.2.0 para preservar o contrato existente. Torná-la peer dependency, externalizá-la ou atualizar o conjunto Effect é uma decisão de compatibilidade para uma versão futura, não um bloqueio desta release.

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -1,0 +1,41 @@
+## v0.2.0
+
+Esta versão amplia a biblioteca e a CLI com APIs públicas compatíveis, reforça privacidade e semântica OpenTelemetry e torna o Collector de produção recuperável sob falhas. Os dois pacotes usam a versão `0.2.0` e o único tag `v0.2.0`.
+
+### Telemetria para aplicações
+
+- Adiciona o entrypoint `@equipe-tech/observability/metrics`, uma API imperativa e independente de framework para counters, histograms e observable gauges, com flush e encerramento limitados, runtimes compartilhados, validação de instrumentos e medições e limites de cardinalidade.
+- Adiciona `@equipe-tech/observability/browser/client`, um cliente imperativo sem tipos Effect na API pública. A fila e os batches são limitados, retries preservam o mesmo batch sanitizado, flushes concorrentes são compartilhados e o encerramento tem prazo finito e abort signal.
+- Redige nomes e campos sensíveis de eventos do browser antes de colocá-los na fila ou entregá-los ao transporte. Campos reservados pelo servidor continuam protegidos.
+- Amplia o suporte de testes com kind, eventos e links de spans, capturas agregadas e flush explícito do exporter.
+
+### NestJS, W3C e HTTP
+
+- Propaga W3C Trace Context para requisições NestJS e preserva relações corretas entre pais remotos, spans de servidor e spans filhos.
+- Alinha spans HTTP às OpenTelemetry HTTP Semantic Conventions: span kind de servidor, nomes por método e template de rota, método original, `http.route`, status final, `error.type`, fechamento prematuro, rede e proxy configurável.
+- Protege privacidade HTTP omitindo query e URL completa, redigindo parâmetros no path e excluindo health e ingestão de eventos por padrão.
+- Adiciona `TelemetryModule.forRootAsync`, com configuração pelo container NestJS, startup coordenado, runtime compartilhado, admissão e drain de requisições, flush limitado e encerramento seguro. O adapter suporta NestJS 10 e 11 com Express.
+- Adiciona a correlação de eventos amplos por requisição com `createRequestWideEventTraceCorrelation`. Trace ID e span ID chegam ao logger antes do handler e permanecem disponíveis em sucesso, erro HTTP, defeito e fechamento prematuro. A bridge pública não depende de evlog em runtime.
+
+### Collector e proteção de dados
+
+- Redige atributos sensíveis em traces, logs e métricas, nomes de eventos de span e corpos textuais de logs. A política cobre chaves compostas e JSON escapado, authorization e cookies, passwords, tokens, API keys, provider secrets, JWTs, emails, documentos e private keys.
+- Normaliza `deployment.environment` e `deployment.environment.name` nos três sinais para manter compatibilidade de consulta.
+- Limita payloads recebidos e filas persistentes por sinal. Configura consumidores, batches por bytes, retry ilimitado com backoff, fsync, limite do storage e comportamento explícito de overflow.
+- Adiciona health check e métricas internas do Collector e documenta filesystem dedicado, alertas de capacidade, drain, backup, rotação, corrupção e recuperação após outage, restart e saturação.
+- Corrige permissões do diretório de dados da stack local para o usuário não-root do Collector em Linux nativo.
+
+### CLI e provisionamento remoto
+
+- Adiciona autenticação e provisionamento específico para Axiom e Sentry, com criação de datasets, tokens e projetos isolados por ambiente.
+- Armazena credenciais locais com modo `0600`, seleciona provedores explicitamente e cobre idempotência, conflitos, retry, interrupção, retomada e rollback de provisionamento parcial.
+- Mantém o provisionamento local de assets idempotente e inclui as novas filas, políticas de proteção, health check e métricas na configuração de produção e no accessory Kamal.
+- Exibe a saída do Docker Compose quando um comando da stack falha.
+
+### Entrega e verificação
+
+- Adiciona a skill de verificação de observabilidade com roteiros para lifecycle local, entrega de pacotes, canário do pipeline, provisionamento, autenticação e recuperação do Collector.
+- Amplia canários locais e deployed para traces, logs e métricas, incluindo recursos, ambiente normalizado, relações de spans e exportação completa.
+- Corrige o workflow de CI para configurar o diretório de estado em runtime.
+- Corrige a publicação npm para tratar tarballs como caminhos relativos explícitos.
+- Adiciona READMEs aos dois pacotes e proveniência npm emitida pelo GitHub Actions.

--- a/docs/releases/v0.2.0.sha256
+++ b/docs/releases/v0.2.0.sha256
@@ -1,2 +1,6 @@
-60ca90d32e48f85ebcd874817c7eb1e8f36a145895951ecc0d74c5b5c28477e8  dist-release/equipe-tech-observability-0.2.0.tgz
-365c6cb45a472099ad27ef1fb6b99658e91a67e2c8e84eec482c0806f57e4e83  dist-release/equipe-tech-observability-cli-0.2.0.tgz
+60ca90d32e48f85ebcd874817c7eb1e8f36a145895951ecc0d74c5b5c28477e8  .release-pack/pack-1/equipe-tech-observability-0.2.0.tgz
+365c6cb45a472099ad27ef1fb6b99658e91a67e2c8e84eec482c0806f57e4e83  .release-pack/pack-1/equipe-tech-observability-cli-0.2.0.tgz
+60ca90d32e48f85ebcd874817c7eb1e8f36a145895951ecc0d74c5b5c28477e8  .release-pack/pack-2/equipe-tech-observability-0.2.0.tgz
+365c6cb45a472099ad27ef1fb6b99658e91a67e2c8e84eec482c0806f57e4e83  .release-pack/pack-2/equipe-tech-observability-cli-0.2.0.tgz
+60ca90d32e48f85ebcd874817c7eb1e8f36a145895951ecc0d74c5b5c28477e8  .release-pack/pack-3/equipe-tech-observability-0.2.0.tgz
+365c6cb45a472099ad27ef1fb6b99658e91a67e2c8e84eec482c0806f57e4e83  .release-pack/pack-3/equipe-tech-observability-cli-0.2.0.tgz

--- a/docs/releases/v0.2.0.sha256
+++ b/docs/releases/v0.2.0.sha256
@@ -1,0 +1,2 @@
+60ca90d32e48f85ebcd874817c7eb1e8f36a145895951ecc0d74c5b5c28477e8  dist-release/equipe-tech-observability-0.2.0.tgz
+365c6cb45a472099ad27ef1fb6b99658e91a67e2c8e84eec482c0806f57e4e83  dist-release/equipe-tech-observability-cli-0.2.0.tgz

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,6 +2,10 @@
 
 CLI da plataforma de observabilidade da Equipe Tech para operar a stack local, provisionar assets do Collector e criar ambientes remotos isolados.
 
+## Requisito de runtime
+
+A CLI exige Bun 1.4 ou posterior. O executável publicado usa `#!/usr/bin/env bun`; instalar o pacote com npm não substitui esse requisito.
+
 ## Instalação
 
 ```sh
@@ -21,6 +25,10 @@ npx @equipe-tech/observability-cli --help
 - `observability provision` gera a configuração de produção do Collector e o accessory Kamal.
 - Os comandos de autenticação e ambiente provisionam recursos específicos de Axiom e Sentry e armazenam credenciais locais com modo restrito.
 - Os assets de produção incluem filas persistentes limitadas, retry, health check, métricas internas, normalização de ambiente e redação de dados sensíveis.
+
+A stack local usa um diretório por versão em `OBSERVABILITY_HOME`, cujo padrão é `~/.local/state/observability`. A atualização para 0.2.0 muda o diretório ativo de `0.1.0` para `0.2.0`. Derrube a stack antiga com a CLI 0.1.0 antes de atualizar; a CLI 0.2.0 não reutiliza nem remove automaticamente o diretório anterior.
+
+A dependência direta `@effect/platform-node-shared@4.0.0-rc.111` impede que instaladores npm selecionem uma release candidate posterior incompatível com `@effect/platform-bun@4.0.0-rc.111`. Remova o pin somente quando todo o conjunto Effect for atualizado e validado em conjunto.
 
 Consulte a [referência completa da CLI](https://github.com/equipe-tech/observability/blob/master/docs/cli-reference.md) e o [guia operacional do Collector](https://github.com/equipe-tech/observability/blob/master/docs/collector-production-operations.md).
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,29 @@
+# @equipe-tech/observability-cli
+
+CLI da plataforma de observabilidade da Equipe Tech para operar a stack local, provisionar assets do Collector e criar ambientes remotos isolados.
+
+## Instalação
+
+```sh
+npm install --global @equipe-tech/observability-cli
+observability --help
+```
+
+Também pode ser executada sem instalação global:
+
+```sh
+npx @equipe-tech/observability-cli --help
+```
+
+## Capacidades
+
+- `observability dev up|status|down` opera o Collector e o viewer locais.
+- `observability provision` gera a configuração de produção do Collector e o accessory Kamal.
+- Os comandos de autenticação e ambiente provisionam recursos específicos de Axiom e Sentry e armazenam credenciais locais com modo restrito.
+- Os assets de produção incluem filas persistentes limitadas, retry, health check, métricas internas, normalização de ambiente e redação de dados sensíveis.
+
+Consulte a [referência completa da CLI](https://github.com/equipe-tech/observability/blob/master/docs/cli-reference.md) e o [guia operacional do Collector](https://github.com/equipe-tech/observability/blob/master/docs/collector-production-operations.md).
+
+## Licença
+
+Apache-2.0

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equipe-tech/observability-cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "CLI da plataforma de observabilidade: ciclo de vida da stack local de desenvolvimento",
   "license": "Apache-2.0",
   "bin": {
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@effect/platform-bun": "4.0.0-rc.111",
+    "@effect/platform-node-shared": "4.0.0-rc.111",
     "effect": "4.0.0-rc.111"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,16 @@
   "name": "@equipe-tech/observability-cli",
   "version": "0.2.0",
   "description": "CLI da plataforma de observabilidade: ciclo de vida da stack local de desenvolvimento",
+  "homepage": "https://github.com/equipe-tech/observability#readme",
+  "bugs": {
+    "url": "https://github.com/equipe-tech/observability/issues"
+  },
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/equipe-tech/observability.git",
+    "directory": "packages/cli"
+  },
   "bin": {
     "observability": "./dist/main.js"
   },
@@ -18,5 +27,8 @@
     "@effect/platform-bun": "4.0.0-rc.111",
     "@effect/platform-node-shared": "4.0.0-rc.111",
     "effect": "4.0.0-rc.111"
+  },
+  "engines": {
+    "bun": ">=1.4.0"
   }
 }

--- a/packages/cli/test/CollectorRecovery.bun.test.ts
+++ b/packages/cli/test/CollectorRecovery.bun.test.ts
@@ -1,10 +1,15 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { Schema } from "effect";
+import { access, chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
+const projectRoot = fileURLToPath(new URL("../../..", import.meta.url));
 const image = "otel/opentelemetry-collector-contrib:0.159.0";
-const enabled = process.env["OBSERVABILITY_COLLECTOR_RECOVERY"] === "1";
+const signalCleanupMode = process.env["OBSERVABILITY_COLLECTOR_RECOVERY_SIGNAL_TEST"] === "1";
+const enabled = process.env["OBSERVABILITY_COLLECTOR_RECOVERY"] === "1" || signalCleanupMode;
+const signalReadyFile = process.env["OBSERVABILITY_COLLECTOR_RECOVERY_SIGNAL_READY_FILE"] ?? "";
 const evidenceRoot = process.env["OBSERVABILITY_COLLECTOR_RECOVERY_ARTIFACT_ROOT"] ?? "";
 const runId = `obs10-${process.pid}-${crypto.randomUUID().slice(0, 8)}`;
 const network = `${runId}-network`;
@@ -434,16 +439,66 @@ interface SaturationResult {
   readonly statuses: ReadonlyArray<number>;
 }
 
-afterAll(async () => {
-  if (!enabled) {
-    return;
+const SignalCleanupReady = Schema.Struct({
+  root: Schema.NonEmptyString,
+  container: Schema.NonEmptyString,
+  network: Schema.NonEmptyString,
+  runId: Schema.NonEmptyString,
+});
+
+const decodeSignalCleanupReady = Schema.decodeUnknownSync(SignalCleanupReady);
+const cleanupSignals: ReadonlyArray<NodeJS.Signals> = ["SIGINT", "SIGTERM"];
+
+const waitForFile = async (path: string): Promise<void> => {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (await Bun.file(path).exists()) {
+      return;
+    }
+    await Bun.sleep(25);
   }
+  throw new Error(`The cleanup harness did not create ${path}.`);
+};
+
+const pathExists = async (path: string): Promise<boolean> => {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const waitForAbsence = async (path: string): Promise<void> => {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (!(await pathExists(path))) {
+      return;
+    }
+    await Bun.sleep(25);
+  }
+  throw new Error(`The cleanup harness left ${path}.`);
+};
+
+let cleanupStarted = false;
+let cleanupResult = Promise.resolve();
+
+const cleanupResources = async (): Promise<void> => {
   for (const container of containers) {
-    Bun.spawnSync(["docker", "rm", "--force", container], { stdout: "ignore", stderr: "ignore" });
+    Bun.spawnSync(["docker", "rm", "--force", container], {
+      stdout: "ignore",
+      stderr: "ignore",
+    });
   }
-  Bun.spawnSync(["docker", "network", "rm", network], { stdout: "ignore", stderr: "ignore" });
-  if (root !== "") {
-    await rm(root, { recursive: true, force: true });
+  containers.clear();
+  Bun.spawnSync(["docker", "network", "rm", network], {
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  const temporaryRoot = root;
+  root = "";
+  if (temporaryRoot !== "") {
+    await rm(temporaryRoot, { recursive: true, force: true });
   }
   const remainingContainers = Bun.spawnSync([
     "docker",
@@ -467,9 +522,58 @@ afterAll(async () => {
     "cleanup.txt",
     `containers=${remainingContainers.trim()}\nnetworks=${remainingNetworks.trim()}`,
   );
+};
+
+const cleanup = (): Promise<void> => {
+  if (!cleanupStarted) {
+    cleanupStarted = true;
+    cleanupResult = cleanupResources();
+  }
+  return cleanupResult;
+};
+
+const terminateAfterCleanup = (exitCode: number): void => {
+  cleanup().then(
+    () => process.exit(exitCode),
+    () => process.exit(exitCode),
+  );
+};
+
+const onSigint = (): void => terminateAfterCleanup(130);
+const onSigterm = (): void => terminateAfterCleanup(143);
+
+if (enabled) {
+  process.once("SIGINT", onSigint);
+  process.once("SIGTERM", onSigterm);
+}
+
+afterAll(async () => {
+  if (!enabled) {
+    return;
+  }
+  await cleanup();
+  process.off("SIGINT", onSigint);
+  process.off("SIGTERM", onSigterm);
 });
 
-const recoveryDescribe = enabled ? describe : describe.skip;
+const signalCleanupDescribe = signalCleanupMode ? describe : describe.skip;
+
+signalCleanupDescribe("Collector recovery signal cleanup", () => {
+  test("removes the temporary root, container, and network on termination", async () => {
+    if (signalReadyFile === "") {
+      throw new Error("The signal cleanup test requires a ready file path.");
+    }
+    root = await mkdtemp(join(tmpdir(), `${runId}-`));
+    runDocker(["network", "create", network]);
+    const container = `${runId}-signal`;
+    containers.add(container);
+    runDocker(["create", "--name", container, "--network", network, image]);
+    await writeFile(signalReadyFile, JSON.stringify({ root, container, network, runId }));
+    await new Promise<never>(() => undefined);
+  }, 30_000);
+});
+
+const recoveryDescribe = enabled && !signalCleanupMode ? describe : describe.skip;
 
 recoveryDescribe("Collector recovery", () => {
   test("persists every signal across restart and rejects requests at queue saturation", async () => {
@@ -687,4 +791,84 @@ recoveryDescribe("Collector recovery", () => {
       ].join("\n"),
     );
   }, 120_000);
+
+  for (const signal of cleanupSignals) {
+    test(`removes recovery resources after ${signal}`, async () => {
+      const controlRoot = await mkdtemp(join(tmpdir(), "collector-cleanup-test-"));
+      const readyFile = join(controlRoot, "ready.json");
+      const child = Bun.spawn(
+        ["bun", "test", "packages/cli/test/CollectorRecovery.bun.test.ts", "--timeout", "30000"],
+        {
+          cwd: projectRoot,
+          env: {
+            ...process.env,
+            OBSERVABILITY_COLLECTOR_RECOVERY: "0",
+            OBSERVABILITY_COLLECTOR_RECOVERY_ARTIFACT_ROOT: "",
+            OBSERVABILITY_COLLECTOR_RECOVERY_SIGNAL_TEST: "1",
+            OBSERVABILITY_COLLECTOR_RECOVERY_SIGNAL_READY_FILE: readyFile,
+          },
+          stdout: "ignore",
+          stderr: "ignore",
+        },
+      );
+      let childRoot = "";
+      let childContainer = "";
+      let childNetwork = "";
+      let childRunId = "";
+      let exited = false;
+      try {
+        await waitForFile(readyFile);
+        const content: unknown = JSON.parse(await readFile(readyFile, "utf8"));
+        const ready = decodeSignalCleanupReady(content);
+        childRoot = ready.root;
+        childContainer = ready.container;
+        childNetwork = ready.network;
+        childRunId = ready.runId;
+        child.kill(signal);
+        const exitCode = await child.exited;
+        exited = true;
+        expect(exitCode).toBe(signal === "SIGINT" ? 130 : 143);
+        await waitForAbsence(childRoot);
+        const remainingContainers = runDocker([
+          "ps",
+          "--all",
+          "--filter",
+          `name=${childRunId}`,
+          "--format",
+          "{{.Names}}",
+        ]);
+        const remainingNetworks = runDocker([
+          "network",
+          "ls",
+          "--filter",
+          `name=${childNetwork}`,
+          "--format",
+          "{{.Name}}",
+        ]);
+        expect(remainingContainers).toBe("");
+        expect(remainingNetworks).toBe("");
+      } finally {
+        if (!exited) {
+          child.kill("SIGKILL");
+          await child.exited;
+        }
+        if (childContainer !== "") {
+          Bun.spawnSync(["docker", "rm", "--force", childContainer], {
+            stdout: "ignore",
+            stderr: "ignore",
+          });
+        }
+        if (childNetwork !== "") {
+          Bun.spawnSync(["docker", "network", "rm", childNetwork], {
+            stdout: "ignore",
+            stderr: "ignore",
+          });
+        }
+        if (childRoot !== "") {
+          await rm(childRoot, { recursive: true, force: true });
+        }
+        await rm(controlRoot, { recursive: true, force: true });
+      }
+    }, 30_000);
+  }
 });

--- a/packages/cli/test/CollectorRecovery.bun.test.ts
+++ b/packages/cli/test/CollectorRecovery.bun.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { Schema } from "effect";
-import { access, chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,6 +8,8 @@ import { fileURLToPath } from "node:url";
 const projectRoot = fileURLToPath(new URL("../../..", import.meta.url));
 const image = "otel/opentelemetry-collector-contrib:0.159.0";
 const signalCleanupMode = process.env["OBSERVABILITY_COLLECTOR_RECOVERY_SIGNAL_TEST"] === "1";
+const signalCleanupScenario =
+  process.env["OBSERVABILITY_COLLECTOR_RECOVERY_SIGNAL_SCENARIO"] ?? "resources";
 const enabled = process.env["OBSERVABILITY_COLLECTOR_RECOVERY"] === "1" || signalCleanupMode;
 const signalReadyFile = process.env["OBSERVABILITY_COLLECTOR_RECOVERY_SIGNAL_READY_FILE"] ?? "";
 const evidenceRoot = process.env["OBSERVABILITY_COLLECTOR_RECOVERY_ARTIFACT_ROOT"] ?? "";
@@ -15,6 +17,10 @@ const runId = `obs10-${process.pid}-${crypto.randomUUID().slice(0, 8)}`;
 const network = `${runId}-network`;
 const containers = new Set<string>();
 let root = "";
+let rootAllocation = Promise.resolve("");
+let signalHandlersInstalled = false;
+let terminationRequested = false;
+let terminationExitCode = 1;
 
 const runDocker = (args: ReadonlyArray<string>): string => {
   const result = Bun.spawnSync(["docker", ...args], {
@@ -440,14 +446,39 @@ interface SaturationResult {
 }
 
 const SignalCleanupReady = Schema.Struct({
-  root: Schema.NonEmptyString,
-  container: Schema.NonEmptyString,
-  network: Schema.NonEmptyString,
+  phase: Schema.NonEmptyString,
+  root: Schema.NonEmptyString.pipe(Schema.optionalKey),
+  container: Schema.NonEmptyString.pipe(Schema.optionalKey),
+  network: Schema.NonEmptyString.pipe(Schema.optionalKey),
   runId: Schema.NonEmptyString,
 });
 
 const decodeSignalCleanupReady = Schema.decodeUnknownSync(SignalCleanupReady);
-const cleanupSignals: ReadonlyArray<NodeJS.Signals> = ["SIGINT", "SIGTERM"];
+
+interface CollectorCleanupScenario {
+  readonly name: string;
+  readonly scenario: string;
+  readonly signals: ReadonlyArray<NodeJS.Signals>;
+  readonly expectedExitCode: number;
+}
+
+const collectorCleanupScenarios: ReadonlyArray<CollectorCleanupScenario> = [
+  { name: "active resources", scenario: "resources", signals: ["SIGINT"], expectedExitCode: 130 },
+  { name: "allocation", scenario: "allocation", signals: ["SIGTERM"], expectedExitCode: 143 },
+  {
+    name: "repeated signals",
+    scenario: "allocation",
+    signals: ["SIGINT", "SIGINT"],
+    expectedExitCode: 130,
+  },
+  {
+    name: "mixed signals",
+    scenario: "allocation",
+    signals: ["SIGTERM", "SIGINT"],
+    expectedExitCode: 143,
+  },
+  { name: "normal failure", scenario: "failure", signals: [], expectedExitCode: 1 },
+];
 
 const waitForFile = async (path: string): Promise<void> => {
   const deadline = Date.now() + 10_000;
@@ -484,6 +515,11 @@ let cleanupStarted = false;
 let cleanupResult = Promise.resolve();
 
 const cleanupResources = async (): Promise<void> => {
+  try {
+    root = await rootAllocation;
+  } catch {
+    root = "";
+  }
   for (const container of containers) {
     Bun.spawnSync(["docker", "rm", "--force", container], {
       stdout: "ignore",
@@ -533,19 +569,37 @@ const cleanup = (): Promise<void> => {
 };
 
 const terminateAfterCleanup = (exitCode: number): void => {
+  if (!terminationRequested) {
+    terminationRequested = true;
+    terminationExitCode = exitCode;
+    cleanup().then(
+      () => process.exit(terminationExitCode),
+      () => process.exit(terminationExitCode),
+    );
+    return;
+  }
   cleanup().then(
-    () => process.exit(exitCode),
-    () => process.exit(exitCode),
+    () => undefined,
+    () => undefined,
   );
 };
 
 const onSigint = (): void => terminateAfterCleanup(130);
 const onSigterm = (): void => terminateAfterCleanup(143);
 
-if (enabled) {
-  process.once("SIGINT", onSigint);
-  process.once("SIGTERM", onSigterm);
-}
+const installSignalHandlers = (): void => {
+  if (!signalHandlersInstalled) {
+    signalHandlersInstalled = true;
+    process.on("SIGINT", onSigint);
+    process.on("SIGTERM", onSigterm);
+  }
+};
+
+const beginRootAllocation = (allocate: () => Promise<string>): Promise<string> => {
+  rootAllocation = allocate();
+  installSignalHandlers();
+  return rootAllocation;
+};
 
 afterAll(async () => {
   if (!enabled) {
@@ -554,21 +608,41 @@ afterAll(async () => {
   await cleanup();
   process.off("SIGINT", onSigint);
   process.off("SIGTERM", onSigterm);
+  signalHandlersInstalled = false;
 });
 
 const signalCleanupDescribe = signalCleanupMode ? describe : describe.skip;
 
 signalCleanupDescribe("Collector recovery signal cleanup", () => {
-  test("removes the temporary root, container, and network on termination", async () => {
+  test("cleans the bounded signal scenario", async () => {
     if (signalReadyFile === "") {
       throw new Error("The signal cleanup test requires a ready file path.");
     }
-    root = await mkdtemp(join(tmpdir(), `${runId}-`));
-    runDocker(["network", "create", network]);
-    const container = `${runId}-signal`;
-    containers.add(container);
-    runDocker(["create", "--name", container, "--network", network, image]);
-    await writeFile(signalReadyFile, JSON.stringify({ root, container, network, runId }));
+    const allocate = async (): Promise<string> => {
+      if (signalCleanupScenario === "allocation") {
+        await writeFile(signalReadyFile, JSON.stringify({ phase: "allocation", runId }));
+        await Bun.sleep(250);
+      }
+      return mkdtemp(join(tmpdir(), `${runId}-`));
+    };
+    root = await beginRootAllocation(allocate);
+    if (terminationRequested) {
+      await cleanup();
+      await Bun.sleep(30_000);
+    }
+    if (signalCleanupScenario !== "allocation") {
+      runDocker(["network", "create", network]);
+      const container = `${runId}-signal`;
+      containers.add(container);
+      runDocker(["create", "--name", container, "--network", network, image]);
+      await writeFile(
+        signalReadyFile,
+        JSON.stringify({ phase: signalCleanupScenario, root, container, network, runId }),
+      );
+      if (signalCleanupScenario === "failure") {
+        throw new Error("The recovery cleanup failure test failed as requested.");
+      }
+    }
     await new Promise<never>(() => undefined);
   }, 30_000);
 });
@@ -577,7 +651,7 @@ const recoveryDescribe = enabled && !signalCleanupMode ? describe : describe.ski
 
 recoveryDescribe("Collector recovery", () => {
   test("persists every signal across restart and rejects requests at queue saturation", async () => {
-    root = await mkdtemp(join(tmpdir(), `${runId}-`));
+    root = await beginRootAllocation(() => mkdtemp(join(tmpdir(), `${runId}-`)));
     runDocker(["network", "create", network]);
     await saveEvidence("run.txt", `run_id=${runId}\nnetwork=${network}\nroot=${root}`);
     await saveEvidence(
@@ -792,8 +866,8 @@ recoveryDescribe("Collector recovery", () => {
     );
   }, 120_000);
 
-  for (const signal of cleanupSignals) {
-    test(`removes recovery resources after ${signal}`, async () => {
+  for (const scenario of collectorCleanupScenarios) {
+    test(`cleans recovery resources for ${scenario.name}`, async () => {
       const controlRoot = await mkdtemp(join(tmpdir(), "collector-cleanup-test-"));
       const readyFile = join(controlRoot, "ready.json");
       const child = Bun.spawn(
@@ -805,6 +879,7 @@ recoveryDescribe("Collector recovery", () => {
             OBSERVABILITY_COLLECTOR_RECOVERY: "0",
             OBSERVABILITY_COLLECTOR_RECOVERY_ARTIFACT_ROOT: "",
             OBSERVABILITY_COLLECTOR_RECOVERY_SIGNAL_TEST: "1",
+            OBSERVABILITY_COLLECTOR_RECOVERY_SIGNAL_SCENARIO: scenario.scenario,
             OBSERVABILITY_COLLECTOR_RECOVERY_SIGNAL_READY_FILE: readyFile,
           },
           stdout: "ignore",
@@ -820,15 +895,22 @@ recoveryDescribe("Collector recovery", () => {
         await waitForFile(readyFile);
         const content: unknown = JSON.parse(await readFile(readyFile, "utf8"));
         const ready = decodeSignalCleanupReady(content);
-        childRoot = ready.root;
-        childContainer = ready.container;
-        childNetwork = ready.network;
+        childRoot = ready.root ?? "";
+        childContainer = ready.container ?? "";
+        childNetwork = ready.network ?? "";
         childRunId = ready.runId;
-        child.kill(signal);
+        for (const signal of scenario.signals) {
+          child.kill(signal);
+        }
         const exitCode = await child.exited;
         exited = true;
-        expect(exitCode).toBe(signal === "SIGINT" ? 130 : 143);
-        await waitForAbsence(childRoot);
+        expect(exitCode).toBe(scenario.expectedExitCode);
+        if (childRoot !== "") {
+          await waitForAbsence(childRoot);
+        }
+        const remainingRoots = (await readdir(tmpdir())).filter((entry) =>
+          entry.startsWith(`${childRunId}-`),
+        );
         const remainingContainers = runDocker([
           "ps",
           "--all",
@@ -841,10 +923,11 @@ recoveryDescribe("Collector recovery", () => {
           "network",
           "ls",
           "--filter",
-          `name=${childNetwork}`,
+          `name=${childRunId}`,
           "--format",
           "{{.Name}}",
         ]);
+        expect(remainingRoots).toEqual([]);
         expect(remainingContainers).toBe("");
         expect(remainingNetworks).toBe("");
       } finally {

--- a/packages/cli/test/PackageSmokeCleanup.bun.test.ts
+++ b/packages/cli/test/PackageSmokeCleanup.bun.test.ts
@@ -1,22 +1,20 @@
 import { describe, expect, test } from "bun:test";
-import { access, mkdtemp, rm } from "node:fs/promises";
+import { Schema } from "effect";
+import { access, mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const projectRoot = fileURLToPath(new URL("../../..", import.meta.url));
-const signals: ReadonlyArray<NodeJS.Signals> = ["SIGINT", "SIGTERM"];
 
-const waitForFile = async (path: string): Promise<void> => {
-  const deadline = Date.now() + 10_000;
-  while (Date.now() < deadline) {
-    if (await Bun.file(path).exists()) {
-      return;
-    }
-    await Bun.sleep(25);
-  }
-  throw new Error(`The cleanup harness did not create ${path}.`);
-};
+const CleanupReady = Schema.Struct({
+  phase: Schema.NonEmptyString,
+  temporaryDirectory: Schema.NonEmptyString.pipe(Schema.optionalKey),
+  commandPid: Schema.Int.pipe(Schema.optionalKey),
+  descendantPid: Schema.Int.pipe(Schema.optionalKey),
+});
+
+const decodeCleanupReady = Schema.decodeUnknownSync(CleanupReady);
 
 const pathExists = async (path: string): Promise<boolean> => {
   try {
@@ -27,52 +25,176 @@ const pathExists = async (path: string): Promise<boolean> => {
   }
 };
 
+const waitForFile = async (path: string): Promise<void> => {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (await pathExists(path)) {
+      return;
+    }
+    await Bun.sleep(10);
+  }
+  throw new Error(`The cleanup harness did not create ${path}.`);
+};
+
 const waitForAbsence = async (path: string): Promise<void> => {
   const deadline = Date.now() + 10_000;
   while (Date.now() < deadline) {
     if (!(await pathExists(path))) {
       return;
     }
-    await Bun.sleep(25);
+    await Bun.sleep(10);
   }
   throw new Error(`The cleanup harness left ${path}.`);
 };
 
-describe("package smoke cleanup", () => {
-  for (const signal of signals) {
-    test(`removes its temporary directory after ${signal}`, async () => {
-      const controlRoot = await mkdtemp(join(tmpdir(), "package-smoke-cleanup-test-"));
-      const readyFile = join(controlRoot, "ready.txt");
-      const child = Bun.spawn(
-        ["bun", "scripts/package-smoke.ts", "--signal-cleanup-test", readyFile],
-        {
-          cwd: projectRoot,
-          stdout: "ignore",
-          stderr: "ignore",
-        },
-      );
-      let temporaryDirectory = "";
-      let exited = false;
-      try {
-        await waitForFile(readyFile);
-        temporaryDirectory = (await Bun.file(readyFile).text()).trim();
-        expect(temporaryDirectory).toContain("observability-package-");
-        expect(await pathExists(temporaryDirectory)).toBe(true);
-        child.kill(signal);
-        const exitCode = await child.exited;
-        exited = true;
-        expect(exitCode).toBe(signal === "SIGINT" ? 130 : 143);
-        await waitForAbsence(temporaryDirectory);
-      } finally {
-        if (!exited) {
-          child.kill("SIGKILL");
-          await child.exited;
-        }
-        if (temporaryDirectory !== "") {
-          await rm(temporaryDirectory, { recursive: true, force: true });
-        }
-        await rm(controlRoot, { recursive: true, force: true });
-      }
-    });
+const pidExists = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
   }
+};
+
+const waitForPidAbsence = async (pid: number): Promise<void> => {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (!pidExists(pid)) {
+      return;
+    }
+    await Bun.sleep(10);
+  }
+  throw new Error(`The cleanup harness left process ${pid}.`);
+};
+
+const packageTemporaryDirectories = async (): Promise<ReadonlyArray<string>> =>
+  (await readdir(tmpdir())).filter((entry) => entry.startsWith("observability-package-")).sort();
+
+interface SignalScenario {
+  readonly scenario: string;
+  readonly signals: ReadonlyArray<NodeJS.Signals>;
+  readonly cleanupDeadlineMilliseconds?: number;
+}
+
+const runSignalScenario = async (options: SignalScenario): Promise<number> => {
+  const controlRoot = await mkdtemp(join(tmpdir(), "package-smoke-cleanup-test-"));
+  const readyFile = join(controlRoot, "ready.json");
+  const before = await packageTemporaryDirectories();
+  const cleanupDeadline = options.cleanupDeadlineMilliseconds ?? 3_000;
+  const child = Bun.spawn(
+    [
+      "bun",
+      "scripts/package-smoke.ts",
+      "--signal-cleanup-test",
+      readyFile,
+      options.scenario,
+      String(cleanupDeadline),
+    ],
+    {
+      cwd: projectRoot,
+      stdout: "ignore",
+      stderr: "ignore",
+    },
+  );
+  let temporaryDirectory = "";
+  let commandPid = 0;
+  let descendantPid = 0;
+  let exited = false;
+  try {
+    await waitForFile(readyFile);
+    const content: unknown = JSON.parse(await Bun.file(readyFile).text());
+    const ready = decodeCleanupReady(content);
+    temporaryDirectory = ready.temporaryDirectory ?? "";
+    commandPid = ready.commandPid ?? 0;
+    descendantPid = ready.descendantPid ?? 0;
+    if (temporaryDirectory !== "") {
+      expect(await pathExists(temporaryDirectory)).toBe(true);
+    }
+    const startedAt = Date.now();
+    for (const signal of options.signals) {
+      child.kill(signal);
+    }
+    const exitCode = await child.exited;
+    exited = true;
+    const elapsed = Date.now() - startedAt;
+    expect(exitCode).toBe(options.signals[0] === "SIGINT" ? 130 : 143);
+    if (temporaryDirectory !== "") {
+      await waitForAbsence(temporaryDirectory);
+    }
+    if (commandPid !== 0) {
+      await waitForPidAbsence(commandPid);
+    }
+    if (descendantPid !== 0) {
+      await waitForPidAbsence(descendantPid);
+    }
+    expect(await packageTemporaryDirectories()).toEqual(before);
+    return elapsed;
+  } finally {
+    if (!exited) {
+      child.kill("SIGKILL");
+      await child.exited;
+    }
+    if (commandPid !== 0 && pidExists(commandPid)) {
+      process.kill(commandPid, "SIGKILL");
+    }
+    if (descendantPid !== 0 && pidExists(descendantPid)) {
+      process.kill(descendantPid, "SIGKILL");
+    }
+    if (temporaryDirectory !== "") {
+      await rm(temporaryDirectory, { recursive: true, force: true });
+    }
+    await rm(controlRoot, { recursive: true, force: true });
+  }
+};
+
+describe("package smoke cleanup", () => {
+  test("joins cleanup when signaled during allocation", async () => {
+    await runSignalScenario({ scenario: "allocation", signals: ["SIGINT"] });
+  });
+
+  test("terminates an active command process tree", async () => {
+    await runSignalScenario({ scenario: "active", signals: ["SIGTERM"] });
+  });
+
+  test("joins repeated identical signals", async () => {
+    await runSignalScenario({ scenario: "allocation", signals: ["SIGINT", "SIGINT"] });
+  });
+
+  test("joins mixed signals and preserves the first exit code", async () => {
+    await runSignalScenario({ scenario: "allocation", signals: ["SIGTERM", "SIGINT"] });
+  });
+
+  test("bounds SIGTERM, SIGKILL, and exit observation by one deadline", async () => {
+    const elapsed = await runSignalScenario({
+      scenario: "deadline",
+      signals: ["SIGTERM"],
+      cleanupDeadlineMilliseconds: 400,
+    });
+    expect(elapsed).toBeLessThan(1_500);
+  });
+
+  test("cleans a normal failure", async () => {
+    const controlRoot = await mkdtemp(join(tmpdir(), "package-smoke-failure-test-"));
+    const readyFile = join(controlRoot, "ready.json");
+    const before = await packageTemporaryDirectories();
+    const child = Bun.spawn(
+      ["bun", "scripts/package-smoke.ts", "--signal-cleanup-test", readyFile, "failure"],
+      { cwd: projectRoot, stdout: "ignore", stderr: "ignore" },
+    );
+    let temporaryDirectory = "";
+    try {
+      await waitForFile(readyFile);
+      const content: unknown = JSON.parse(await Bun.file(readyFile).text());
+      temporaryDirectory = decodeCleanupReady(content).temporaryDirectory ?? "";
+      expect(await child.exited).toBe(1);
+      await waitForAbsence(temporaryDirectory);
+      expect(await packageTemporaryDirectories()).toEqual(before);
+    } finally {
+      child.kill("SIGKILL");
+      if (temporaryDirectory !== "") {
+        await rm(temporaryDirectory, { recursive: true, force: true });
+      }
+      await rm(controlRoot, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/cli/test/PackageSmokeCleanup.bun.test.ts
+++ b/packages/cli/test/PackageSmokeCleanup.bun.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { access, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const signals: ReadonlyArray<NodeJS.Signals> = ["SIGINT", "SIGTERM"];
+
+const waitForFile = async (path: string): Promise<void> => {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (await Bun.file(path).exists()) {
+      return;
+    }
+    await Bun.sleep(25);
+  }
+  throw new Error(`The cleanup harness did not create ${path}.`);
+};
+
+const pathExists = async (path: string): Promise<boolean> => {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const waitForAbsence = async (path: string): Promise<void> => {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (!(await pathExists(path))) {
+      return;
+    }
+    await Bun.sleep(25);
+  }
+  throw new Error(`The cleanup harness left ${path}.`);
+};
+
+describe("package smoke cleanup", () => {
+  for (const signal of signals) {
+    test(`removes its temporary directory after ${signal}`, async () => {
+      const controlRoot = await mkdtemp(join(tmpdir(), "package-smoke-cleanup-test-"));
+      const readyFile = join(controlRoot, "ready.txt");
+      const child = Bun.spawn(
+        ["bun", "scripts/package-smoke.ts", "--signal-cleanup-test", readyFile],
+        {
+          cwd: projectRoot,
+          stdout: "ignore",
+          stderr: "ignore",
+        },
+      );
+      let temporaryDirectory = "";
+      let exited = false;
+      try {
+        await waitForFile(readyFile);
+        temporaryDirectory = (await Bun.file(readyFile).text()).trim();
+        expect(temporaryDirectory).toContain("observability-package-");
+        expect(await pathExists(temporaryDirectory)).toBe(true);
+        child.kill(signal);
+        const exitCode = await child.exited;
+        exited = true;
+        expect(exitCode).toBe(signal === "SIGINT" ? 130 : 143);
+        await waitForAbsence(temporaryDirectory);
+      } finally {
+        if (!exited) {
+          child.kill("SIGKILL");
+          await child.exited;
+        }
+        if (temporaryDirectory !== "") {
+          await rm(temporaryDirectory, { recursive: true, force: true });
+        }
+        await rm(controlRoot, { recursive: true, force: true });
+      }
+    });
+  }
+});

--- a/packages/telemetry/LICENSE
+++ b/packages/telemetry/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -1,0 +1,27 @@
+# @equipe-tech/observability
+
+Biblioteca OpenTelemetry da Equipe Tech para aplicações Effect, Node.js, NestJS e browser.
+
+## Instalação
+
+```sh
+npm install @equipe-tech/observability effect
+```
+
+## Entrypoints
+
+- `@equipe-tech/observability`: configuração, eventos de browser e wide events.
+- `@equipe-tech/observability/metrics`: métricas imperativas sem tipos Effect na API pública.
+- `@equipe-tech/observability/node`: runtime OTLP para Node.js e ingestão de eventos do browser.
+- `@equipe-tech/observability/nestjs`: interceptor HTTP, módulo de ciclo de vida e correlação de eventos por requisição.
+- `@equipe-tech/observability/browser`: serviço Effect de telemetria do browser.
+- `@equipe-tech/observability/browser/client`: cliente imperativo de browser sem tipos Effect na API pública.
+- `@equipe-tech/observability/testing`: captura OTLP em memória para testes.
+
+O adapter NestJS suporta NestJS 10 e 11 com Express. Os peers NestJS e RxJS são opcionais para consumidores que não usam esse entrypoint.
+
+Consulte a [documentação completa](https://github.com/equipe-tech/observability#readme) para configuração, política de dados, semântica HTTP e exemplos.
+
+## Licença
+
+Apache-2.0

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -2,7 +2,16 @@
   "name": "@equipe-tech/observability",
   "version": "0.2.0",
   "description": "Contrato OpenTelemetry da Equipe Tech: configuracao, layer OTLP e wide events sobre Effect",
+  "homepage": "https://github.com/equipe-tech/observability#readme",
+  "bugs": {
+    "url": "https://github.com/equipe-tech/observability/issues"
+  },
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/equipe-tech/observability.git",
+    "directory": "packages/telemetry"
+  },
   "files": [
     "dist"
   ],

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equipe-tech/observability",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Contrato OpenTelemetry da Equipe Tech: configuracao, layer OTLP e wide events sobre Effect",
   "license": "Apache-2.0",
   "files": [

--- a/scripts/package-smoke.ts
+++ b/scripts/package-smoke.ts
@@ -59,6 +59,7 @@ try {
       directory: join(root, "packages/telemetry"),
       archive: "telemetry.tgz",
       required: [
+        "package/README.md",
         "package/dist/LICENSE",
         "package/dist/index.js",
         "package/dist/index.d.ts",
@@ -82,6 +83,7 @@ try {
       directory: join(root, "packages/cli"),
       archive: "cli.tgz",
       required: [
+        "package/README.md",
         "package/dist/LICENSE",
         "package/dist/main.js",
         "package/dist/main.d.ts",
@@ -217,6 +219,41 @@ try {
     }),
   );
   requireSuccess(await run(["bun", "install"], consumer), "Installing packed packages");
+
+  const nodeConsumer = join(temporaryDirectory, "node consumer outside repository");
+  await mkdir(nodeConsumer, { recursive: true });
+  await writeFile(
+    join(nodeConsumer, "package.json"),
+    JSON.stringify({
+      private: true,
+      type: "module",
+      dependencies: {
+        "@equipe-tech/observability": `file:${join(temporaryDirectory, "telemetry.tgz")}`,
+        "@equipe-tech/observability-cli": `file:${join(temporaryDirectory, "cli.tgz")}`,
+      },
+    }),
+  );
+  requireSuccess(
+    await run(["npm", "install"], nodeConsumer),
+    "Installing packed packages with npm",
+  );
+  requireSuccess(
+    await run(
+      [
+        "node",
+        "--input-type=module",
+        "--eval",
+        "const [root, metrics, node, browser, client, testing] = await Promise.all([import('@equipe-tech/observability'), import('@equipe-tech/observability/metrics'), import('@equipe-tech/observability/node'), import('@equipe-tech/observability/browser'), import('@equipe-tech/observability/browser/client'), import('@equipe-tech/observability/testing')]); if (!root.Telemetry || !metrics.createMetrics || !node.runMain || !browser.BrowserTelemetry || !client.createBrowserTelemetryClient || !testing.run) process.exit(1);",
+      ],
+      nodeConsumer,
+    ),
+    "Importing packed packages with Node.js",
+  );
+  requireSuccess(
+    await run([join(nodeConsumer, "node_modules/.bin/observability"), "--help"], nodeConsumer),
+    "Executing the npm-installed CLI",
+  );
+
   const declarations = new Bun.Glob("**/*.d.ts");
   for (const packageName of ["observability", "observability-cli"]) {
     const distribution = join(consumer, "node_modules/@equipe-tech", packageName, "dist");

--- a/scripts/package-smoke.ts
+++ b/scripts/package-smoke.ts
@@ -5,10 +5,25 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = fileURLToPath(new URL("..", import.meta.url));
+const cleanupTestIndex = process.argv.indexOf("--signal-cleanup-test");
+const cleanupReadyFile = cleanupTestIndex === -1 ? "" : (process.argv[cleanupTestIndex + 1] ?? "");
+const cleanupScenario =
+  cleanupTestIndex === -1 ? "" : (process.argv[cleanupTestIndex + 2] ?? "idle");
+const requestedCleanupDeadline = Number(
+  cleanupTestIndex === -1 ? "3000" : (process.argv[cleanupTestIndex + 3] ?? "3000"),
+);
+const cleanupDeadlineMilliseconds =
+  Number.isFinite(requestedCleanupDeadline) && requestedCleanupDeadline > 0
+    ? requestedCleanupDeadline
+    : 3_000;
+const processGroupsSupported = process.platform !== "win32";
 let temporaryDirectory = "";
 let cleanupStarted = false;
 let cleanupResult = Promise.resolve();
+let terminationRequested = false;
+let terminationExitCode = 1;
 const activeChildren = new Set<ReturnType<typeof Bun.spawn>>();
+let allocationPromise = Promise.resolve("");
 
 type CommandResult = {
   readonly exitCode: number;
@@ -17,7 +32,13 @@ type CommandResult = {
 };
 
 const run = (command: Array<string>, cwd: string, env = process.env): Promise<CommandResult> => {
-  const child = Bun.spawn(command, { cwd, env, stdout: "pipe", stderr: "pipe" });
+  const child = Bun.spawn(command, {
+    cwd,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+    detached: processGroupsSupported,
+  });
   activeChildren.add(child);
   return Promise.all([
     child.exited,
@@ -51,21 +72,53 @@ const assertArchive = (
   }
 };
 
-const stopChild = async (child: ReturnType<typeof Bun.spawn>): Promise<void> => {
-  child.kill("SIGTERM");
-  const exited = await Promise.race([
-    child.exited.then(() => true),
-    Bun.sleep(2_000).then(() => false),
-  ]);
-  if (!exited) {
-    child.kill("SIGKILL");
-    await child.exited;
+const signalChild = (child: ReturnType<typeof Bun.spawn>, signal: NodeJS.Signals): void => {
+  if (processGroupsSupported) {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      child.kill(signal);
+      return;
+    }
+  }
+  child.kill(signal);
+};
+
+const waitForChildren = async (
+  children: ReadonlyArray<ReturnType<typeof Bun.spawn>>,
+  deadline: number,
+): Promise<void> => {
+  while (Date.now() < deadline && children.some((child) => activeChildren.has(child))) {
+    await Bun.sleep(10);
   }
 };
 
-const cleanupTemporaryDirectory = async (): Promise<void> => {
-  await Promise.all([...activeChildren].map(stopChild));
+const stopChildren = async (deadline: number): Promise<void> => {
+  const children = [...activeChildren];
+  for (const child of children) {
+    signalChild(child, "SIGTERM");
+  }
+  const remaining = Math.max(0, deadline - Date.now());
+  const termDeadline = Date.now() + Math.floor(remaining / 2);
+  await waitForChildren(children, termDeadline);
+  for (const child of children) {
+    if (activeChildren.has(child)) {
+      signalChild(child, "SIGKILL");
+    }
+  }
+  await waitForChildren(children, deadline);
   activeChildren.clear();
+};
+
+const cleanupTemporaryDirectory = async (): Promise<void> => {
+  try {
+    temporaryDirectory = await allocationPromise;
+  } catch {
+    temporaryDirectory = "";
+  }
+  const deadline = Date.now() + cleanupDeadlineMilliseconds;
+  await stopChildren(deadline);
   if (temporaryDirectory !== "") {
     await rm(temporaryDirectory, { recursive: true, force: true });
   }
@@ -80,28 +133,69 @@ const cleanup = (): Promise<void> => {
 };
 
 const terminateAfterCleanup = (exitCode: number): void => {
+  if (!terminationRequested) {
+    terminationRequested = true;
+    terminationExitCode = exitCode;
+    cleanup().then(
+      () => process.exit(terminationExitCode),
+      () => process.exit(terminationExitCode),
+    );
+    return;
+  }
   cleanup().then(
-    () => process.exit(exitCode),
-    () => process.exit(exitCode),
+    () => undefined,
+    () => undefined,
   );
 };
 
 const onSigint = (): void => terminateAfterCleanup(130);
 const onSigterm = (): void => terminateAfterCleanup(143);
 
-process.once("SIGINT", onSigint);
-process.once("SIGTERM", onSigterm);
+const allocateTemporaryDirectory = async (): Promise<string> => {
+  if (cleanupScenario === "allocation") {
+    if (cleanupReadyFile === "") {
+      throw new Error("The allocation cleanup test requires a ready file path.");
+    }
+    await writeFile(cleanupReadyFile, JSON.stringify({ phase: "allocation" }));
+    await Bun.sleep(250);
+  }
+  return mkdtemp(join(tmpdir(), "observability-package-"));
+};
+
+allocationPromise = allocateTemporaryDirectory();
+process.on("SIGINT", onSigint);
+process.on("SIGTERM", onSigterm);
 
 try {
-  temporaryDirectory = await mkdtemp(join(tmpdir(), "observability-package-"));
-  const signalTestIndex = process.argv.indexOf("--signal-cleanup-test");
-  if (signalTestIndex !== -1) {
-    const readyFile = process.argv[signalTestIndex + 1];
-    if (readyFile === undefined) {
+  temporaryDirectory = await allocationPromise;
+  if (terminationRequested) {
+    await cleanup();
+    await Bun.sleep(cleanupDeadlineMilliseconds);
+  }
+  if (cleanupTestIndex !== -1) {
+    if (cleanupReadyFile === "") {
       throw new Error("The signal cleanup test requires a ready file path.");
     }
-    await writeFile(readyFile, temporaryDirectory);
-    await Bun.sleep(60_000);
+    if (cleanupScenario === "failure") {
+      await writeFile(cleanupReadyFile, JSON.stringify({ phase: "failure", temporaryDirectory }));
+      throw new Error("The package cleanup failure test failed as requested.");
+    }
+    if (cleanupScenario === "active" || cleanupScenario === "deadline") {
+      const stubborn = cleanupScenario === "deadline";
+      const descendantProgram = stubborn
+        ? 'process.on("SIGTERM", () => undefined); await Bun.sleep(60000);'
+        : "await Bun.sleep(60000);";
+      const commandProgram = [
+        stubborn ? 'process.on("SIGTERM", () => undefined);' : "",
+        `const descendant = Bun.spawn(["bun", "--eval", ${JSON.stringify(descendantProgram)}], { stdout: "ignore", stderr: "ignore" });`,
+        `await Bun.write(${JSON.stringify(cleanupReadyFile)}, JSON.stringify({ phase: "active", temporaryDirectory: ${JSON.stringify(temporaryDirectory)}, commandPid: process.pid, descendantPid: descendant.pid }));`,
+        "await Bun.sleep(60000);",
+      ].join("\n");
+      await run(["bun", "--eval", commandProgram], root);
+    } else if (cleanupScenario !== "allocation") {
+      await writeFile(cleanupReadyFile, JSON.stringify({ phase: "idle", temporaryDirectory }));
+      await Bun.sleep(60_000);
+    }
   }
 
   const cliManifest: unknown = JSON.parse(

--- a/scripts/package-smoke.ts
+++ b/scripts/package-smoke.ts
@@ -5,13 +5,10 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = fileURLToPath(new URL("..", import.meta.url));
-const temporaryDirectory = await mkdtemp(join(tmpdir(), "observability-package-"));
-const cliManifest: unknown = JSON.parse(
-  await readFile(join(root, "packages/cli/package.json"), "utf8"),
-);
-const cliVersion = Schema.decodeUnknownSync(Schema.Struct({ version: Schema.NonEmptyString }))(
-  cliManifest,
-).version;
+let temporaryDirectory = "";
+let cleanupStarted = false;
+let cleanupResult = Promise.resolve();
+const activeChildren = new Set<ReturnType<typeof Bun.spawn>>();
 
 type CommandResult = {
   readonly exitCode: number;
@@ -21,11 +18,14 @@ type CommandResult = {
 
 const run = (command: Array<string>, cwd: string, env = process.env): Promise<CommandResult> => {
   const child = Bun.spawn(command, { cwd, env, stdout: "pipe", stderr: "pipe" });
+  activeChildren.add(child);
   return Promise.all([
     child.exited,
     new Response(child.stdout).text(),
     new Response(child.stderr).text(),
-  ]).then(([exitCode, stdout, stderr]) => ({ exitCode, stdout, stderr }));
+  ])
+    .then(([exitCode, stdout, stderr]) => ({ exitCode, stdout, stderr }))
+    .finally(() => activeChildren.delete(child));
 };
 
 const requireSuccess = (result: CommandResult, operation: string): void => {
@@ -51,7 +51,59 @@ const assertArchive = (
   }
 };
 
+const cleanupTemporaryDirectory = async (): Promise<void> => {
+  const exits: Array<Promise<number>> = [];
+  for (const child of activeChildren) {
+    child.kill("SIGTERM");
+    exits.push(child.exited);
+  }
+  await Promise.all(exits);
+  activeChildren.clear();
+  if (temporaryDirectory !== "") {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+};
+
+const cleanup = (): Promise<void> => {
+  if (!cleanupStarted) {
+    cleanupStarted = true;
+    cleanupResult = cleanupTemporaryDirectory();
+  }
+  return cleanupResult;
+};
+
+const terminateAfterCleanup = (exitCode: number): void => {
+  cleanup().then(
+    () => process.exit(exitCode),
+    () => process.exit(exitCode),
+  );
+};
+
+const onSigint = (): void => terminateAfterCleanup(130);
+const onSigterm = (): void => terminateAfterCleanup(143);
+
+process.once("SIGINT", onSigint);
+process.once("SIGTERM", onSigterm);
+
 try {
+  temporaryDirectory = await mkdtemp(join(tmpdir(), "observability-package-"));
+  const signalTestIndex = process.argv.indexOf("--signal-cleanup-test");
+  if (signalTestIndex !== -1) {
+    const readyFile = process.argv[signalTestIndex + 1];
+    if (readyFile === undefined) {
+      throw new Error("The signal cleanup test requires a ready file path.");
+    }
+    await writeFile(readyFile, temporaryDirectory);
+    await Bun.sleep(60_000);
+  }
+
+  const cliManifest: unknown = JSON.parse(
+    await readFile(join(root, "packages/cli/package.json"), "utf8"),
+  );
+  const cliVersion = Schema.decodeUnknownSync(Schema.Struct({ version: Schema.NonEmptyString }))(
+    cliManifest,
+  ).version;
+
   requireSuccess(await run(["bun", "run", "build"], root), "The package build");
 
   const packages = [
@@ -466,5 +518,7 @@ try {
     throw new Error("The packed CLI did not render the Kamal accessory template.");
   }
 } finally {
-  await rm(temporaryDirectory, { recursive: true, force: true });
+  await cleanup();
+  process.off("SIGINT", onSigint);
+  process.off("SIGTERM", onSigterm);
 }

--- a/scripts/package-smoke.ts
+++ b/scripts/package-smoke.ts
@@ -59,6 +59,7 @@ try {
       directory: join(root, "packages/telemetry"),
       archive: "telemetry.tgz",
       required: [
+        "package/LICENSE",
         "package/README.md",
         "package/dist/LICENSE",
         "package/dist/index.js",
@@ -83,6 +84,7 @@ try {
       directory: join(root, "packages/cli"),
       archive: "cli.tgz",
       required: [
+        "package/LICENSE",
         "package/README.md",
         "package/dist/LICENSE",
         "package/dist/main.js",
@@ -117,6 +119,15 @@ try {
     );
     requireSuccess(listing, `Reading ${packageSpec.archive}`);
     assertArchive(listing.stdout, packageSpec.required, ["package/src/", "package/test/"]);
+    const packedLicense = await run(
+      ["tar", "-xOf", join(temporaryDirectory, packageSpec.archive), "package/LICENSE"],
+      temporaryDirectory,
+    );
+    requireSuccess(packedLicense, `Reading the root license from ${packageSpec.archive}`);
+    const repositoryLicense = await readFile(join(root, "LICENSE"), "utf8");
+    if (packedLicense.stdout !== repositoryLicense) {
+      throw new Error(`The package root license differs in ${packageSpec.archive}.`);
+    }
   }
 
   for (const nestMajor of [10, 11]) {

--- a/scripts/package-smoke.ts
+++ b/scripts/package-smoke.ts
@@ -51,13 +51,20 @@ const assertArchive = (
   }
 };
 
-const cleanupTemporaryDirectory = async (): Promise<void> => {
-  const exits: Array<Promise<number>> = [];
-  for (const child of activeChildren) {
-    child.kill("SIGTERM");
-    exits.push(child.exited);
+const stopChild = async (child: ReturnType<typeof Bun.spawn>): Promise<void> => {
+  child.kill("SIGTERM");
+  const exited = await Promise.race([
+    child.exited.then(() => true),
+    Bun.sleep(2_000).then(() => false),
+  ]);
+  if (!exited) {
+    child.kill("SIGKILL");
+    await child.exited;
   }
-  await Promise.all(exits);
+};
+
+const cleanupTemporaryDirectory = async (): Promise<void> => {
+  await Promise.all([...activeChildren].map(stopChild));
   activeChildren.clear();
   if (temporaryDirectory !== "") {
     await rm(temporaryDirectory, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- prepare synchronized `0.2.0` packages and handwritten release notes
- add provenance metadata, package READMEs/licenses, deterministic checksum enforcement, and fail-closed publication gates
- verify npm and Bun consumers, Nest 10/11, Collector recovery, signal cleanup, and reproducible tarballs

## Verification

- six deterministic tarball hashes match `docs/releases/v0.2.0.sha256`
- clean npm/Node and Bun external installations
- Collector 0.159.0 validation, recovery, local canary, and teardown
- `bun check`, build, full tests, package smoke, actionlint, provenance dry runs, and independent exact-head review
- no tag, release, npm publication, registry mutation, or deployed-provider call

Linear: OBS-9
