### PR TITLE
fix(cli): create MetricsDB datasets and correlation gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,11 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag existente ainda não publicada (exemplo: v0.2.0)"
+        description: "Tag existente exata a publicar (exemplo: v0.2.1)"
+        required: true
+        type: string
+      confirm_tag:
+        description: "Repita exatamente o tag aprovado para confirmar a publicação"
         required: true
         type: string
 
@@ -29,16 +33,32 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          fetch-depth: 0
       - name: Validate tag against the package manifests
         id: meta
         env:
-          INPUT_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_REF: ${{ github.ref }}
+          INPUT_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+          CONFIRM_TAG: ${{ inputs.confirm_tag || '' }}
         run: |
           set -euo pipefail
           tag="$INPUT_TAG"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            [[ "$CONFIRM_TAG" == "$tag" ]] \
+              || { echo "Publication confirmation must exactly match $tag."; exit 1; }
+            [[ "$EVENT_REF" == "refs/tags/$tag" ]] \
+              || { echo "Publication dispatch must run from the exact tag ref refs/tags/$tag."; exit 1; }
+          fi
           [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$ ]] \
             || { echo "The tag $tag does not match the release tag format."; exit 1; }
+          git show-ref --verify --quiet "refs/tags/$tag" \
+            || { echo "The tag $tag does not exist in this checkout."; exit 1; }
+          tag_commit="$(git rev-list -n 1 "$tag")"
+          head_commit="$(git rev-parse HEAD)"
+          [[ "$head_commit" == "$tag_commit" ]] \
+            || { echo "HEAD $head_commit is not the exact commit for $tag ($tag_commit)."; exit 1; }
           version="${tag#v}"
           for manifest in packages/telemetry/package.json packages/cli/package.json; do
             manifest_version="$(jq -r .version "$manifest")"
@@ -64,10 +84,12 @@ jobs:
       run_deployed_canary: false
 
   release:
+    if: github.event_name == 'workflow_dispatch'
     needs:
       - tag-check
       - verify
     runs-on: ubuntu-latest
+    environment: publication
     permissions:
       contents: write
     steps:
@@ -158,10 +180,12 @@ jobs:
         run: rm -rf .release-pack dist-release release-notes.md
 
   publish-npm:
+    if: github.event_name == 'workflow_dispatch'
     needs:
       - tag-check
       - release
     runs-on: ubuntu-latest
+    environment: publication
     permissions:
       contents: read
       id-token: write

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ O comando é idempotente. Um arquivo provisionado que foi modificado localmente 
 
 ### Ambientes remotos
 
-A CLI autentica com Axiom e Sentry, cria recursos isolados por ambiente e salva as credenciais com modo `0600`.
+A CLI autentica com Axiom e Sentry, cria recursos isolados por ambiente e salva as credenciais com modo `0600`. Datasets Axiom usam kinds específicos por sinal, aceitam edge deployment e retenção explícitos e nunca são excluídos automaticamente. A exportação de um ambiente Axiom espera a ação manual de Correlation e `--correlation-confirmed`.
 
 Consulte estes documentos:
 
@@ -159,7 +159,7 @@ O projeto usa [Effect](https://effect.website) v4 e conventional commits.
 
 ### Release
 
-Toda preparação e publicação segue exclusivamente o [runbook de publicação coordenada](docs/release-publication-runbook.md). As notas aprovadas de `v0.2.0` são o arquivo manuscrito [docs/releases/v0.2.0.md](docs/releases/v0.2.0.md). Não crie tags, releases, assets ou publicações npm por comandos fora do gate humano documentado no runbook.
+Toda preparação e publicação segue exclusivamente o [runbook de publicação coordenada](docs/release-publication-runbook.md). As notas candidatas de `v0.2.1` são o arquivo manuscrito [docs/releases/v0.2.1.md](docs/releases/v0.2.1.md). Não crie tags, releases, assets ou publicações npm por comandos fora do gate humano documentado no runbook.
 
 ## Propriedade e transferência
 

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "packages/cli": {
       "name": "@equipe-tech/observability-cli",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "bin": {
         "observability": "./dist/main.js",
       },
@@ -32,7 +32,7 @@
     },
     "packages/telemetry": {
       "name": "@equipe-tech/observability",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "effect": "4.0.0-rc.111",
       },

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -43,7 +43,10 @@ observability provision \
   [--environment <name>]... \
   [--provider <axiom|sentry>]... \
   [--sentry-platform <platform>] \
-  [--rotate-token]
+  [--rotate-token] \
+  [--axiom-edge-deployment <id>] \
+  [--axiom-retention-days <days>] \
+  [--correlation-confirmed]
 ```
 
 Sem `--environment`, o comando gera somente os assets locais. As flags remotas válidas não fazem chamadas externas nesse modo.
@@ -54,7 +57,11 @@ Sem `--provider`, um ambiente novo configura Axiom e Sentry. Um ambiente existen
 
 A seleção é aditiva. Selecionar Axiom em um ambiente Sentry adiciona Axiom sem remover Sentry.
 
-Axiom cria três datasets e um token de ingestão por ambiente. Sentry usa um projeto para todos os ambientes da aplicação.
+Axiom cria traces e logs como `axiom:events:v1` e métricas como `otel:metrics:v1`. `--axiom-edge-deployment` aplica e verifica um edge deployment explícito. `--axiom-retention-days` aceita somente dias positivos e aplica retenção explícita sem inventar o padrão da organização. A CLI nunca exclui datasets incompatíveis.
+
+Axiom não oferece uma API pública estável para grupos de Correlation. O provisionamento salva e imprime uma ação manual com o nome, slug e os três datasets. Depois de criar o grupo no Console, repita o provisionamento com `--correlation-confirmed`. A confirmação só é aceita após uma leitura nova dos datasets, incluindo o kind MetricsDB e o edge deployment da métrica.
+
+Sentry usa um projeto para todos os ambientes da aplicação.
 
 `--rotate-token` exige Axiom em todos os ambientes solicitados. A CLI marca a mutação como pendente antes da chamada ao Axiom e salva o novo segredo após cada ambiente. Uma falha de transporte, resposta ilegível, HTTP 5xx ou status 2xx inesperado exige outra rotação explícita.
 
@@ -90,6 +97,8 @@ Um ambiente Sentry imprime `SENTRY_DSN`.
 
 Um ambiente combinado imprime a união dessas variáveis. A saída contém segredos e não aplica mascaramento.
 
+Ambientes Axiom bloqueiam a exportação com `OBS_CLI_CORRELATION_CONFIRMATION_REQUIRED` enquanto a ação manual não tiver confirmação explícita.
+
 ## Arquivo de credenciais
 
 O caminho padrão é `~/.local/state/observability/credentials.json`. `OBSERVABILITY_HOME` altera o diretório pai.
@@ -98,9 +107,9 @@ A CLI cria o diretório com modo `0700`. A CLI cria o arquivo com modo `0600`.
 
 O arquivo contém tokens administrativos, tokens de ingestão, DSNs e o estado dos ambientes. A CLI recusa um arquivo acessível por outros usuários.
 
-A CLI atual migra o formato de versão 1 para a versão 2 antes de uma chamada externa. A migração preserva os segredos e o modo `0600`.
+A CLI atual migra os formatos 1 e 2 diretamente para a versão 3 antes de uma chamada externa. A migração preserva segredos, IDs, nomes de datasets, estado Sentry, mutações pendentes e o modo `0600`. Ambientes Axiom migrados ficam em `verification-required`.
 
-Não use uma versão antiga da CLI após a migração. Versões antigas não leem o formato de versão 2.
+Não volte para a CLI 0.2.0 após a migração. Ela não lê o formato 3. Restaure um backup seguro do formato anterior somente se também restaurar e validar os segredos de runtime correspondentes.
 
 A CLI serializa atualizações com um lock entre processos. Um comando espera no máximo 30 segundos por outra atualização.
 
@@ -122,22 +131,28 @@ O nome do token Axiom segue este formato:
 
 ## Erros remotos
 
-| Código                                        | Significado                                                    |
-| --------------------------------------------- | -------------------------------------------------------------- |
-| `OBS_CLI_CREDENTIALS_INVALID`                 | O arquivo ou a configuração de credenciais não passa no parse. |
-| `OBS_CLI_CREDENTIALS_INSECURE`                | O arquivo de credenciais permite acesso para outros usuários.  |
-| `OBS_CLI_CREDENTIALS_FAILED`                  | A CLI não consegue acessar o arquivo de credenciais.           |
-| `OBS_CLI_CREDENTIALS_VERSION_UNSUPPORTED`     | Uma CLI antiga não lê a versão do arquivo.                     |
-| `OBS_CLI_CREDENTIALS_BUSY`                    | Outro processo mantém o lock de atualização.                   |
-| `OBS_CLI_REMOTE_CREDENTIALS_MISSING`          | Uma seleção combinada não encontra as duas credenciais.        |
-| `OBS_CLI_REMOTE_PROVIDER_CREDENTIALS_MISSING` | Um provider selecionado não tem credenciais.                   |
-| `OBS_CLI_REMOTE_INVALID_PROVIDER`             | `--provider` não contém `axiom` ou `sentry`.                   |
-| `OBS_CLI_REMOTE_UNAUTHORIZED`                 | O provider recusa a credencial ou o acesso à organização.      |
-| `OBS_CLI_REMOTE_FAILED`                       | A requisição falha ou o provider retorna um status inesperado. |
-| `OBS_CLI_REMOTE_INVALID_RESPONSE`             | A resposta do provider não passa no parse.                     |
-| `OBS_CLI_REMOTE_INVALID_ENVIRONMENT`          | O ambiente ou o nome derivado de um dataset é inválido.        |
-| `OBS_CLI_REMOTE_ROTATION_NOT_SELECTED`        | Uma rotação inclui um ambiente sem Axiom.                      |
-| `OBS_CLI_REMOTE_TOKEN_UNAVAILABLE`            | O token existe no Axiom, mas a CLI não possui o valor secreto. |
-| `OBS_CLI_REMOTE_PARTIAL_FAILURE`              | Um ambiente falha após a CLI salvar ambientes anteriores.      |
-| `OBS_CLI_REMOTE_OUTCOME_UNKNOWN`              | Uma mutação do token Axiom não tem resultado local confirmado. |
-| `OBS_CLI_REMOTE_ENVIRONMENT_NOT_FOUND`        | O arquivo local não contém o projeto e o ambiente solicitados. |
+| Código                                         | Significado                                                                 |
+| ---------------------------------------------- | --------------------------------------------------------------------------- |
+| `OBS_CLI_CREDENTIALS_INVALID`                  | O arquivo ou a configuração de credenciais não passa no parse.              |
+| `OBS_CLI_CREDENTIALS_INSECURE`                 | O arquivo de credenciais permite acesso para outros usuários.               |
+| `OBS_CLI_CREDENTIALS_FAILED`                   | A CLI não consegue acessar o arquivo de credenciais.                        |
+| `OBS_CLI_CREDENTIALS_VERSION_UNSUPPORTED`      | Uma CLI antiga não lê a versão do arquivo.                                  |
+| `OBS_CLI_CREDENTIALS_BUSY`                     | Outro processo mantém o lock de atualização.                                |
+| `OBS_CLI_REMOTE_CREDENTIALS_MISSING`           | Uma seleção combinada não encontra as duas credenciais.                     |
+| `OBS_CLI_REMOTE_PROVIDER_CREDENTIALS_MISSING`  | Um provider selecionado não tem credenciais.                                |
+| `OBS_CLI_REMOTE_INVALID_PROVIDER`              | `--provider` não contém `axiom` ou `sentry`.                                |
+| `OBS_CLI_REMOTE_UNAUTHORIZED`                  | O provider recusa a credencial ou o acesso à organização.                   |
+| `OBS_CLI_REMOTE_FAILED`                        | A requisição falha ou o provider retorna um status inesperado.              |
+| `OBS_CLI_REMOTE_INVALID_RESPONSE`              | A resposta do provider não passa no parse.                                  |
+| `OBS_CLI_REMOTE_INVALID_ENVIRONMENT`           | O ambiente ou o nome derivado de um dataset é inválido.                     |
+| `OBS_CLI_REMOTE_ROTATION_NOT_SELECTED`         | Uma rotação inclui um ambiente sem Axiom.                                   |
+| `OBS_CLI_REMOTE_TOKEN_UNAVAILABLE`             | O token existe no Axiom, mas a CLI não possui o valor secreto.              |
+| `OBS_CLI_REMOTE_PARTIAL_FAILURE`               | Um ambiente falha após a CLI salvar ambientes anteriores.                   |
+| `OBS_CLI_REMOTE_OUTCOME_UNKNOWN`               | Uma mutação do token Axiom não tem resultado local confirmado.              |
+| `OBS_CLI_REMOTE_ENVIRONMENT_NOT_FOUND`         | O arquivo local não contém o projeto e o ambiente solicitados.              |
+| `OBS_CLI_AXIOM_METRICS_MIGRATION_REQUIRED`     | O dataset de métricas existe com kind incompatível e exige migração manual. |
+| `OBS_CLI_AXIOM_DATASET_CONFIGURATION_CONFLICT` | Kind, edge deployment ou retenção não corresponde ao contrato solicitado.   |
+| `OBS_CLI_AXIOM_REMOTE_NAME_CONFLICT`           | Há nomes remotos duplicados de dataset ou token.                            |
+| `OBS_CLI_AXIOM_TOKEN_CAPABILITIES_MISMATCH`    | O token não tem somente ingest-create nos três datasets exatos.             |
+| `OBS_CLI_AXIOM_RETENTION_INVALID`              | A retenção informada não é um inteiro positivo.                             |
+| `OBS_CLI_CORRELATION_CONFIRMATION_REQUIRED`    | A ação manual de Correlation ainda não foi confirmada.                      |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -57,9 +57,9 @@ Sem `--provider`, um ambiente novo configura Axiom e Sentry. Um ambiente existen
 
 A seleção é aditiva. Selecionar Axiom em um ambiente Sentry adiciona Axiom sem remover Sentry.
 
-Axiom cria traces e logs como `axiom:events:v1` e métricas como `otel:metrics:v1`. `--axiom-edge-deployment` aplica e verifica um edge deployment explícito. `--axiom-retention-days` aceita somente dias positivos e aplica retenção explícita sem inventar o padrão da organização. A CLI nunca exclui datasets incompatíveis.
+Axiom cria traces e logs como `axiom:events:v1` e métricas como `otel:metrics:v1`. `--axiom-edge-deployment` aplica e verifica um edge deployment explícito. `--axiom-retention-days` aceita somente dias positivos e aplica retenção explícita somente na criação. Se um dataset existente divergir em dias ou `useRetentionPeriod`, o preflight falha sem mutação. A CLI nunca altera retenção nem exclui datasets durante reconciliação.
 
-Axiom não oferece uma API pública estável para grupos de Correlation. O provisionamento salva e imprime uma ação manual com o nome, slug e os três datasets. Depois de criar o grupo no Console, repita o provisionamento com `--correlation-confirmed`. A confirmação só é aceita após uma leitura nova dos datasets, incluindo o kind MetricsDB e o edge deployment da métrica.
+Axiom não oferece uma API pública estável para grupos de Correlation. Uma primeira invocação concluída salva e imprime uma ação manual com o nome, slug e os três datasets. Depois de criar o grupo no Console, repita o provisionamento com `--correlation-confirmed` e um `--axiom-edge-deployment` explícito. A confirmação rejeita a mesma invocação que cria recursos, exige a ação manual persistida correspondente e verifica o edge exato em traces, logs e métricas.
 
 Sentry usa um projeto para todos os ambientes da aplicação.
 

--- a/docs/environment-management.md
+++ b/docs/environment-management.md
@@ -48,7 +48,7 @@ A CLI cria três datasets para cada ambiente:
 - `<project>-<environment>-logs`
 - `<project>-<environment>-metrics`
 
-Traces e logs usam `axiom:events:v1`. Métricas usam `otel:metrics:v1`. A CLI verifica kind, edge deployment explícito e retenção explícita antes de mutar recursos. Ela nunca exclui um dataset incompatível. Uma métrica antiga com kind Events exige preservação e migração manual.
+Traces e logs usam `axiom:events:v1`. Métricas usam `otel:metrics:v1`. A CLI verifica kind, edge deployment explícito e retenção explícita no preflight. Retenção divergente é um conflito destrutivo e nunca produz PUT automático. A CLI nunca exclui um dataset incompatível. Uma métrica antiga com kind Events exige preservação e migração manual.
 
 A CLI também cria um token de ingestão para cada ambiente. O token concede ingest-create somente aos três datasets exatos daquele ambiente.
 

--- a/docs/environment-management.md
+++ b/docs/environment-management.md
@@ -48,7 +48,11 @@ A CLI cria três datasets para cada ambiente:
 - `<project>-<environment>-logs`
 - `<project>-<environment>-metrics`
 
-A CLI também cria um token de ingestão para cada ambiente. O token concede acesso somente aos três datasets daquele ambiente.
+Traces e logs usam `axiom:events:v1`. Métricas usam `otel:metrics:v1`. A CLI verifica kind, edge deployment explícito e retenção explícita antes de mutar recursos. Ela nunca exclui um dataset incompatível. Uma métrica antiga com kind Events exige preservação e migração manual.
+
+A CLI também cria um token de ingestão para cada ambiente. O token concede ingest-create somente aos três datasets exatos daquele ambiente.
+
+Como Axiom não publica uma API estável de Correlation, a CLI persiste uma ação manual. A exportação permanece bloqueada até o operador criar o grupo no Console e repetir o provisionamento com `--correlation-confirmed`.
 
 Esse isolamento permite retenções e permissões diferentes. Uma credencial de `staging` não concede acesso aos dados de `production`.
 

--- a/docs/release-publication-runbook.md
+++ b/docs/release-publication-runbook.md
@@ -8,7 +8,9 @@ Este runbook prepara a candidata `0.2.1`, mas separa todas as mutações por um 
 - Um único tag anotado `v0.2.1` aponta para o commit aprovado que contém os dois manifests e as notas.
 - O commit aprovado está no histórico de `origin/master` antes da criação do tag.
 - Os tarballs aprovados contêm READMEs, licença Apache-2.0, declarações, entrypoints e assets esperados.
-- O workflow usa OpenID Connect com `id-token: write` e `npm publish --provenance`.
+- O push do tag executa somente verificação e não pode criar GitHub Release nem publicar no npm.
+- A publicação exige `workflow_dispatch` separado com `tag` e `confirm_tag` exatamente iguais, checkout do tag existente e aprovação do environment protegido `publication`.
+- O workflow usa OpenID Connect com `id-token: write` e `npm publish --provenance` somente nos jobs de publicação disparados manualmente.
 - A publicação exige `NPM_TOKEN`, autenticação confirmada por `npm whoami` e as variáveis de requisição OIDC do GitHub. A ausência de qualquer requisito falha o job.
 - A verificação acionada pela release não recebe AXIOM_TOKEN nem outro secret de provider e não executa o canário deployed.
 - Nenhum comando de mutação desta página roda sem aprovação do responsável pela release.
@@ -183,7 +185,7 @@ git tag -a v0.2.1 "$approved_sha" -m "Release 0.2.1"
 git push origin v0.2.1
 ```
 
-O push do tag aciona o workflow. Não rode `npm publish`, `gh release create`, upload de asset ou alteração de dist-tag manual em paralelo.
+O push do tag aciona somente a verificação reutilizável. Ele não cria release e não publica pacotes. Depois da verificação, selecione o próprio ref `v0.2.1` na interface e abra manualmente o workflow `Release` com `tag=v0.2.1` e `confirm_tag=v0.2.1`. O workflow exige que o dispatch rode do ref exato do tag, que o tag exista, que o checkout corresponda ao commit exato e que o environment protegido `publication` seja aprovado. Não rode `npm publish`, `gh release create`, upload de asset ou alteração de dist-tag manual em paralelo.
 
 ## Verificação após publicação
 
@@ -202,7 +204,7 @@ Confirme dois assets no GitHub Release, proveniência nos dois pacotes npm, `lat
 
 - Antes do tag, corrija no branch, repita toda a validação, gere novos hashes e peça nova aprovação do SHA.
 - Se o tag remoto existir mas o GitHub Release e os dois pacotes ainda não tiverem sido publicados, cancele o workflow. Remova eventual draft e o tag somente com aprovação explícita. Nunca mova um tag de release publicado.
-- Se somente um pacote for publicado, preserve a versão publicada. Corrija a causa e reexecute o workflow por `workflow_dispatch` com o tag existente. A release e os assets existentes não são sobrescritos, os checksums são revalidados e a versão já publicada é ignorada de forma idempotente.
+- Se somente um pacote for publicado, preserve a versão publicada. Corrija a causa e reexecute o workflow por `workflow_dispatch` com `tag` e `confirm_tag` iguais ao tag existente. A release e os assets existentes não são sobrescritos, os checksums são revalidados e a versão já publicada é ignorada de forma idempotente.
 - Se um pacote publicado tiver defeito, faça uma correção coordenada com nova versão patch nos dois pacotes. Não reutilize `0.2.1`.
 - A CLI 0.2.0 não lê credenciais no formato 3. Um rollback da CLI exige restaurar um backup seguro anterior à migração e validar os segredos de runtime; não converta o arquivo manualmente.
 - Não use `npm unpublish` como rollback normal. `npm deprecate` ou mudança manual de dist-tag exigem aprovação explícita, mensagem de substituição e verificação dos dois pacotes.

--- a/docs/release-publication-runbook.md
+++ b/docs/release-publication-runbook.md
@@ -1,11 +1,11 @@
 # Publicação coordenada dos pacotes
 
-Este runbook prepara uma publicação, mas separa todas as mutações por um gate humano explícito. Os comandos usam `0.2.0` e `v0.2.0`; substitua ambos somente depois de uma nova análise semver e revisão dos manifests.
+Este runbook prepara a candidata `0.2.1`, mas separa todas as mutações por um gate humano explícito. Nenhum tag, release ou pacote é publicado durante a preparação.
 
 ## Invariantes
 
 - `@equipe-tech/observability` e `@equipe-tech/observability-cli` usam exatamente a mesma versão.
-- Um único tag anotado `v0.2.0` aponta para o commit aprovado que contém os dois manifests e as notas.
+- Um único tag anotado `v0.2.1` aponta para o commit aprovado que contém os dois manifests e as notas.
 - O commit aprovado está no histórico de `origin/master` antes da criação do tag.
 - Os tarballs aprovados contêm READMEs, licença Apache-2.0, declarações, entrypoints e assets esperados.
 - O workflow usa OpenID Connect com `id-token: write` e `npm publish --provenance`.
@@ -20,9 +20,9 @@ set -euo pipefail
 git fetch origin --tags --prune
 git status --short --branch
 test -z "$(git status --porcelain)"
-test "$(jq -r .version packages/telemetry/package.json)" = "0.2.0"
-test "$(jq -r .version packages/cli/package.json)" = "0.2.0"
-test -z "$(git tag --list v0.2.0)"
+test "$(jq -r .version packages/telemetry/package.json)" = "0.2.1"
+test "$(jq -r .version packages/cli/package.json)" = "0.2.1"
+test -z "$(git tag --list v0.2.1)"
 for package in @equipe-tech/observability @equipe-tech/observability-cli; do
   if output="$(npm view "$package" version dist-tags versions --json 2>&1)"; then
     echo "$output"
@@ -33,7 +33,7 @@ for package in @equipe-tech/observability @equipe-tech/observability-cli; do
     exit 1
   fi
 done
-bun scripts/release.ts 0.2.0 --dry-run
+bun scripts/release.ts 0.2.1 --dry-run
 bun check
 bun run build
 bun run test
@@ -114,41 +114,41 @@ for pack_set in pack-1 pack-2 pack-3; do
   (
     cd packages/telemetry
     bun pm pack --ignore-scripts --quiet \
-      --filename "$destination/equipe-tech-observability-0.2.0.tgz"
+      --filename "$destination/equipe-tech-observability-0.2.1.tgz"
   )
   (
     cd packages/cli
     bun pm pack --ignore-scripts --quiet \
-      --filename "$destination/equipe-tech-observability-cli-0.2.0.tgz"
+      --filename "$destination/equipe-tech-observability-cli-0.2.1.tgz"
   )
 done
 {
   for pack_set in pack-2 pack-3; do
-    cmp "$pack_root/pack-1/equipe-tech-observability-0.2.0.tgz" \
-      "$pack_root/$pack_set/equipe-tech-observability-0.2.0.tgz"
+    cmp "$pack_root/pack-1/equipe-tech-observability-0.2.1.tgz" \
+      "$pack_root/$pack_set/equipe-tech-observability-0.2.1.tgz"
     echo "observability pack-1 and $pack_set are byte-identical"
-    cmp "$pack_root/pack-1/equipe-tech-observability-cli-0.2.0.tgz" \
-      "$pack_root/$pack_set/equipe-tech-observability-cli-0.2.0.tgz"
+    cmp "$pack_root/pack-1/equipe-tech-observability-cli-0.2.1.tgz" \
+      "$pack_root/$pack_set/equipe-tech-observability-cli-0.2.1.tgz"
     echo "observability-cli pack-1 and $pack_set are byte-identical"
   done
   sha256sum .release-pack/pack-*/*.tgz
-  sha256sum --check docs/releases/v0.2.0.sha256
+  sha256sum --check docs/releases/v0.2.1.sha256
 } | tee "$evidence_root/triple-pack.txt"
-tar -tzf "$pack_root/pack-1/equipe-tech-observability-0.2.0.tgz" | sort \
+tar -tzf "$pack_root/pack-1/equipe-tech-observability-0.2.1.tgz" | sort \
   > "$evidence_root/observability-files.txt"
-tar -tzf "$pack_root/pack-1/equipe-tech-observability-cli-0.2.0.tgz" | sort \
+tar -tzf "$pack_root/pack-1/equipe-tech-observability-cli-0.2.1.tgz" | sort \
   > "$evidence_root/observability-cli-files.txt"
 mkdir dist-release
 cp "$pack_root/pack-1"/*.tgz dist-release/
-npm publish "./dist-release/equipe-tech-observability-0.2.0.tgz" \
+npm publish "./dist-release/equipe-tech-observability-0.2.1.tgz" \
   --access public --tag latest --provenance --dry-run
-npm publish "./dist-release/equipe-tech-observability-cli-0.2.0.tgz" \
+npm publish "./dist-release/equipe-tech-observability-cli-0.2.1.tgz" \
   --access public --tag latest --provenance --dry-run
 cleanup
 trap - EXIT HUP INT TERM
 ```
 
-Os seis SHA-256 devem coincidir exatamente com `docs/releases/v0.2.0.sha256`. Os três conjuntos usam diretórios vazios e nomes determinísticos; compare `pack-1` com `pack-2` e `pack-3` antes da aprovação. Confira nomes, versões, repository, homepage, bugs e engines dos manifests empacotados, export maps, todos os `.d.ts`, modo executável da CLI, assets do Collector e Kamal, READMEs, licenças na raiz e em `dist`, dependency ranges e ausência de `workspace:`, fontes, testes, credenciais e arquivos alheios.
+Os seis SHA-256 devem coincidir exatamente com `docs/releases/v0.2.1.sha256`. Os três conjuntos usam diretórios vazios e nomes determinísticos; compare `pack-1` com `pack-2` e `pack-3` antes da aprovação. Confira nomes, versões, repository, homepage, bugs e engines dos manifests empacotados, export maps, todos os `.d.ts`, modo executável da CLI, assets do Collector e Kamal, READMEs, licenças na raiz e em `dist`, dependency ranges e ausência de `workspace:`, fontes, testes, credenciais e arquivos alheios.
 
 Instale esses mesmos tarballs em diretórios temporários Node e Bun. Importe raiz, metrics, node, nestjs, browser, browser/client e testing. Compile consumidores NestJS 10 e 11, execute o cliente de browser empacotado e confirme o gate gzip. Execute `observability --help`, `dev status` e provisionamento local. `bun run test:package` automatiza essa matriz; uma instalação Node separada confirma a resolução fora do Bun.
 
@@ -157,7 +157,7 @@ Instale esses mesmos tarballs em diretórios temporários Node e Bun. Importe ra
 Entregue ao responsável:
 
 - SHA completo do commit candidato e confirmação de que ele pertence a `origin/master`;
-- diff desde `v0.1.0` e notas `docs/releases/v0.2.0.md`;
+- diff desde `v0.2.0` e notas `docs/releases/v0.2.1.md`;
 - saídas de check, build, testes, smoke, Collector, recovery e canário local;
 - listagens e SHA-256 dos dois tarballs;
 - saídas dos dois `npm publish --dry-run`;
@@ -176,11 +176,11 @@ git fetch origin --tags --prune
 approved_sha="<SHA_APROVADO>"
 test "$(git rev-parse "$approved_sha")" = "$approved_sha"
 git merge-base --is-ancestor "$approved_sha" origin/master
-test "$(git show "$approved_sha:packages/telemetry/package.json" | jq -r .version)" = "0.2.0"
-test "$(git show "$approved_sha:packages/cli/package.json" | jq -r .version)" = "0.2.0"
-test -z "$(git ls-remote --tags origin refs/tags/v0.2.0 refs/tags/v0.2.0^{})"
-git tag -a v0.2.0 "$approved_sha" -m "Release 0.2.0"
-git push origin v0.2.0
+test "$(git show "$approved_sha:packages/telemetry/package.json" | jq -r .version)" = "0.2.1"
+test "$(git show "$approved_sha:packages/cli/package.json" | jq -r .version)" = "0.2.1"
+test -z "$(git ls-remote --tags origin refs/tags/v0.2.1 refs/tags/v0.2.1^{})"
+git tag -a v0.2.1 "$approved_sha" -m "Release 0.2.1"
+git push origin v0.2.1
 ```
 
 O push do tag aciona o workflow. Não rode `npm publish`, `gh release create`, upload de asset ou alteração de dist-tag manual em paralelo.
@@ -188,21 +188,22 @@ O push do tag aciona o workflow. Não rode `npm publish`, `gh release create`, u
 ## Verificação após publicação
 
 ```sh
-git ls-remote --tags origin refs/tags/v0.2.0 refs/tags/v0.2.0^{}
-gh release view v0.2.0 --json tagName,isDraft,isPrerelease,assets,url
-npm view @equipe-tech/observability@0.2.0 version dist.integrity dist.shasum --json
-npm view @equipe-tech/observability-cli@0.2.0 version dist.integrity dist.shasum --json
+git ls-remote --tags origin refs/tags/v0.2.1 refs/tags/v0.2.1^{}
+gh release view v0.2.1 --json tagName,isDraft,isPrerelease,assets,url
+npm view @equipe-tech/observability@0.2.1 version dist.integrity dist.shasum --json
+npm view @equipe-tech/observability-cli@0.2.1 version dist.integrity dist.shasum --json
 npm view @equipe-tech/observability dist-tags --json
 npm view @equipe-tech/observability-cli dist-tags --json
 ```
 
-Confirme dois assets no GitHub Release, proveniência nos dois pacotes npm, `latest: 0.2.0` em ambos e instalação limpa por versão em Node e Bun.
+Confirme dois assets no GitHub Release, proveniência nos dois pacotes npm, `latest: 0.2.1` em ambos e instalação limpa por versão em Node e Bun.
 
 ## Falha e rollback
 
 - Antes do tag, corrija no branch, repita toda a validação, gere novos hashes e peça nova aprovação do SHA.
 - Se o tag remoto existir mas o GitHub Release e os dois pacotes ainda não tiverem sido publicados, cancele o workflow. Remova eventual draft e o tag somente com aprovação explícita. Nunca mova um tag de release publicado.
 - Se somente um pacote for publicado, preserve a versão publicada. Corrija a causa e reexecute o workflow por `workflow_dispatch` com o tag existente. A release e os assets existentes não são sobrescritos, os checksums são revalidados e a versão já publicada é ignorada de forma idempotente.
-- Se um pacote publicado tiver defeito, faça uma correção coordenada com nova versão patch nos dois pacotes. Não reutilize `0.2.0`.
+- Se um pacote publicado tiver defeito, faça uma correção coordenada com nova versão patch nos dois pacotes. Não reutilize `0.2.1`.
+- A CLI 0.2.0 não lê credenciais no formato 3. Um rollback da CLI exige restaurar um backup seguro anterior à migração e validar os segredos de runtime; não converta o arquivo manualmente.
 - Não use `npm unpublish` como rollback normal. `npm deprecate` ou mudança manual de dist-tag exigem aprovação explícita, mensagem de substituição e verificação dos dois pacotes.
 - Preserve logs do workflow, SHA aprovado, hashes locais, integrities npm e URL do release como evidência do incidente.

--- a/docs/releases/v0.2.1.md
+++ b/docs/releases/v0.2.1.md
@@ -1,0 +1,32 @@
+## v0.2.1
+
+Esta correção prepara os dois pacotes na versão `0.2.1` e corrige o provisionamento Axiom sem publicar tag, release ou pacote.
+
+### Correção de datasets e tokens Axiom
+
+- Cria traces e logs como `axiom:events:v1` e métricas como `otel:metrics:v1`.
+- Faz parse de registros completos de datasets e tokens na fronteira HTTP.
+- Executa preflight somente leitura antes de mutações e rejeita nomes duplicados, kinds incompatíveis, conflitos de edge deployment, retenção e capabilities.
+- Reconcila retenção explícita, relê datasets após resultados ambíguos e nunca exclui datasets.
+- Retorna `OBS_CLI_AXIOM_METRICS_MIGRATION_REQUIRED` para uma métrica antiga criada como Events. A preservação e eventual exclusão desse dataset são ações manuais.
+- Verifica ingest-create somente para os três nomes exatos e envia o corpo documentado `newToken` na regeneração.
+
+### Correlation manual
+
+Axiom não publica uma API estável para grupos de Correlation. O provisionamento persiste e imprime o nome, slug e os três datasets da ação manual. `env export` fica bloqueado até o operador criar o grupo no Console e repetir o provisionamento com `--correlation-confirmed`.
+
+A confirmação só é persistida depois de uma leitura nova que verifica nomes, kinds, edge deployment e retenção solicitada. Ela registra a afirmação do operador e não afirma uma verificação remota do grupo.
+
+### Credenciais e rollback
+
+O formato de credenciais passa para a versão 3. Migrações das versões 1 e 2 preservam segredos administrativos e de ingestão, IDs de token, nomes de datasets, estado Sentry e mutações pendentes. Ambientes Axiom migrados ficam em `verification-required`.
+
+A CLI 0.2.0 não lê o formato 3. Não faça downgrade depois da migração. Um rollback exige restaurar um backup seguro do arquivo anterior e validar separadamente que os segredos de runtime correspondem ao estado restaurado.
+
+### Riscos operacionais
+
+- A migração de uma métrica Events pode remover histórico se o operador excluir o dataset sem preservação.
+- Ingestão ativa pode recriar o dataset genérico durante a janela de migração.
+- Reduzir retenção explicitamente pode remover dados antigos.
+- Regenerar um token pode interromper ingestão até o novo segredo ser implantado.
+- Regras do plano Axiom podem recusar edge deployment ou retenção solicitados.

--- a/docs/releases/v0.2.1.md
+++ b/docs/releases/v0.2.1.md
@@ -7,7 +7,7 @@ Esta correção prepara os dois pacotes na versão `0.2.1` e corrige o provision
 - Cria traces e logs como `axiom:events:v1` e métricas como `otel:metrics:v1`.
 - Faz parse de registros completos de datasets e tokens na fronteira HTTP.
 - Executa preflight somente leitura antes de mutações e rejeita nomes duplicados, kinds incompatíveis, conflitos de edge deployment, retenção e capabilities.
-- Reconcila retenção explícita, relê datasets após resultados ambíguos e nunca exclui datasets.
+- Trata retenção divergente como conflito destrutivo no preflight, nunca envia PUT de retenção, relê datasets após resultados ambíguos e nunca exclui datasets.
 - Retorna `OBS_CLI_AXIOM_METRICS_MIGRATION_REQUIRED` para uma métrica antiga criada como Events. A preservação e eventual exclusão desse dataset são ações manuais.
 - Verifica ingest-create somente para os três nomes exatos e envia o corpo documentado `newToken` na regeneração.
 
@@ -15,7 +15,7 @@ Esta correção prepara os dois pacotes na versão `0.2.1` e corrige o provision
 
 Axiom não publica uma API estável para grupos de Correlation. O provisionamento persiste e imprime o nome, slug e os três datasets da ação manual. `env export` fica bloqueado até o operador criar o grupo no Console e repetir o provisionamento com `--correlation-confirmed`.
 
-A confirmação só é persistida depois de uma leitura nova que verifica nomes, kinds, edge deployment e retenção solicitada. Ela registra a afirmação do operador e não afirma uma verificação remota do grupo.
+A confirmação exige uma ação `manual-required` correspondente salva por uma invocação anterior concluída e um edge deployment explícito e idêntico nos três sinais. Ela nunca cria recursos e confirma na mesma chamada. Depois de uma leitura nova, registra a afirmação do operador sem afirmar uma verificação remota do grupo.
 
 ### Credenciais e rollback
 
@@ -27,6 +27,6 @@ A CLI 0.2.0 não lê o formato 3. Não faça downgrade depois da migração. Um 
 
 - A migração de uma métrica Events pode remover histórico se o operador excluir o dataset sem preservação.
 - Ingestão ativa pode recriar o dataset genérico durante a janela de migração.
-- Reduzir retenção explicitamente pode remover dados antigos.
+- Alterar retenção manualmente pode remover dados antigos; a CLI apenas detecta a divergência.
 - Regenerar um token pode interromper ingestão até o novo segredo ser implantado.
 - Regras do plano Axiom podem recusar edge deployment ou retenção solicitados.

--- a/docs/releases/v0.2.1.sha256
+++ b/docs/releases/v0.2.1.sha256
@@ -1,6 +1,6 @@
 d68f5259fac829bad262537de567f547e7f12aab3a6a3f4bb2af81fd8bc41cf7  .release-pack/pack-1/equipe-tech-observability-0.2.1.tgz
-24b04bd186a0a54238e6f7cafea2e4156e245808bf7c03ba3ae8c32c406c4368  .release-pack/pack-1/equipe-tech-observability-cli-0.2.1.tgz
+8e6cccfff37da09c60e0e34ec9fe9b395e05c24a237c4531cf699e4fa5b99cff  .release-pack/pack-1/equipe-tech-observability-cli-0.2.1.tgz
 d68f5259fac829bad262537de567f547e7f12aab3a6a3f4bb2af81fd8bc41cf7  .release-pack/pack-2/equipe-tech-observability-0.2.1.tgz
-24b04bd186a0a54238e6f7cafea2e4156e245808bf7c03ba3ae8c32c406c4368  .release-pack/pack-2/equipe-tech-observability-cli-0.2.1.tgz
+8e6cccfff37da09c60e0e34ec9fe9b395e05c24a237c4531cf699e4fa5b99cff  .release-pack/pack-2/equipe-tech-observability-cli-0.2.1.tgz
 d68f5259fac829bad262537de567f547e7f12aab3a6a3f4bb2af81fd8bc41cf7  .release-pack/pack-3/equipe-tech-observability-0.2.1.tgz
-24b04bd186a0a54238e6f7cafea2e4156e245808bf7c03ba3ae8c32c406c4368  .release-pack/pack-3/equipe-tech-observability-cli-0.2.1.tgz
+8e6cccfff37da09c60e0e34ec9fe9b395e05c24a237c4531cf699e4fa5b99cff  .release-pack/pack-3/equipe-tech-observability-cli-0.2.1.tgz

--- a/docs/releases/v0.2.1.sha256
+++ b/docs/releases/v0.2.1.sha256
@@ -1,0 +1,6 @@
+d68f5259fac829bad262537de567f547e7f12aab3a6a3f4bb2af81fd8bc41cf7  .release-pack/pack-1/equipe-tech-observability-0.2.1.tgz
+24b04bd186a0a54238e6f7cafea2e4156e245808bf7c03ba3ae8c32c406c4368  .release-pack/pack-1/equipe-tech-observability-cli-0.2.1.tgz
+d68f5259fac829bad262537de567f547e7f12aab3a6a3f4bb2af81fd8bc41cf7  .release-pack/pack-2/equipe-tech-observability-0.2.1.tgz
+24b04bd186a0a54238e6f7cafea2e4156e245808bf7c03ba3ae8c32c406c4368  .release-pack/pack-2/equipe-tech-observability-cli-0.2.1.tgz
+d68f5259fac829bad262537de567f547e7f12aab3a6a3f4bb2af81fd8bc41cf7  .release-pack/pack-3/equipe-tech-observability-0.2.1.tgz
+24b04bd186a0a54238e6f7cafea2e4156e245808bf7c03ba3ae8c32c406c4368  .release-pack/pack-3/equipe-tech-observability-cli-0.2.1.tgz

--- a/docs/setup-project-environments.md
+++ b/docs/setup-project-environments.md
@@ -71,15 +71,31 @@ observability provision \
   --name livro-caixa \
   --environment staging \
   --environment production \
-  --sentry-platform node
+  --sentry-platform node \
+  --axiom-edge-deployment <edge-deployment-id> \
+  --axiom-retention-days 30
 ```
 
 O comando cria estes recursos:
 
-- seis datasets Axiom;
+- seis datasets Axiom com kinds corretos, edge deployment explícito e retenção de 30 dias;
 - dois tokens Axiom com acesso somente para ingestão;
 - um projeto Sentry chamado `livro-caixa`;
 - os assets do Collector e do accessory Kamal.
+
+Axiom Correlation exige uma ação manual. Para cada ambiente, crie no Console o grupo, slug e seleção de datasets impressos pela CLI. Depois confirme com uma leitura nova dos datasets:
+
+```sh
+observability provision \
+  --name livro-caixa \
+  --environment staging \
+  --provider axiom \
+  --axiom-edge-deployment <edge-deployment-id> \
+  --axiom-retention-days 30 \
+  --correlation-confirmed
+```
+
+A CLI não usa endpoints não documentados e não afirma que verificou o grupo remoto. Sem essa confirmação, `env export` permanece bloqueado.
 
 O comando não imprime os tokens de runtime.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -26,7 +26,7 @@ npx @equipe-tech/observability-cli --help
 - Os comandos de autenticação e ambiente provisionam recursos específicos de Axiom e Sentry e armazenam credenciais locais com modo restrito.
 - Os assets de produção incluem filas persistentes limitadas, retry, health check, métricas internas, normalização de ambiente e redação de dados sensíveis.
 
-A stack local usa um diretório por versão em `OBSERVABILITY_HOME`, cujo padrão é `~/.local/state/observability`. A atualização para 0.2.0 muda o diretório ativo de `0.1.0` para `0.2.0`. Derrube a stack antiga com a CLI 0.1.0 antes de atualizar; a CLI 0.2.0 não reutiliza nem remove automaticamente o diretório anterior.
+A stack local usa um diretório por versão em `OBSERVABILITY_HOME`, cujo padrão é `~/.local/state/observability`. A CLI 0.2.1 usa o diretório ativo `0.2.1`. Derrube uma stack iniciada por versão anterior antes de atualizar; a CLI atual não reutiliza nem remove automaticamente o diretório anterior.
 
 A dependência direta `@effect/platform-node-shared@4.0.0-rc.111` impede que instaladores npm selecionem uma release candidate posterior incompatível com `@effect/platform-bun@4.0.0-rc.111`. Remova o pin somente quando todo o conjunto Effect for atualizado e validado em conjunto.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equipe-tech/observability-cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "CLI da plataforma de observabilidade: ciclo de vida da stack local de desenvolvimento",
   "homepage": "https://github.com/equipe-tech/observability#readme",
   "bugs": {

--- a/packages/cli/src/Cli.ts
+++ b/packages/cli/src/Cli.ts
@@ -167,6 +167,21 @@ const provisionRotateToken = Flag.boolean("rotate-token").pipe(
   Flag.withDefault(false),
 );
 
+const provisionAxiomEdgeDeployment = Flag.string("axiom-edge-deployment").pipe(
+  Flag.withDescription("Identificador do edge deployment Axiom para os datasets"),
+  Flag.optional,
+);
+
+const provisionAxiomRetentionDays = Flag.integer("axiom-retention-days").pipe(
+  Flag.withDescription("Retenção Axiom explícita em dias positivos"),
+  Flag.optional,
+);
+
+const provisionCorrelationConfirmed = Flag.boolean("correlation-confirmed").pipe(
+  Flag.withDescription("Confirma que o grupo de correlação salvo foi criado no Console Axiom"),
+  Flag.withDefault(false),
+);
+
 const provision = Command.make(
   "provision",
   {
@@ -177,8 +192,22 @@ const provision = Command.make(
     providers: provisionProviders,
     platform: provisionPlatform,
     rotateToken: provisionRotateToken,
+    axiomEdgeDeployment: provisionAxiomEdgeDeployment,
+    axiomRetentionDays: provisionAxiomRetentionDays,
+    correlationConfirmed: provisionCorrelationConfirmed,
   },
-  Effect.fn(function* ({ dir, environments, force, name, platform, providers, rotateToken }) {
+  Effect.fn(function* ({
+    axiomEdgeDeployment,
+    axiomRetentionDays,
+    correlationConfirmed,
+    dir,
+    environments,
+    force,
+    name,
+    platform,
+    providers,
+    rotateToken,
+  }) {
     const selectedProviders = yield* parseProviderSelection(providers);
     const assets = yield* ProvisionAssets;
     const projectName = yield* assets.resolveName(dir, name);
@@ -205,6 +234,9 @@ const provision = Command.make(
       selectedProviders,
       platform,
       rotateToken,
+      Option.getOrUndefined(axiomEdgeDeployment),
+      Option.getOrUndefined(axiomRetentionDays),
+      correlationConfirmed,
     );
     for (const environment of configured) {
       const providerNames = environmentProviderNames(environment).join(",");
@@ -223,6 +255,17 @@ const provision = Command.make(
         parts.push(`sentry-project=${sentry.value.project}`);
       }
       yield* Console.log(parts.join("  "));
+      if (Option.isSome(axiom) && axiom.value.correlation.type === "manual-required") {
+        yield* Console.log(
+          `manual-action  Open the Axiom Console and create Correlation group "${axiom.value.correlation.groupName}" with slug "${axiom.value.correlation.groupSlug}".`,
+        );
+        yield* Console.log(
+          `manual-action  Select traces dataset ${axiom.value.correlation.tracesDataset}, logs dataset ${axiom.value.correlation.logsDataset}, and metrics dataset ${axiom.value.correlation.metricsDataset}.`,
+        );
+        yield* Console.log(
+          "manual-action  Save the group, then rerun this command with --correlation-confirmed. The CLI cannot verify the group through a stable public Axiom API.",
+        );
+      }
     }
     if (configured.some((environment) => Option.isSome(environmentAxiom(environment)))) {
       yield* Console.log(

--- a/packages/cli/src/CredentialsStore.ts
+++ b/packages/cli/src/CredentialsStore.ts
@@ -23,6 +23,56 @@ export class SentryCredentials extends Schema.Class<SentryCredentials>(
   baseUrl: Schema.URLFromString,
 }) {}
 
+export const AxiomDatasetKind = Schema.Literals([
+  "axiom:events:v1",
+  "otel:logs:v1",
+  "otel:metrics:v1",
+  "otel:traces:v1",
+]);
+
+export class VerifiedAxiomDataset extends Schema.Class<VerifiedAxiomDataset>(
+  "@equipe-tech/observability-cli/VerifiedAxiomDataset",
+)({
+  id: Schema.NonEmptyString,
+  name: Schema.NonEmptyString,
+  kind: AxiomDatasetKind,
+  edgeDeployment: Schema.NonEmptyString.pipe(Schema.optionalKey),
+  retentionDays: Schema.Int.check(Schema.isGreaterThan(0)).pipe(Schema.optionalKey),
+  useRetentionPeriod: Schema.Boolean,
+}) {}
+
+const VerificationRequired = Schema.Struct({ type: Schema.Literal("verification-required") });
+const ManualCorrelation = Schema.Struct({
+  type: Schema.Literal("manual-required"),
+  groupName: Schema.NonEmptyString,
+  groupSlug: Schema.NonEmptyString,
+  tracesDataset: Schema.NonEmptyString,
+  logsDataset: Schema.NonEmptyString,
+  metricsDataset: Schema.NonEmptyString,
+});
+const ConfirmedCorrelation = Schema.Struct({
+  type: Schema.Literal("operator-confirmed"),
+  groupName: Schema.NonEmptyString,
+  groupSlug: Schema.NonEmptyString,
+  tracesDataset: Schema.NonEmptyString,
+  logsDataset: Schema.NonEmptyString,
+  metricsDataset: Schema.NonEmptyString,
+  confirmedAt: Schema.NonEmptyString,
+});
+export const AxiomCorrelationState = Schema.Union([
+  VerificationRequired,
+  ManualCorrelation,
+  ConfirmedCorrelation,
+]);
+export type AxiomCorrelationState = typeof AxiomCorrelationState.Type;
+
+const VerifiedAxiomDatasets = Schema.Struct({
+  traces: VerifiedAxiomDataset,
+  logs: VerifiedAxiomDataset,
+  metrics: VerifiedAxiomDataset,
+});
+export type VerifiedAxiomDatasets = typeof VerifiedAxiomDatasets.Type;
+
 export class AxiomEnvironment extends Schema.Class<AxiomEnvironment>(
   "@equipe-tech/observability-cli/AxiomEnvironment",
 )({
@@ -31,6 +81,8 @@ export class AxiomEnvironment extends Schema.Class<AxiomEnvironment>(
   tracesDataset: Schema.NonEmptyString,
   logsDataset: Schema.NonEmptyString,
   metricsDataset: Schema.NonEmptyString,
+  datasets: VerifiedAxiomDatasets.pipe(Schema.optionalKey),
+  correlation: AxiomCorrelationState,
 }) {}
 
 export class SentryEnvironment extends Schema.Class<SentryEnvironment>(
@@ -79,12 +131,50 @@ export class PendingAxiomMutation extends Schema.Class<PendingAxiomMutation>(
 export class CredentialsFile extends Schema.Class<CredentialsFile>(
   "@equipe-tech/observability-cli/CredentialsFile",
 )({
-  version: Schema.Literal(2),
+  version: Schema.Literal(3),
   axiom: AxiomCredentials.pipe(Schema.optionalKey),
   sentry: SentryCredentials.pipe(Schema.optionalKey),
   environments: Schema.Array(ManagedEnvironment),
   pendingAxiomMutations: Schema.Array(PendingAxiomMutation).pipe(Schema.optionalKey),
 }) {}
+
+const Version2AxiomEnvironment = Schema.Struct({
+  tokenId: Schema.NonEmptyString,
+  token: Schema.NonEmptyString,
+  tracesDataset: Schema.NonEmptyString,
+  logsDataset: Schema.NonEmptyString,
+  metricsDataset: Schema.NonEmptyString,
+});
+const Version2AxiomProviders = Schema.Struct({
+  type: Schema.Literal("axiom"),
+  axiom: Version2AxiomEnvironment,
+});
+const Version2SentryProviders = Schema.Struct({
+  type: Schema.Literal("sentry"),
+  sentry: SentryEnvironment,
+});
+const Version2CombinedProviders = Schema.Struct({
+  type: Schema.Literal("combined"),
+  axiom: Version2AxiomEnvironment,
+  sentry: SentryEnvironment,
+});
+const Version2ManagedEnvironment = Schema.Struct({
+  project: Schema.NonEmptyString,
+  environment: Schema.NonEmptyString,
+  providers: Schema.Union([
+    Version2AxiomProviders,
+    Version2SentryProviders,
+    Version2CombinedProviders,
+  ]),
+});
+const Version2CredentialsFile = Schema.Struct({
+  version: Schema.Literal(2),
+  axiom: AxiomCredentials.pipe(Schema.optionalKey),
+  sentry: SentryCredentials.pipe(Schema.optionalKey),
+  environments: Schema.Array(Version2ManagedEnvironment),
+  pendingAxiomMutations: Schema.Array(PendingAxiomMutation).pipe(Schema.optionalKey),
+});
+type Version2CredentialsFile = typeof Version2CredentialsFile.Type;
 
 const LegacyManagedEnvironment = Schema.Struct({
   project: Schema.NonEmptyString,
@@ -110,6 +200,7 @@ type LegacyCredentialsFile = typeof LegacyCredentialsFile.Type;
 const CredentialsVersion = Schema.Struct({ version: Schema.Number });
 const decodeCredentialsVersion = Schema.decodeUnknownEffect(CredentialsVersion);
 const decodeLegacyCredentialsFile = Schema.decodeUnknownEffect(LegacyCredentialsFile);
+const decodeVersion2CredentialsFile = Schema.decodeUnknownEffect(Version2CredentialsFile);
 const decodeCredentialsFile = Schema.decodeUnknownEffect(CredentialsFile);
 
 const LockOwner = Schema.Struct({
@@ -121,7 +212,8 @@ const LockOwner = Schema.Struct({
 const decodeLockOwner = Schema.decodeUnknownEffect(LockOwner);
 
 type PersistedCredentials =
-  | { readonly type: "legacy"; readonly credentials: LegacyCredentialsFile }
+  | { readonly type: "version-1"; readonly credentials: LegacyCredentialsFile }
+  | { readonly type: "version-2"; readonly credentials: Version2CredentialsFile }
   | { readonly type: "current"; readonly credentials: CredentialsFile };
 
 export class CredentialsError extends Schema.TaggedError<CredentialsError>()("CredentialsError", {
@@ -160,7 +252,7 @@ const parseCredentials = Effect.fn("parseCredentials")(function* (
     catch: invalidCredentials,
   });
   const version = yield* decodeCredentialsVersion(value).pipe(Effect.mapError(invalidCredentials));
-  if (version.version > 2) {
+  if (version.version > 3) {
     return yield* new CredentialsError({
       code: "OBS_CLI_CREDENTIALS_VERSION_UNSUPPORTED",
       message: "The credentials file was written by a newer CLI. Update the CLI and retry.",
@@ -171,9 +263,15 @@ const parseCredentials = Effect.fn("parseCredentials")(function* (
     const credentials = yield* decodeLegacyCredentialsFile(value).pipe(
       Effect.mapError(invalidCredentials),
     );
-    return { type: "legacy", credentials };
+    return { type: "version-1", credentials };
   }
   if (version.version === 2) {
+    const credentials = yield* decodeVersion2CredentialsFile(value).pipe(
+      Effect.mapError(invalidCredentials),
+    );
+    return { type: "version-2", credentials };
+  }
+  if (version.version === 3) {
     const credentials = yield* decodeCredentialsFile(value).pipe(
       Effect.mapError(invalidCredentials),
     );
@@ -182,7 +280,66 @@ const parseCredentials = Effect.fn("parseCredentials")(function* (
   return yield* invalidCredentials(version.version);
 });
 
-const migrateCredentials = (legacy: LegacyCredentialsFile): CredentialsFile => {
+const unverifiedAxiomEnvironment = (environment: {
+  readonly tokenId: string;
+  readonly token: string;
+  readonly tracesDataset: string;
+  readonly logsDataset: string;
+  readonly metricsDataset: string;
+}): AxiomEnvironment =>
+  new AxiomEnvironment({
+    tokenId: environment.tokenId,
+    token: environment.token,
+    tracesDataset: environment.tracesDataset,
+    logsDataset: environment.logsDataset,
+    metricsDataset: environment.metricsDataset,
+    correlation: { type: "verification-required" },
+  });
+
+const makeMigratedCredentials = (
+  axiom: AxiomCredentials | undefined,
+  sentry: SentryCredentials | undefined,
+  environments: ReadonlyArray<ManagedEnvironment>,
+  pendingAxiomMutations: ReadonlyArray<PendingAxiomMutation> = [],
+): CredentialsFile => {
+  const pending = pendingAxiomMutations.length === 0 ? undefined : pendingAxiomMutations;
+  if (axiom !== undefined && sentry !== undefined) {
+    return pending === undefined
+      ? new CredentialsFile({ version: 3, environments, axiom, sentry })
+      : new CredentialsFile({
+          version: 3,
+          environments,
+          axiom,
+          sentry,
+          pendingAxiomMutations: pending,
+        });
+  }
+  if (axiom !== undefined) {
+    return pending === undefined
+      ? new CredentialsFile({ version: 3, environments, axiom })
+      : new CredentialsFile({
+          version: 3,
+          environments,
+          axiom,
+          pendingAxiomMutations: pending,
+        });
+  }
+  if (sentry !== undefined) {
+    return pending === undefined
+      ? new CredentialsFile({ version: 3, environments, sentry })
+      : new CredentialsFile({
+          version: 3,
+          environments,
+          sentry,
+          pendingAxiomMutations: pending,
+        });
+  }
+  return pending === undefined
+    ? new CredentialsFile({ version: 3, environments })
+    : new CredentialsFile({ version: 3, environments, pendingAxiomMutations: pending });
+};
+
+const migrateVersion1Credentials = (legacy: LegacyCredentialsFile): CredentialsFile => {
   const environments = legacy.environments.map(
     (environment) =>
       new ManagedEnvironment({
@@ -190,7 +347,7 @@ const migrateCredentials = (legacy: LegacyCredentialsFile): CredentialsFile => {
         environment: environment.environment,
         providers: {
           type: "combined",
-          axiom: new AxiomEnvironment({
+          axiom: unverifiedAxiomEnvironment({
             tokenId: environment.axiomTokenId,
             token: environment.axiomToken,
             tracesDataset: environment.tracesDataset,
@@ -204,21 +361,38 @@ const migrateCredentials = (legacy: LegacyCredentialsFile): CredentialsFile => {
         },
       }),
   );
-  if (legacy.axiom !== undefined && legacy.sentry !== undefined) {
-    return new CredentialsFile({
-      version: 2,
-      axiom: legacy.axiom,
-      sentry: legacy.sentry,
-      environments,
+  return makeMigratedCredentials(legacy.axiom, legacy.sentry, environments);
+};
+
+const migrateVersion2Credentials = (legacy: Version2CredentialsFile): CredentialsFile => {
+  const environments = legacy.environments.map((environment) => {
+    if (environment.providers.type === "sentry") {
+      return new ManagedEnvironment({
+        project: environment.project,
+        environment: environment.environment,
+        providers: environment.providers,
+      });
+    }
+    const axiom = unverifiedAxiomEnvironment(environment.providers.axiom);
+    if (environment.providers.type === "axiom") {
+      return new ManagedEnvironment({
+        project: environment.project,
+        environment: environment.environment,
+        providers: { type: "axiom", axiom },
+      });
+    }
+    return new ManagedEnvironment({
+      project: environment.project,
+      environment: environment.environment,
+      providers: { type: "combined", axiom, sentry: environment.providers.sentry },
     });
-  }
-  if (legacy.axiom !== undefined) {
-    return new CredentialsFile({ version: 2, axiom: legacy.axiom, environments });
-  }
-  if (legacy.sentry !== undefined) {
-    return new CredentialsFile({ version: 2, sentry: legacy.sentry, environments });
-  }
-  return new CredentialsFile({ version: 2, environments });
+  });
+  return makeMigratedCredentials(
+    legacy.axiom,
+    legacy.sentry,
+    environments,
+    legacy.pendingAxiomMutations ?? [],
+  );
 };
 
 export type CredentialsAccess = {
@@ -562,7 +736,10 @@ export class CredentialsStore extends Context.Service<
         if (persisted.value.type === "current") {
           return Option.some(persisted.value.credentials);
         }
-        const migrated = migrateCredentials(persisted.value.credentials);
+        const migrated =
+          persisted.value.type === "version-1"
+            ? migrateVersion1Credentials(persisted.value.credentials)
+            : migrateVersion2Credentials(persisted.value.credentials);
         yield* save(migrated);
         return Option.some(migrated);
       });
@@ -602,4 +779,4 @@ export class CredentialsStore extends Context.Service<
 }
 
 export const emptyCredentials = (): CredentialsFile =>
-  new CredentialsFile({ version: 2, environments: [] });
+  new CredentialsFile({ version: 3, environments: [] });

--- a/packages/cli/src/ProviderApis.ts
+++ b/packages/cli/src/ProviderApis.ts
@@ -28,15 +28,13 @@ export class AxiomDataset extends Schema.Class<AxiomDataset>(
 
 const AxiomDatasets = Schema.Array(AxiomDataset);
 const AxiomCapabilityActions = Schema.Array(Schema.NonEmptyString);
-const AxiomDatasetCapability = Schema.Struct({
-  ingest: AxiomCapabilityActions.pipe(Schema.optionalKey),
-  query: AxiomCapabilityActions.pipe(Schema.optionalKey),
-});
+const AxiomDatasetCapability = Schema.Record(Schema.NonEmptyString, AxiomCapabilityActions);
 export const AxiomDatasetCapabilities = Schema.Record(
   Schema.NonEmptyString,
   AxiomDatasetCapability,
 );
 const AxiomOrganizationCapabilities = Schema.Record(Schema.NonEmptyString, AxiomCapabilityActions);
+const AxiomViewCapabilities = Schema.Record(Schema.NonEmptyString, AxiomCapabilityActions);
 
 export class AxiomToken extends Schema.Class<AxiomToken>(
   "@equipe-tech/observability-cli/AxiomToken",
@@ -47,6 +45,7 @@ export class AxiomToken extends Schema.Class<AxiomToken>(
   expiresAt: Schema.String.pipe(Schema.optionalKey),
   datasetCapabilities: AxiomDatasetCapabilities,
   orgCapabilities: AxiomOrganizationCapabilities,
+  viewCapabilities: AxiomViewCapabilities,
 }) {}
 
 const AxiomTokens = Schema.Array(AxiomToken);
@@ -294,11 +293,6 @@ export class AxiomApi extends Context.Service<
       name: string,
       options?: AxiomDatasetCreateOptions,
     ): Effect.Effect<AxiomDataset, RemoteApiError>;
-    updateDatasetRetention(
-      credentials: AxiomCredentials,
-      dataset: AxiomDataset,
-      retentionDays: number,
-    ): Effect.Effect<AxiomDataset, RemoteApiError>;
     tokens(credentials: AxiomCredentials): Effect.Effect<ReadonlyArray<AxiomToken>, RemoteApiError>;
     createToken(
       credentials: AxiomCredentials,
@@ -419,40 +413,6 @@ export class AxiomApi extends Context.Service<
             ),
           );
         }),
-        updateDatasetRetention: Effect.fn("AxiomApi.updateDatasetRetention")(
-          function* (credentials, dataset, retentionDays) {
-            const options: AxiomDatasetCreateOptions =
-              dataset.edgeDeployment === undefined
-                ? { kind: dataset.kind, retentionDays }
-                : {
-                    kind: dataset.kind,
-                    edgeDeployment: dataset.edgeDeployment,
-                    retentionDays,
-                  };
-            const mutation = Effect.gen(function* () {
-              const response = yield* remoteRequest(
-                "Axiom",
-                axiomUrl(baseUrl, `/v2/datasets/${encodeURIComponent(dataset.id)}`),
-                {
-                  method: "PUT",
-                  headers: axiomHeaders(credentials),
-                  body: JSON.stringify({ retentionDays, useRetentionPeriod: true }),
-                },
-              );
-              yield* expectStatus("Axiom", response, [200]);
-              const updated = yield* parseDatasetResponse(response);
-              if (updated.name !== dataset.name || !datasetMatches(updated, options)) {
-                return yield* invalidResponse("Axiom", response.status, updated);
-              }
-              return updated;
-            });
-            return yield* mutation.pipe(
-              Effect.catchTag("RemoteApiError", (error) =>
-                recoverDataset(credentials, dataset.name, options, error),
-              ),
-            );
-          },
-        ),
         tokens: Effect.fn("AxiomApi.tokens")(function* (credentials) {
           const response = yield* remoteRequest("Axiom", axiomUrl(baseUrl, "/v2/tokens"), {
             headers: axiomHeaders(credentials),

--- a/packages/cli/src/ProviderApis.ts
+++ b/packages/cli/src/ProviderApis.ts
@@ -6,9 +6,49 @@ const AxiomUser = Schema.Struct({
   email: Schema.NonEmptyString,
 });
 
-const AxiomDataset = Schema.Struct({ name: Schema.NonEmptyString });
+export const AxiomDatasetKind = Schema.Literals([
+  "axiom:events:v1",
+  "otel:logs:v1",
+  "otel:metrics:v1",
+  "otel:traces:v1",
+]);
+export type AxiomDatasetKind = typeof AxiomDatasetKind.Type;
+
+export class AxiomDataset extends Schema.Class<AxiomDataset>(
+  "@equipe-tech/observability-cli/AxiomDataset",
+)({
+  id: Schema.NonEmptyString,
+  name: Schema.NonEmptyString,
+  description: Schema.String,
+  kind: AxiomDatasetKind,
+  edgeDeployment: Schema.NonEmptyString.pipe(Schema.optionalKey),
+  retentionDays: Schema.Int.check(Schema.isGreaterThan(0)).pipe(Schema.optionalKey),
+  useRetentionPeriod: Schema.Boolean,
+}) {}
+
 const AxiomDatasets = Schema.Array(AxiomDataset);
-const AxiomToken = Schema.Struct({ id: Schema.NonEmptyString, name: Schema.NonEmptyString });
+const AxiomCapabilityActions = Schema.Array(Schema.NonEmptyString);
+const AxiomDatasetCapability = Schema.Struct({
+  ingest: AxiomCapabilityActions.pipe(Schema.optionalKey),
+  query: AxiomCapabilityActions.pipe(Schema.optionalKey),
+});
+export const AxiomDatasetCapabilities = Schema.Record(
+  Schema.NonEmptyString,
+  AxiomDatasetCapability,
+);
+const AxiomOrganizationCapabilities = Schema.Record(Schema.NonEmptyString, AxiomCapabilityActions);
+
+export class AxiomToken extends Schema.Class<AxiomToken>(
+  "@equipe-tech/observability-cli/AxiomToken",
+)({
+  id: Schema.NonEmptyString,
+  name: Schema.NonEmptyString,
+  description: Schema.String,
+  expiresAt: Schema.String.pipe(Schema.optionalKey),
+  datasetCapabilities: AxiomDatasetCapabilities,
+  orgCapabilities: AxiomOrganizationCapabilities,
+}) {}
+
 const AxiomTokens = Schema.Array(AxiomToken);
 const AxiomTokenSecret = Schema.Struct({
   id: Schema.NonEmptyString,
@@ -29,6 +69,7 @@ const SentryClientKey = Schema.Struct({
 const SentryClientKeys = Schema.Array(SentryClientKey);
 
 const decodeAxiomUser = Schema.decodeUnknownEffect(AxiomUser);
+const decodeAxiomDataset = Schema.decodeUnknownEffect(AxiomDataset);
 const decodeAxiomDatasets = Schema.decodeUnknownEffect(AxiomDatasets);
 const decodeAxiomTokens = Schema.decodeUnknownEffect(AxiomTokens);
 const decodeAxiomTokenSecret = Schema.decodeUnknownEffect(AxiomTokenSecret);
@@ -42,11 +83,19 @@ const AxiomTestEnvironment = Schema.Struct({
 const decodeAxiomTestEnvironment = Schema.decodeUnknownEffect(AxiomTestEnvironment);
 const decodeAxiomTestUrl = Schema.decodeUnknownEffect(Schema.URLFromString);
 
+export type AxiomDatasetCreateOptions = {
+  readonly kind?: AxiomDatasetKind;
+  readonly edgeDeployment?: string;
+  readonly retentionDays?: number;
+};
+
 export class RemoteApiError extends Schema.TaggedError<RemoteApiError>()("RemoteApiError", {
   code: Schema.Literals([
     "OBS_CLI_REMOTE_UNAUTHORIZED",
     "OBS_CLI_REMOTE_FAILED",
     "OBS_CLI_REMOTE_INVALID_RESPONSE",
+    "OBS_CLI_AXIOM_DATASET_CONFLICT",
+    "OBS_CLI_AXIOM_DATASET_OUTCOME_UNKNOWN",
   ]),
   message: Schema.String,
   provider: Schema.Literals(["Axiom", "Sentry"]),
@@ -191,15 +240,66 @@ const axiomHeaders = (credentials: AxiomCredentials) => ({
   "X-Axiom-Org-Id": credentials.organizationId,
 });
 
+const desiredDatasetKind = (options: AxiomDatasetCreateOptions): AxiomDatasetKind =>
+  options.kind ?? "axiom:events:v1";
+
+const datasetMatches = (dataset: AxiomDataset, options: AxiomDatasetCreateOptions): boolean => {
+  if (dataset.kind !== desiredDatasetKind(options)) {
+    return false;
+  }
+  if (options.edgeDeployment !== undefined && dataset.edgeDeployment !== options.edgeDeployment) {
+    return false;
+  }
+  return (
+    options.retentionDays === undefined ||
+    (dataset.useRetentionPeriod && dataset.retentionDays === options.retentionDays)
+  );
+};
+
+const datasetBody = (name: string, options: AxiomDatasetCreateOptions) => {
+  const body: {
+    name: string;
+    description: string;
+    kind: AxiomDatasetKind;
+    edgeDeployment?: string;
+    retentionDays?: number;
+    useRetentionPeriod?: boolean;
+  } = {
+    name,
+    description: `OpenTelemetry data for ${name}`,
+    kind: desiredDatasetKind(options),
+  };
+  if (options.edgeDeployment !== undefined) {
+    body.edgeDeployment = options.edgeDeployment;
+  }
+  if (options.retentionDays !== undefined) {
+    body.retentionDays = options.retentionDays;
+    body.useRetentionPeriod = true;
+  }
+  return body;
+};
+
+const tokenCapabilities = (datasets: ReadonlyArray<string>) =>
+  Object.fromEntries(datasets.map((dataset) => [dataset, { ingest: ["create"] }]));
+
 export class AxiomApi extends Context.Service<
   AxiomApi,
   {
     identity(credentials: AxiomCredentials): Effect.Effect<string, RemoteApiError>;
-    datasets(credentials: AxiomCredentials): Effect.Effect<ReadonlyArray<string>, RemoteApiError>;
-    createDataset(credentials: AxiomCredentials, name: string): Effect.Effect<void, RemoteApiError>;
-    tokens(
+    datasets(
       credentials: AxiomCredentials,
-    ): Effect.Effect<ReadonlyArray<{ readonly id: string; readonly name: string }>, RemoteApiError>;
+    ): Effect.Effect<ReadonlyArray<AxiomDataset>, RemoteApiError>;
+    createDataset(
+      credentials: AxiomCredentials,
+      name: string,
+      options?: AxiomDatasetCreateOptions,
+    ): Effect.Effect<AxiomDataset, RemoteApiError>;
+    updateDatasetRetention(
+      credentials: AxiomCredentials,
+      dataset: AxiomDataset,
+      retentionDays: number,
+    ): Effect.Effect<AxiomDataset, RemoteApiError>;
+    tokens(credentials: AxiomCredentials): Effect.Effect<ReadonlyArray<AxiomToken>, RemoteApiError>;
     createToken(
       credentials: AxiomCredentials,
       name: string,
@@ -207,7 +307,8 @@ export class AxiomApi extends Context.Service<
     ): Effect.Effect<{ readonly id: string; readonly token: string }, RemoteApiError>;
     regenerateToken(
       credentials: AxiomCredentials,
-      id: string,
+      token: AxiomToken,
+      datasets: ReadonlyArray<string>,
     ): Effect.Effect<{ readonly id: string; readonly token: string }, RemoteApiError>;
   }
 >()("@equipe-tech/observability-cli/AxiomApi") {
@@ -215,6 +316,66 @@ export class AxiomApi extends Context.Service<
     AxiomApi,
     Effect.gen(function* () {
       const baseUrl = yield* resolveAxiomBaseUrl();
+
+      const listDatasets = Effect.fn("AxiomApi.datasets")(function* (credentials) {
+        const response = yield* remoteRequest("Axiom", axiomUrl(baseUrl, "/v2/datasets"), {
+          headers: axiomHeaders(credentials),
+        });
+        yield* expectStatus("Axiom", response, [200]);
+        const value = yield* parseRemoteJson("Axiom", response);
+        return yield* decodeAxiomDatasets(value).pipe(
+          Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
+        );
+      });
+
+      const recoverDataset = Effect.fn("AxiomApi.recoverDataset")(function* (
+        credentials: AxiomCredentials,
+        name: string,
+        options: AxiomDatasetCreateOptions,
+        original: RemoteApiError,
+      ): Effect.fn.Return<AxiomDataset, RemoteApiError> {
+        const matches = (yield* listDatasets(credentials)).filter(
+          (dataset) => dataset.name === name,
+        );
+        const match = matches[0];
+        if (matches.length === 1 && match !== undefined && datasetMatches(match, options)) {
+          return match;
+        }
+        if (matches.length > 0 || original.status === 409) {
+          return yield* new RemoteApiError({
+            code: "OBS_CLI_AXIOM_DATASET_CONFLICT",
+            message: `Axiom dataset ${name} does not match the requested configuration. Review its kind, edge deployment and retention before retrying.`,
+            provider: "Axiom",
+            status: original.status,
+            cause: original,
+          });
+        }
+        if (
+          original.status === 0 ||
+          original.status >= 500 ||
+          original.code === "OBS_CLI_REMOTE_INVALID_RESPONSE" ||
+          (original.status >= 200 && original.status < 300)
+        ) {
+          return yield* new RemoteApiError({
+            code: "OBS_CLI_AXIOM_DATASET_OUTCOME_UNKNOWN",
+            message: `The outcome of creating Axiom dataset ${name} is unknown. Verify the remote dataset before retrying.`,
+            provider: "Axiom",
+            status: original.status,
+            cause: original,
+          });
+        }
+        return yield* original;
+      });
+
+      const parseDatasetResponse = Effect.fn("AxiomApi.parseDatasetResponse")(function* (
+        response: RemoteResponse,
+      ) {
+        const value = yield* parseRemoteJson("Axiom", response);
+        return yield* decodeAxiomDataset(value).pipe(
+          Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
+        );
+      });
+
       return AxiomApi.of({
         identity: Effect.fn("AxiomApi.identity")(function* (credentials) {
           const response = yield* remoteRequest("Axiom", axiomUrl(baseUrl, "/v2/user"), {
@@ -227,25 +388,71 @@ export class AxiomApi extends Context.Service<
           );
           return user.email;
         }),
-        datasets: Effect.fn("AxiomApi.datasets")(function* (credentials) {
-          const response = yield* remoteRequest("Axiom", axiomUrl(baseUrl, "/v2/datasets"), {
-            headers: axiomHeaders(credentials),
+        datasets: listDatasets,
+        createDataset: Effect.fn("AxiomApi.createDataset")(function* (
+          credentials,
+          name,
+          options = {},
+        ) {
+          const mutation = Effect.gen(function* () {
+            const response = yield* remoteRequest("Axiom", axiomUrl(baseUrl, "/v2/datasets"), {
+              method: "POST",
+              headers: axiomHeaders(credentials),
+              body: JSON.stringify(datasetBody(name, options)),
+            });
+            yield* expectStatus("Axiom", response, [200, 201]);
+            const dataset = yield* parseDatasetResponse(response);
+            if (dataset.name !== name || !datasetMatches(dataset, options)) {
+              return yield* new RemoteApiError({
+                code: "OBS_CLI_REMOTE_INVALID_RESPONSE",
+                message: `Axiom returned a dataset that does not match ${name}. Verify the remote resource before retrying.`,
+                provider: "Axiom",
+                status: response.status,
+                cause: dataset,
+              });
+            }
+            return dataset;
           });
-          yield* expectStatus("Axiom", response, [200]);
-          const value = yield* parseRemoteJson("Axiom", response);
-          const datasets = yield* decodeAxiomDatasets(value).pipe(
-            Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
+          return yield* mutation.pipe(
+            Effect.catchTag("RemoteApiError", (error) =>
+              recoverDataset(credentials, name, options, error),
+            ),
           );
-          return datasets.map((dataset) => dataset.name);
         }),
-        createDataset: Effect.fn("AxiomApi.createDataset")(function* (credentials, name) {
-          const response = yield* remoteRequest("Axiom", axiomUrl(baseUrl, "/v2/datasets"), {
-            method: "POST",
-            headers: axiomHeaders(credentials),
-            body: JSON.stringify({ name, description: `OpenTelemetry data for ${name}` }),
-          });
-          yield* expectStatus("Axiom", response, [200, 201, 409]);
-        }),
+        updateDatasetRetention: Effect.fn("AxiomApi.updateDatasetRetention")(
+          function* (credentials, dataset, retentionDays) {
+            const options: AxiomDatasetCreateOptions =
+              dataset.edgeDeployment === undefined
+                ? { kind: dataset.kind, retentionDays }
+                : {
+                    kind: dataset.kind,
+                    edgeDeployment: dataset.edgeDeployment,
+                    retentionDays,
+                  };
+            const mutation = Effect.gen(function* () {
+              const response = yield* remoteRequest(
+                "Axiom",
+                axiomUrl(baseUrl, `/v2/datasets/${encodeURIComponent(dataset.id)}`),
+                {
+                  method: "PUT",
+                  headers: axiomHeaders(credentials),
+                  body: JSON.stringify({ retentionDays, useRetentionPeriod: true }),
+                },
+              );
+              yield* expectStatus("Axiom", response, [200]);
+              const updated = yield* parseDatasetResponse(response);
+              if (updated.name !== dataset.name || !datasetMatches(updated, options)) {
+                return yield* invalidResponse("Axiom", response.status, updated);
+              }
+              return updated;
+            });
+            return yield* mutation.pipe(
+              Effect.catchTag("RemoteApiError", (error) =>
+                recoverDataset(credentials, dataset.name, options, error),
+              ),
+            );
+          },
+        ),
         tokens: Effect.fn("AxiomApi.tokens")(function* (credentials) {
           const response = yield* remoteRequest("Axiom", axiomUrl(baseUrl, "/v2/tokens"), {
             headers: axiomHeaders(credentials),
@@ -257,16 +464,13 @@ export class AxiomApi extends Context.Service<
           );
         }),
         createToken: Effect.fn("AxiomApi.createToken")(function* (credentials, name, datasets) {
-          const datasetCapabilities = Object.fromEntries(
-            datasets.map((dataset) => [dataset, { ingest: ["create"] }]),
-          );
           const response = yield* remoteRequest("Axiom", axiomUrl(baseUrl, "/v2/tokens"), {
             method: "POST",
             headers: axiomHeaders(credentials),
             body: JSON.stringify({
               name,
               description: `Collector ingest token for ${name}`,
-              datasetCapabilities,
+              datasetCapabilities: tokenCapabilities(datasets),
               orgCapabilities: {},
               viewCapabilities: {},
             }),
@@ -277,18 +481,32 @@ export class AxiomApi extends Context.Service<
             Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
           );
         }),
-        regenerateToken: Effect.fn("AxiomApi.regenerateToken")(function* (credentials, id) {
-          const response = yield* remoteRequest(
-            "Axiom",
-            axiomUrl(baseUrl, `/v2/tokens/${encodeURIComponent(id)}/regenerate`),
-            { method: "POST", headers: axiomHeaders(credentials) },
-          );
-          yield* expectStatus("Axiom", response, [200]);
-          const value = yield* parseRemoteJson("Axiom", response);
-          return yield* decodeAxiomTokenSecret(value).pipe(
-            Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
-          );
-        }),
+        regenerateToken: Effect.fn("AxiomApi.regenerateToken")(
+          function* (credentials, token, datasets) {
+            const response = yield* remoteRequest(
+              "Axiom",
+              axiomUrl(baseUrl, `/v2/tokens/${encodeURIComponent(token.id)}/regenerate`),
+              {
+                method: "POST",
+                headers: axiomHeaders(credentials),
+                body: JSON.stringify({
+                  newToken: {
+                    name: token.name,
+                    description: token.description,
+                    datasetCapabilities: tokenCapabilities(datasets),
+                    orgCapabilities: {},
+                    viewCapabilities: {},
+                  },
+                }),
+              },
+            );
+            yield* expectStatus("Axiom", response, [200]);
+            const value = yield* parseRemoteJson("Axiom", response);
+            return yield* decodeAxiomTokenSecret(value).pipe(
+              Effect.mapError((cause) => invalidResponse("Axiom", response.status, cause)),
+            );
+          },
+        ),
       });
     }),
   );

--- a/packages/cli/src/RemoteEnvironment.ts
+++ b/packages/cli/src/RemoteEnvironment.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, Option, Schema } from "effect";
+import { Context, DateTime, Effect, Layer, Option, Schema } from "effect";
 import {
   AxiomCredentials,
   AxiomEnvironment,
@@ -10,9 +10,17 @@ import {
   ManagedEnvironment,
   PendingAxiomMutation,
   SentryCredentials,
+  VerifiedAxiomDataset,
   SentryEnvironment,
 } from "./CredentialsStore.ts";
-import { AxiomApi, RemoteApiError, SentryApi } from "./ProviderApis.ts";
+import {
+  AxiomApi,
+  AxiomDataset,
+  AxiomDatasetCreateOptions,
+  AxiomToken,
+  RemoteApiError,
+  SentryApi,
+} from "./ProviderApis.ts";
 
 const EnvironmentName = Schema.NonEmptyString.check(
   Schema.isMaxLength(32),
@@ -41,8 +49,19 @@ export class RemoteEnvironmentError extends Schema.TaggedError<RemoteEnvironment
       "OBS_CLI_REMOTE_PARTIAL_FAILURE",
       "OBS_CLI_REMOTE_OUTCOME_UNKNOWN",
       "OBS_CLI_REMOTE_ENVIRONMENT_NOT_FOUND",
+      "OBS_CLI_AXIOM_METRICS_MIGRATION_REQUIRED",
+      "OBS_CLI_AXIOM_DATASET_CONFIGURATION_CONFLICT",
+      "OBS_CLI_AXIOM_REMOTE_NAME_CONFLICT",
+      "OBS_CLI_AXIOM_TOKEN_CAPABILITIES_MISMATCH",
+      "OBS_CLI_CORRELATION_CONFIRMATION_REQUIRED",
+      "OBS_CLI_AXIOM_RETENTION_INVALID",
     ]),
     message: Schema.String,
+    datasetName: Schema.NonEmptyString.pipe(Schema.optionalKey),
+    actualKind: Schema.NonEmptyString.pipe(Schema.optionalKey),
+    requiredKind: Schema.NonEmptyString.pipe(Schema.optionalKey),
+    project: Schema.NonEmptyString.pipe(Schema.optionalKey),
+    environment: Schema.NonEmptyString.pipe(Schema.optionalKey),
     cause: Schema.Defect(),
   },
 ) {}
@@ -188,7 +207,7 @@ const makeCredentialsFile = (
   if (pendingAxiomMutations.length > 0) {
     if (axiom !== undefined && sentry !== undefined) {
       return new CredentialsFile({
-        version: 2,
+        version: 3,
         axiom,
         sentry,
         environments,
@@ -196,23 +215,23 @@ const makeCredentialsFile = (
       });
     }
     if (axiom !== undefined) {
-      return new CredentialsFile({ version: 2, axiom, environments, pendingAxiomMutations });
+      return new CredentialsFile({ version: 3, axiom, environments, pendingAxiomMutations });
     }
     if (sentry !== undefined) {
-      return new CredentialsFile({ version: 2, sentry, environments, pendingAxiomMutations });
+      return new CredentialsFile({ version: 3, sentry, environments, pendingAxiomMutations });
     }
-    return new CredentialsFile({ version: 2, environments, pendingAxiomMutations });
+    return new CredentialsFile({ version: 3, environments, pendingAxiomMutations });
   }
   if (axiom !== undefined && sentry !== undefined) {
-    return new CredentialsFile({ version: 2, axiom, sentry, environments });
+    return new CredentialsFile({ version: 3, axiom, sentry, environments });
   }
   if (axiom !== undefined) {
-    return new CredentialsFile({ version: 2, axiom, environments });
+    return new CredentialsFile({ version: 3, axiom, environments });
   }
   if (sentry !== undefined) {
-    return new CredentialsFile({ version: 2, sentry, environments });
+    return new CredentialsFile({ version: 3, sentry, environments });
   }
-  return new CredentialsFile({ version: 2, environments });
+  return new CredentialsFile({ version: 3, environments });
 };
 
 const pendingAxiomMutations = (credentials: CredentialsFile): ReadonlyArray<PendingAxiomMutation> =>
@@ -367,6 +386,51 @@ const partialFailure = (
   });
 };
 
+const expectedDatasetCapabilities = (
+  token: AxiomToken,
+  datasets: ReadonlyArray<string>,
+): boolean => {
+  const capabilityNames = Object.keys(token.datasetCapabilities);
+  if (capabilityNames.length !== datasets.length || token.orgCapabilities === undefined) {
+    return false;
+  }
+  if (Object.keys(token.orgCapabilities).length !== 0) {
+    return false;
+  }
+  return datasets.every((dataset) => {
+    const capability = token.datasetCapabilities[dataset];
+    return (
+      capability !== undefined &&
+      capability.ingest?.length === 1 &&
+      capability.ingest[0] === "create" &&
+      (capability.query === undefined || capability.query.length === 0)
+    );
+  });
+};
+
+const verifiedDataset = (dataset: AxiomDataset): VerifiedAxiomDataset => {
+  const common = {
+    id: dataset.id,
+    name: dataset.name,
+    kind: dataset.kind,
+    useRetentionPeriod: dataset.useRetentionPeriod,
+  };
+  if (dataset.edgeDeployment !== undefined && dataset.retentionDays !== undefined) {
+    return new VerifiedAxiomDataset({
+      ...common,
+      edgeDeployment: dataset.edgeDeployment,
+      retentionDays: dataset.retentionDays,
+    });
+  }
+  if (dataset.edgeDeployment !== undefined) {
+    return new VerifiedAxiomDataset({ ...common, edgeDeployment: dataset.edgeDeployment });
+  }
+  if (dataset.retentionDays !== undefined) {
+    return new VerifiedAxiomDataset({ ...common, retentionDays: dataset.retentionDays });
+  }
+  return new VerifiedAxiomDataset(common);
+};
+
 const mutationOutcomeUnknown = (
   error: RemoteApiError,
   completed: ReadonlyArray<string>,
@@ -480,6 +544,9 @@ export class RemoteEnvironment extends Context.Service<
       providers: ReadonlyArray<ProviderName>,
       platform: string,
       rotateToken: boolean,
+      axiomEdgeDeployment?: string,
+      axiomRetentionDays?: number,
+      correlationConfirmed?: boolean,
     ): Effect.Effect<
       ReadonlyArray<ManagedEnvironment>,
       CredentialsError | RemoteApiError | RemoteEnvironmentError
@@ -510,138 +577,347 @@ export class RemoteEnvironment extends Context.Service<
       });
 
       return RemoteEnvironment.of({
-        provision: Effect.fn("RemoteEnvironment.provision")(
-          function* (
-            project,
-            environments,
-            explicitProviders,
-            platform,
-            rotateToken,
-          ): Effect.fn.Return<
-            ReadonlyArray<ManagedEnvironment>,
-            CredentialsError | RemoteApiError | RemoteEnvironmentError
-          > {
-            const validated: Array<{
-              readonly name: string;
-              readonly datasets: EnvironmentDatasets;
-            }> = [];
-            for (const rawEnvironment of environments) {
-              const name = yield* parseEnvironmentName(rawEnvironment);
-              validated.push({ name, datasets: yield* environmentDatasets(project, name) });
-            }
-            return yield* store.exclusive((access) =>
-              Effect.gen(function* () {
-                let credentials = yield* currentCredentials(access);
-                const requested: Array<RequestedEnvironment> = [];
-                for (const environment of validated) {
-                  const existing = existingEnvironment(credentials, project, environment.name);
-                  requested.push({
-                    name: environment.name,
-                    datasets: environment.datasets,
-                    existing,
-                    providers: effectiveProviders(explicitProviders, existing),
-                  });
+        provision: Effect.fn("RemoteEnvironment.provision")(function* (
+          project,
+          environments,
+          explicitProviders,
+          platform,
+          rotateToken,
+          axiomEdgeDeployment,
+          axiomRetentionDays,
+          correlationConfirmed = false,
+        ): Effect.fn.Return<
+          ReadonlyArray<ManagedEnvironment>,
+          CredentialsError | RemoteApiError | RemoteEnvironmentError
+        > {
+          if (
+            axiomRetentionDays !== undefined &&
+            (!Number.isInteger(axiomRetentionDays) || axiomRetentionDays <= 0)
+          ) {
+            return yield* new RemoteEnvironmentError({
+              code: "OBS_CLI_AXIOM_RETENTION_INVALID",
+              message: "Axiom retention days must be a positive integer.",
+              cause: axiomRetentionDays,
+            });
+          }
+          if (axiomEdgeDeployment !== undefined && axiomEdgeDeployment.length === 0) {
+            return yield* new RemoteEnvironmentError({
+              code: "OBS_CLI_AXIOM_DATASET_CONFIGURATION_CONFLICT",
+              message: "The Axiom edge deployment identifier must not be empty.",
+              cause: axiomEdgeDeployment,
+            });
+          }
+          const validated: Array<{
+            readonly name: string;
+            readonly datasets: EnvironmentDatasets;
+          }> = [];
+          for (const rawEnvironment of environments) {
+            const name = yield* parseEnvironmentName(rawEnvironment);
+            validated.push({ name, datasets: yield* environmentDatasets(project, name) });
+          }
+          return yield* store.exclusive((access) =>
+            Effect.gen(function* () {
+              let credentials = yield* currentCredentials(access);
+              const requested: Array<RequestedEnvironment> = [];
+              for (const environment of validated) {
+                const existing = existingEnvironment(credentials, project, environment.name);
+                requested.push({
+                  name: environment.name,
+                  datasets: environment.datasets,
+                  existing,
+                  providers: effectiveProviders(explicitProviders, existing),
+                });
+              }
+              if (
+                rotateToken &&
+                requested.some((environment) => !environment.providers.includes("axiom"))
+              ) {
+                return yield* new RemoteEnvironmentError({
+                  code: "OBS_CLI_REMOTE_ROTATION_NOT_SELECTED",
+                  message:
+                    "Token rotation requires Axiom for every requested environment. Select --provider axiom or remove --rotate-token.",
+                  cause: "rotate-token",
+                });
+              }
+              if (
+                !rotateToken &&
+                requested.some(
+                  (environment) =>
+                    environment.providers.includes("axiom") &&
+                    hasPendingAxiomMutation(credentials, project, environment.name),
+                )
+              ) {
+                return yield* new RemoteEnvironmentError({
+                  code: "OBS_CLI_REMOTE_TOKEN_UNAVAILABLE",
+                  message:
+                    "A previous Axiom token mutation did not reach a durable checkpoint. Rerun with --rotate-token.",
+                  cause: "pending-axiom-mutation",
+                });
+              }
+
+              const selected = new Set(requested.flatMap((environment) => environment.providers));
+              const providerCredentials = yield* requireCredentials(credentials, selected);
+              const axiomCredentials = providerCredentials.axiom;
+              const sentryCredentials = providerCredentials.sentry;
+              const existingDatasets =
+                selected.has("axiom") && Option.isSome(axiomCredentials)
+                  ? [...(yield* axiomApi.datasets(axiomCredentials.value))]
+                  : [];
+              const existingTokens =
+                selected.has("axiom") && Option.isSome(axiomCredentials)
+                  ? [...(yield* axiomApi.tokens(axiomCredentials.value))]
+                  : [];
+
+              for (const request of requested) {
+                if (!request.providers.includes("axiom")) {
+                  continue;
                 }
-                if (
-                  rotateToken &&
-                  requested.some((environment) => !environment.providers.includes("axiom"))
-                ) {
+                const desiredDatasets = [
+                  { name: request.datasets.traces, kind: "axiom:events:v1" },
+                  { name: request.datasets.logs, kind: "axiom:events:v1" },
+                  { name: request.datasets.metrics, kind: "otel:metrics:v1" },
+                ];
+                for (const desired of desiredDatasets) {
+                  const matches = existingDatasets.filter(
+                    (dataset) => dataset.name === desired.name,
+                  );
+                  if (matches.length > 1) {
+                    return yield* new RemoteEnvironmentError({
+                      code: "OBS_CLI_AXIOM_REMOTE_NAME_CONFLICT",
+                      message: `Axiom contains multiple datasets named ${desired.name}. Resolve the duplicate names before retrying.`,
+                      cause: desired.name,
+                    });
+                  }
+                  const match = matches[0];
+                  if (match === undefined) {
+                    continue;
+                  }
+                  if (match.kind !== desired.kind) {
+                    if (desired.name === request.datasets.metrics) {
+                      return yield* new RemoteEnvironmentError({
+                        code: "OBS_CLI_AXIOM_METRICS_MIGRATION_REQUIRED",
+                        message: `Axiom metrics dataset ${desired.name} has kind ${match.kind}, but ${desired.kind} is required. Preserve historical metrics, stop ingestion, and replace the dataset manually before retrying.`,
+                        datasetName: desired.name,
+                        actualKind: match.kind,
+                        requiredKind: desired.kind,
+                        project,
+                        environment: request.name,
+                        cause: `${project}/${request.name}`,
+                      });
+                    }
+                    return yield* new RemoteEnvironmentError({
+                      code: "OBS_CLI_AXIOM_DATASET_CONFIGURATION_CONFLICT",
+                      message: `Axiom dataset ${desired.name} has incompatible kind ${match.kind}. Review the dataset before retrying.`,
+                      cause: desired.name,
+                    });
+                  }
+                  if (
+                    axiomEdgeDeployment !== undefined &&
+                    match.edgeDeployment !== axiomEdgeDeployment
+                  ) {
+                    return yield* new RemoteEnvironmentError({
+                      code: "OBS_CLI_AXIOM_DATASET_CONFIGURATION_CONFLICT",
+                      message: `Axiom dataset ${desired.name} does not use edge deployment ${axiomEdgeDeployment}. Reconcile the edge deployment in Axiom before retrying.`,
+                      cause: desired.name,
+                    });
+                  }
+                }
+
+                const tokenName = `${project}-${request.name}-collector`;
+                const namedTokens = existingTokens.filter((token) => token.name === tokenName);
+                if (namedTokens.length > 1) {
                   return yield* new RemoteEnvironmentError({
-                    code: "OBS_CLI_REMOTE_ROTATION_NOT_SELECTED",
-                    message:
-                      "Token rotation requires Axiom for every requested environment. Select --provider axiom or remove --rotate-token.",
-                    cause: "rotate-token",
+                    code: "OBS_CLI_AXIOM_REMOTE_NAME_CONFLICT",
+                    message: `Axiom contains multiple tokens named ${tokenName}. Resolve the duplicate names before retrying.`,
+                    cause: tokenName,
                   });
                 }
-                if (
-                  !rotateToken &&
-                  requested.some(
-                    (environment) =>
-                      environment.providers.includes("axiom") &&
-                      hasPendingAxiomMutation(credentials, project, environment.name),
-                  )
-                ) {
+                const remoteToken = namedTokens[0];
+                const localAxiom = Option.isSome(request.existing)
+                  ? environmentAxiom(request.existing.value)
+                  : Option.none<AxiomEnvironment>();
+                const datasetNames = [
+                  request.datasets.traces,
+                  request.datasets.logs,
+                  request.datasets.metrics,
+                ];
+                if (!rotateToken && remoteToken !== undefined) {
+                  if (!expectedDatasetCapabilities(remoteToken, datasetNames)) {
+                    return yield* new RemoteEnvironmentError({
+                      code: "OBS_CLI_AXIOM_TOKEN_CAPABILITIES_MISMATCH",
+                      message: `Axiom token ${tokenName} does not have exact ingest-create access to the three environment datasets. Rerun with --rotate-token.`,
+                      cause: tokenName,
+                    });
+                  }
+                  if (Option.isNone(localAxiom) || localAxiom.value.tokenId !== remoteToken.id) {
+                    return yield* new RemoteEnvironmentError({
+                      code: "OBS_CLI_REMOTE_TOKEN_UNAVAILABLE",
+                      message: `Axiom already contains token ${tokenName}, but its matching local secret is unavailable. Rerun with --rotate-token.`,
+                      cause: tokenName,
+                    });
+                  }
+                }
+                if (!rotateToken && remoteToken === undefined && Option.isSome(localAxiom)) {
                   return yield* new RemoteEnvironmentError({
                     code: "OBS_CLI_REMOTE_TOKEN_UNAVAILABLE",
-                    message:
-                      "A previous Axiom token mutation did not reach a durable checkpoint. Rerun with --rotate-token.",
-                    cause: "pending-axiom-mutation",
+                    message: `The stored token for ${project}/${request.name} does not match Axiom. Rerun with --rotate-token.`,
+                    cause: tokenName,
                   });
                 }
+              }
 
-                const selected = new Set(requested.flatMap((environment) => environment.providers));
-                const providerCredentials = yield* requireCredentials(credentials, selected);
-                const axiomCredentials = providerCredentials.axiom;
-                const sentryCredentials = providerCredentials.sentry;
+              let sentry = Option.none<SentryEnvironment>();
+              if (selected.has("sentry") && Option.isSome(sentryCredentials)) {
+                const sentryProject = yield* sentryApi.ensureProject(
+                  sentryCredentials.value,
+                  project,
+                  platform,
+                );
+                const sentryDsn = yield* sentryApi.dsn(sentryCredentials.value, sentryProject);
+                sentry = Option.some(
+                  new SentryEnvironment({ project: sentryProject, dsn: sentryDsn }),
+                );
+              }
 
-                let sentry = Option.none<SentryEnvironment>();
-                if (selected.has("sentry") && Option.isSome(sentryCredentials)) {
-                  const sentryProject = yield* sentryApi.ensureProject(
-                    sentryCredentials.value,
-                    project,
-                    platform,
-                  );
-                  const sentryDsn = yield* sentryApi.dsn(sentryCredentials.value, sentryProject);
-                  sentry = Option.some(
-                    new SentryEnvironment({ project: sentryProject, dsn: sentryDsn }),
-                  );
-                }
+              const completed: Array<string> = [];
+              const provisioned: Array<ManagedEnvironment> = [];
 
-                const existingDatasets =
-                  selected.has("axiom") && Option.isSome(axiomCredentials)
-                    ? [...(yield* axiomApi.datasets(axiomCredentials.value))]
-                    : [];
-                const existingTokens =
-                  selected.has("axiom") && Option.isSome(axiomCredentials)
-                    ? [...(yield* axiomApi.tokens(axiomCredentials.value))]
-                    : [];
-                const completed: Array<string> = [];
-                const provisioned: Array<ManagedEnvironment> = [];
+              for (const request of requested) {
+                const checkpoint: Effect.Effect<
+                  ManagedEnvironment,
+                  CredentialsError | RemoteApiError | RemoteEnvironmentError
+                > = Effect.gen(function* () {
+                  let axiom = Option.isSome(request.existing)
+                    ? environmentAxiom(request.existing.value)
+                    : Option.none<AxiomEnvironment>();
+                  let selectedSentry = Option.isSome(request.existing)
+                    ? environmentSentry(request.existing.value)
+                    : Option.none<SentryEnvironment>();
+                  if (request.providers.includes("sentry")) {
+                    selectedSentry = sentry;
+                  }
 
-                for (const request of requested) {
-                  const checkpoint: Effect.Effect<
-                    ManagedEnvironment,
-                    CredentialsError | RemoteApiError | RemoteEnvironmentError
-                  > = Effect.gen(function* () {
-                    let axiom = Option.isSome(request.existing)
-                      ? environmentAxiom(request.existing.value)
-                      : Option.none<AxiomEnvironment>();
-                    let selectedSentry = Option.isSome(request.existing)
-                      ? environmentSentry(request.existing.value)
-                      : Option.none<SentryEnvironment>();
-                    if (request.providers.includes("sentry")) {
-                      selectedSentry = sentry;
-                    }
-
-                    let tokenMutated = false;
-                    if (request.providers.includes("axiom") && Option.isSome(axiomCredentials)) {
-                      const datasetNames = [
-                        request.datasets.traces,
-                        request.datasets.logs,
-                        request.datasets.metrics,
-                      ];
-                      for (const dataset of datasetNames) {
-                        if (!existingDatasets.includes(dataset)) {
-                          yield* axiomApi.createDataset(axiomCredentials.value, dataset);
-                          existingDatasets.push(dataset);
+                  let tokenMutated = false;
+                  if (request.providers.includes("axiom") && Option.isSome(axiomCredentials)) {
+                    const datasetNames = [
+                      request.datasets.traces,
+                      request.datasets.logs,
+                      request.datasets.metrics,
+                    ];
+                    const desiredDatasets: ReadonlyArray<{
+                      readonly name: string;
+                      readonly kind: "axiom:events:v1" | "otel:metrics:v1";
+                    }> = [
+                      { name: request.datasets.traces, kind: "axiom:events:v1" },
+                      { name: request.datasets.logs, kind: "axiom:events:v1" },
+                      { name: request.datasets.metrics, kind: "otel:metrics:v1" },
+                    ];
+                    const reconciledDatasets: Array<AxiomDataset> = [];
+                    for (const desired of desiredDatasets) {
+                      let dataset = existingDatasets.find(
+                        (candidate) => candidate.name === desired.name,
+                      );
+                      if (dataset === undefined) {
+                        const options: AxiomDatasetCreateOptions =
+                          axiomEdgeDeployment === undefined
+                            ? axiomRetentionDays === undefined
+                              ? { kind: desired.kind }
+                              : { kind: desired.kind, retentionDays: axiomRetentionDays }
+                            : axiomRetentionDays === undefined
+                              ? { kind: desired.kind, edgeDeployment: axiomEdgeDeployment }
+                              : {
+                                  kind: desired.kind,
+                                  edgeDeployment: axiomEdgeDeployment,
+                                  retentionDays: axiomRetentionDays,
+                                };
+                        dataset = yield* axiomApi.createDataset(
+                          axiomCredentials.value,
+                          desired.name,
+                          options,
+                        );
+                        existingDatasets.push(dataset);
+                      } else if (
+                        axiomRetentionDays !== undefined &&
+                        (!dataset.useRetentionPeriod ||
+                          dataset.retentionDays !== axiomRetentionDays)
+                      ) {
+                        dataset = yield* axiomApi.updateDatasetRetention(
+                          axiomCredentials.value,
+                          dataset,
+                          axiomRetentionDays,
+                        );
+                        const index = existingDatasets.findIndex(
+                          (candidate) => candidate.id === dataset?.id,
+                        );
+                        if (index >= 0) {
+                          existingDatasets[index] = dataset;
                         }
                       }
+                      reconciledDatasets.push(dataset);
+                    }
 
-                      const tokenName = `${project}-${request.name}-collector`;
-                      const remoteToken = existingTokens.find((token) => token.name === tokenName);
-                      const localAxiom = Option.isSome(request.existing)
-                        ? environmentAxiom(request.existing.value)
-                        : Option.none<AxiomEnvironment>();
-                      let token: { readonly id: string; readonly token: string };
-                      if (rotateToken) {
-                        tokenMutated = true;
-                        credentials = markAxiomMutationPending(credentials, project, request.name);
-                        yield* access.save(credentials);
-                        token = yield* (
-                          remoteToken === undefined
-                            ? axiomApi.createToken(axiomCredentials.value, tokenName, datasetNames)
-                            : axiomApi.regenerateToken(axiomCredentials.value, remoteToken.id)
-                        ).pipe(
+                    const tokenName = `${project}-${request.name}-collector`;
+                    const remoteToken = existingTokens.find((token) => token.name === tokenName);
+                    const localAxiom = Option.isSome(request.existing)
+                      ? environmentAxiom(request.existing.value)
+                      : Option.none<AxiomEnvironment>();
+                    let token: { readonly id: string; readonly token: string };
+                    if (rotateToken) {
+                      tokenMutated = true;
+                      credentials = markAxiomMutationPending(credentials, project, request.name);
+                      yield* access.save(credentials);
+                      token = yield* (
+                        remoteToken === undefined
+                          ? axiomApi.createToken(axiomCredentials.value, tokenName, datasetNames)
+                          : axiomApi.regenerateToken(
+                              axiomCredentials.value,
+                              remoteToken,
+                              datasetNames,
+                            )
+                      ).pipe(
+                        Effect.catchTag("RemoteApiError", (error) => {
+                          const classified = mutationOutcomeUnknown(error, completed);
+                          if (
+                            classified._tag === "RemoteEnvironmentError" &&
+                            classified.code === "OBS_CLI_REMOTE_OUTCOME_UNKNOWN"
+                          ) {
+                            return Effect.fail(classified);
+                          }
+                          credentials = clearPendingAxiomMutation(
+                            credentials,
+                            project,
+                            request.name,
+                          );
+                          return access
+                            .save(credentials)
+                            .pipe(Effect.andThen(Effect.fail(classified)));
+                        }),
+                      );
+                    } else if (Option.isSome(localAxiom)) {
+                      if (
+                        remoteToken === undefined ||
+                        remoteToken.id !== localAxiom.value.tokenId
+                      ) {
+                        return yield* new RemoteEnvironmentError({
+                          code: "OBS_CLI_REMOTE_TOKEN_UNAVAILABLE",
+                          message: `The stored token for ${project}/${request.name} does not match Axiom. Rerun with --rotate-token.`,
+                          cause: tokenName,
+                        });
+                      }
+                      token = { id: localAxiom.value.tokenId, token: localAxiom.value.token };
+                    } else if (remoteToken !== undefined) {
+                      return yield* new RemoteEnvironmentError({
+                        code: "OBS_CLI_REMOTE_TOKEN_UNAVAILABLE",
+                        message: `Axiom already contains token ${tokenName}, but its secret is unavailable. Rerun with --rotate-token.`,
+                        cause: tokenName,
+                      });
+                    } else {
+                      tokenMutated = true;
+                      credentials = markAxiomMutationPending(credentials, project, request.name);
+                      yield* access.save(credentials);
+                      token = yield* axiomApi
+                        .createToken(axiomCredentials.value, tokenName, datasetNames)
+                        .pipe(
                           Effect.catchTag("RemoteApiError", (error) => {
                             const classified = mutationOutcomeUnknown(error, completed);
                             if (
@@ -660,101 +936,145 @@ export class RemoteEnvironment extends Context.Service<
                               .pipe(Effect.andThen(Effect.fail(classified)));
                           }),
                         );
-                        if (remoteToken === undefined) {
-                          existingTokens.push({ id: token.id, name: tokenName });
-                        }
-                      } else if (Option.isSome(localAxiom)) {
+                    }
+                    let verified = reconciledDatasets;
+                    if (correlationConfirmed) {
+                      verified = [...(yield* axiomApi.datasets(axiomCredentials.value))].filter(
+                        (dataset) => datasetNames.includes(dataset.name),
+                      );
+                      if (verified.length !== 3) {
+                        return yield* new RemoteEnvironmentError({
+                          code: "OBS_CLI_AXIOM_DATASET_CONFIGURATION_CONFLICT",
+                          message: `A fresh Axiom verification could not find all three datasets for ${project}/${request.name}. Retry after verifying the remote resources.`,
+                          project,
+                          environment: request.name,
+                          cause: `${project}/${request.name}`,
+                        });
+                      }
+                      for (const desired of desiredDatasets) {
+                        const matches = verified.filter((dataset) => dataset.name === desired.name);
+                        const dataset = matches[0];
                         if (
-                          remoteToken === undefined ||
-                          remoteToken.id !== localAxiom.value.tokenId
+                          matches.length !== 1 ||
+                          dataset === undefined ||
+                          dataset.kind !== desired.kind ||
+                          (axiomEdgeDeployment !== undefined &&
+                            dataset.edgeDeployment !== axiomEdgeDeployment) ||
+                          (axiomRetentionDays !== undefined &&
+                            (!dataset.useRetentionPeriod ||
+                              dataset.retentionDays !== axiomRetentionDays))
                         ) {
                           return yield* new RemoteEnvironmentError({
-                            code: "OBS_CLI_REMOTE_TOKEN_UNAVAILABLE",
-                            message: `The stored token for ${project}/${request.name} does not match Axiom. Rerun with --rotate-token.`,
-                            cause: tokenName,
+                            code: "OBS_CLI_AXIOM_DATASET_CONFIGURATION_CONFLICT",
+                            message: `A fresh Axiom verification found an incompatible dataset ${desired.name}. Reconcile its kind, edge deployment and retention before confirming correlation.`,
+                            cause: desired.name,
                           });
                         }
-                        token = { id: localAxiom.value.tokenId, token: localAxiom.value.token };
-                      } else if (remoteToken !== undefined) {
-                        return yield* new RemoteEnvironmentError({
-                          code: "OBS_CLI_REMOTE_TOKEN_UNAVAILABLE",
-                          message: `Axiom already contains token ${tokenName}, but its secret is unavailable. Rerun with --rotate-token.`,
-                          cause: tokenName,
-                        });
-                      } else {
-                        tokenMutated = true;
-                        credentials = markAxiomMutationPending(credentials, project, request.name);
-                        yield* access.save(credentials);
-                        token = yield* axiomApi
-                          .createToken(axiomCredentials.value, tokenName, datasetNames)
-                          .pipe(
-                            Effect.catchTag("RemoteApiError", (error) => {
-                              const classified = mutationOutcomeUnknown(error, completed);
-                              if (
-                                classified._tag === "RemoteEnvironmentError" &&
-                                classified.code === "OBS_CLI_REMOTE_OUTCOME_UNKNOWN"
-                              ) {
-                                return Effect.fail(classified);
-                              }
-                              credentials = clearPendingAxiomMutation(
-                                credentials,
-                                project,
-                                request.name,
-                              );
-                              return access
-                                .save(credentials)
-                                .pipe(Effect.andThen(Effect.fail(classified)));
-                            }),
-                          );
-                        existingTokens.push({ id: token.id, name: tokenName });
                       }
-                      axiom = Option.some(
-                        new AxiomEnvironment({
-                          tokenId: token.id,
-                          token: token.token,
-                          tracesDataset: request.datasets.traces,
-                          logsDataset: request.datasets.logs,
-                          metricsDataset: request.datasets.metrics,
-                        }),
+                      const freshMetrics = verified.find(
+                        (dataset) => dataset.name === request.datasets.metrics,
                       );
+                      if (freshMetrics?.edgeDeployment === undefined) {
+                        return yield* new RemoteEnvironmentError({
+                          code: "OBS_CLI_AXIOM_DATASET_CONFIGURATION_CONFLICT",
+                          message: `Axiom metrics dataset ${request.datasets.metrics} has no verified edge deployment. Configure one before confirming correlation.`,
+                          cause: request.datasets.metrics,
+                        });
+                      }
                     }
+                    const traces = verified.find(
+                      (dataset) => dataset.name === request.datasets.traces,
+                    );
+                    const logs = verified.find((dataset) => dataset.name === request.datasets.logs);
+                    const metrics = verified.find(
+                      (dataset) => dataset.name === request.datasets.metrics,
+                    );
+                    if (traces === undefined || logs === undefined || metrics === undefined) {
+                      return yield* new RemoteEnvironmentError({
+                        code: "OBS_CLI_AXIOM_DATASET_CONFIGURATION_CONFLICT",
+                        message: `Axiom did not return the complete dataset contract for ${project}/${request.name}. Verify the remote resources before retrying.`,
+                        cause: `${project}/${request.name}`,
+                      });
+                    }
+                    const groupName = `${project} ${request.name}`;
+                    const groupSlug = `${project}-${request.name}`;
+                    const currentCorrelation = Option.isSome(axiom)
+                      ? axiom.value.correlation
+                      : undefined;
+                    let correlation: AxiomEnvironment["correlation"] = {
+                      type: "manual-required",
+                      groupName,
+                      groupSlug,
+                      tracesDataset: request.datasets.traces,
+                      logsDataset: request.datasets.logs,
+                      metricsDataset: request.datasets.metrics,
+                    };
+                    if (correlationConfirmed) {
+                      const now = yield* DateTime.now;
+                      correlation = {
+                        type: "operator-confirmed",
+                        groupName,
+                        groupSlug,
+                        tracesDataset: request.datasets.traces,
+                        logsDataset: request.datasets.logs,
+                        metricsDataset: request.datasets.metrics,
+                        confirmedAt: DateTime.formatIso(now),
+                      };
+                    } else if (currentCorrelation?.type === "operator-confirmed") {
+                      correlation = currentCorrelation;
+                    }
+                    axiom = Option.some(
+                      new AxiomEnvironment({
+                        tokenId: token.id,
+                        token: token.token,
+                        tracesDataset: request.datasets.traces,
+                        logsDataset: request.datasets.logs,
+                        metricsDataset: request.datasets.metrics,
+                        datasets: {
+                          traces: verifiedDataset(traces),
+                          logs: verifiedDataset(logs),
+                          metrics: verifiedDataset(metrics),
+                        },
+                        correlation,
+                      }),
+                    );
+                  }
 
-                    const environment = new ManagedEnvironment({
-                      project,
-                      environment: request.name,
-                      providers: yield* makeProviders(axiom, selectedSentry),
-                    });
-                    credentials = replaceEnvironment(credentials, environment);
-                    if (tokenMutated) {
-                      credentials = clearPendingAxiomMutation(credentials, project, request.name);
-                      yield* access.save(credentials).pipe(
-                        Effect.mapError(
-                          (error) =>
-                            new RemoteEnvironmentError({
-                              code: "OBS_CLI_REMOTE_OUTCOME_UNKNOWN",
-                              message: `The Axiom token changed, but local state could not be saved. Rotate the token before retrying. Saved environments: ${completed.length === 0 ? "none" : completed.join(", ")}.`,
-                              cause: error,
-                            }),
-                        ),
-                      );
-                    } else {
-                      yield* access.save(credentials);
-                    }
-                    completed.push(`${project}/${request.name}`);
-                    return environment;
+                  const environment = new ManagedEnvironment({
+                    project,
+                    environment: request.name,
+                    providers: yield* makeProviders(axiom, selectedSentry),
                   });
-                  const result = yield* checkpoint.pipe(
-                    Effect.catchTag("RemoteApiError", (error) =>
-                      Effect.fail(partialFailure(error, completed)),
-                    ),
-                  );
-                  provisioned.push(result);
-                }
-                return provisioned;
-              }),
-            );
-          },
-        ),
+                  credentials = replaceEnvironment(credentials, environment);
+                  if (tokenMutated) {
+                    credentials = clearPendingAxiomMutation(credentials, project, request.name);
+                    yield* access.save(credentials).pipe(
+                      Effect.mapError(
+                        (error) =>
+                          new RemoteEnvironmentError({
+                            code: "OBS_CLI_REMOTE_OUTCOME_UNKNOWN",
+                            message: `The Axiom token changed, but local state could not be saved. Rotate the token before retrying. Saved environments: ${completed.length === 0 ? "none" : completed.join(", ")}.`,
+                            cause: error,
+                          }),
+                      ),
+                    );
+                  } else {
+                    yield* access.save(credentials);
+                  }
+                  completed.push(`${project}/${request.name}`);
+                  return environment;
+                });
+                const result = yield* checkpoint.pipe(
+                  Effect.catchTag("RemoteApiError", (error) =>
+                    Effect.fail(partialFailure(error, completed)),
+                  ),
+                );
+                provisioned.push(result);
+              }
+              return provisioned;
+            }),
+          );
+        }),
         list,
         export: Effect.fn("RemoteEnvironment.export")(function* (project, rawEnvironment) {
           const environment = yield* parseEnvironmentName(rawEnvironment);
@@ -776,6 +1096,17 @@ export class RemoteEnvironment extends Context.Service<
             return yield* new RemoteEnvironmentError({
               code: "OBS_CLI_REMOTE_TOKEN_UNAVAILABLE",
               message: `The stored token for ${project}/${environment} may be stale after an unresolved mutation. Rerun provisioning with --provider axiom --rotate-token before exporting it.`,
+              cause: `${project}/${environment}`,
+            });
+          }
+          const managedAxiom = environmentAxiom(managed);
+          if (
+            Option.isSome(managedAxiom) &&
+            managedAxiom.value.correlation.type !== "operator-confirmed"
+          ) {
+            return yield* new RemoteEnvironmentError({
+              code: "OBS_CLI_CORRELATION_CONFIRMATION_REQUIRED",
+              message: `Correlation for ${project}/${environment} requires a manual Axiom Console action. Create the saved group and rerun provisioning with --correlation-confirmed before exporting deploy variables.`,
               cause: `${project}/${environment}`,
             });
           }

--- a/packages/cli/src/RemoteEnvironment.ts
+++ b/packages/cli/src/RemoteEnvironment.ts
@@ -391,21 +391,45 @@ const expectedDatasetCapabilities = (
   datasets: ReadonlyArray<string>,
 ): boolean => {
   const capabilityNames = Object.keys(token.datasetCapabilities);
-  if (capabilityNames.length !== datasets.length || token.orgCapabilities === undefined) {
+  if (capabilityNames.length !== datasets.length) {
     return false;
   }
-  if (Object.keys(token.orgCapabilities).length !== 0) {
+  if (
+    Object.keys(token.orgCapabilities).length !== 0 ||
+    Object.keys(token.viewCapabilities).length !== 0
+  ) {
     return false;
   }
   return datasets.every((dataset) => {
     const capability = token.datasetCapabilities[dataset];
-    return (
-      capability !== undefined &&
-      capability.ingest?.length === 1 &&
-      capability.ingest[0] === "create" &&
-      (capability.query === undefined || capability.query.length === 0)
-    );
+    if (capability === undefined || Object.keys(capability).length !== 1) {
+      return false;
+    }
+    return capability.ingest?.length === 1 && capability.ingest[0] === "create";
   });
+};
+
+const matchingManualCorrelation = (
+  existing: Option.Option<ManagedEnvironment>,
+  project: string,
+  environment: string,
+  datasets: EnvironmentDatasets,
+): boolean => {
+  if (Option.isNone(existing)) {
+    return false;
+  }
+  const axiom = environmentAxiom(existing.value);
+  if (Option.isNone(axiom) || axiom.value.correlation.type !== "manual-required") {
+    return false;
+  }
+  const correlation = axiom.value.correlation;
+  return (
+    correlation.groupName === `${project} ${environment}` &&
+    correlation.groupSlug === `${project}-${environment}` &&
+    correlation.tracesDataset === datasets.traces &&
+    correlation.logsDataset === datasets.logs &&
+    correlation.metricsDataset === datasets.metrics
+  );
 };
 
 const verifiedDataset = (dataset: AxiomDataset): VerifiedAxiomDataset => {
@@ -628,6 +652,33 @@ export class RemoteEnvironment extends Context.Service<
                   providers: effectiveProviders(explicitProviders, existing),
                 });
               }
+              if (correlationConfirmed) {
+                if (axiomEdgeDeployment === undefined) {
+                  return yield* new RemoteEnvironmentError({
+                    code: "OBS_CLI_CORRELATION_CONFIRMATION_REQUIRED",
+                    message:
+                      "Correlation confirmation requires one explicit --axiom-edge-deployment value.",
+                    cause: "missing-axiom-edge-deployment",
+                  });
+                }
+                for (const request of requested) {
+                  if (
+                    !request.providers.includes("axiom") ||
+                    !matchingManualCorrelation(
+                      request.existing,
+                      project,
+                      request.name,
+                      request.datasets,
+                    )
+                  ) {
+                    return yield* new RemoteEnvironmentError({
+                      code: "OBS_CLI_CORRELATION_CONFIRMATION_REQUIRED",
+                      message: `Correlation for ${project}/${request.name} can be confirmed only after a prior completed provisioning invocation saved the matching manual action.`,
+                      cause: `${project}/${request.name}`,
+                    });
+                  }
+                }
+              }
               if (
                 rotateToken &&
                 requested.some((environment) => !environment.providers.includes("axiom"))
@@ -690,6 +741,13 @@ export class RemoteEnvironment extends Context.Service<
                   }
                   const match = matches[0];
                   if (match === undefined) {
+                    if (correlationConfirmed) {
+                      return yield* new RemoteEnvironmentError({
+                        code: "OBS_CLI_AXIOM_DATASET_CONFIGURATION_CONFLICT",
+                        message: `Axiom dataset ${desired.name} is missing. Restore it and complete provisioning before confirming correlation.`,
+                        cause: desired.name,
+                      });
+                    }
                     continue;
                   }
                   if (match.kind !== desired.kind) {
@@ -708,6 +766,16 @@ export class RemoteEnvironment extends Context.Service<
                     return yield* new RemoteEnvironmentError({
                       code: "OBS_CLI_AXIOM_DATASET_CONFIGURATION_CONFLICT",
                       message: `Axiom dataset ${desired.name} has incompatible kind ${match.kind}. Review the dataset before retrying.`,
+                      cause: desired.name,
+                    });
+                  }
+                  if (
+                    axiomRetentionDays !== undefined &&
+                    (!match.useRetentionPeriod || match.retentionDays !== axiomRetentionDays)
+                  ) {
+                    return yield* new RemoteEnvironmentError({
+                      code: "OBS_CLI_AXIOM_DATASET_CONFIGURATION_CONFLICT",
+                      message: `Axiom dataset ${desired.name} has retention that differs from the explicitly requested ${axiomRetentionDays} days. Retention changes are destructive and must be performed manually before retrying.`,
                       cause: desired.name,
                     });
                   }
@@ -836,22 +904,6 @@ export class RemoteEnvironment extends Context.Service<
                           options,
                         );
                         existingDatasets.push(dataset);
-                      } else if (
-                        axiomRetentionDays !== undefined &&
-                        (!dataset.useRetentionPeriod ||
-                          dataset.retentionDays !== axiomRetentionDays)
-                      ) {
-                        dataset = yield* axiomApi.updateDatasetRetention(
-                          axiomCredentials.value,
-                          dataset,
-                          axiomRetentionDays,
-                        );
-                        const index = existingDatasets.findIndex(
-                          (candidate) => candidate.id === dataset?.id,
-                        );
-                        if (index >= 0) {
-                          existingDatasets[index] = dataset;
-                        }
                       }
                       reconciledDatasets.push(dataset);
                     }

--- a/packages/cli/test/CredentialsStore.bun.test.ts
+++ b/packages/cli/test/CredentialsStore.bun.test.ts
@@ -83,14 +83,14 @@ const administrativeCredentials = () => ({
 });
 
 describe("CredentialsStore", () => {
-  test.serial("writes version 2 credentials durably with owner-only permissions", () =>
+  test.serial("writes version 3 credentials durably with owner-only permissions", () =>
     withCredentialsHome("observability-credentials-", async (root) => {
       const credentials = administrativeCredentials();
       const result = await Effect.runPromise(
         Effect.gen(function* () {
           const store = yield* CredentialsStore;
           const fs = yield* FileSystem.FileSystem;
-          yield* store.save(new CredentialsFile({ version: 2, ...credentials, environments: [] }));
+          yield* store.save(new CredentialsFile({ version: 3, ...credentials, environments: [] }));
           const loaded = yield* store.load();
           const info = yield* fs.stat(store.path);
           const lockExists = yield* fs.exists(`${root}/.credentials.lock`);
@@ -102,7 +102,7 @@ describe("CredentialsStore", () => {
       expect(result.lockExists).toBeFalse();
       expect(Option.isSome(result.loaded)).toBeTrue();
       if (Option.isSome(result.loaded)) {
-        expect(result.loaded.value.version).toBe(2);
+        expect(result.loaded.value.version).toBe(3);
         expect(result.loaded.value.axiom?.token).toBe("xapt-secret");
         expect(result.loaded.value.sentry?.baseUrl.toString()).toBe("https://sentry.io/");
       }
@@ -148,7 +148,7 @@ describe("CredentialsStore", () => {
         }).pipe(Effect.provide(CredentialsStore.layer), Effect.provide(BunServices.layer)),
       );
 
-      expect(decodePersistedVersion(JSON.parse(result.content)).version).toBe(2);
+      expect(decodePersistedVersion(JSON.parse(result.content)).version).toBe(3);
       expect(result.content).toContain("legacy-axiom-secret");
       expect(result.content).toContain("legacy-sentry-secret");
       expect(result.content).toContain("legacy-ingest-secret");
@@ -156,13 +156,65 @@ describe("CredentialsStore", () => {
       expect(Option.isSome(result.loaded)).toBeTrue();
       if (Option.isSome(result.loaded)) {
         expect(result.loaded.value.environments[0]?.providers.type).toBe("combined");
+        const providers = result.loaded.value.environments[0]?.providers;
+        if (providers?.type === "combined") {
+          expect(providers.axiom.correlation.type).toBe("verification-required");
+        }
+      }
+    }),
+  );
+
+  test.serial("migrates version 2 and preserves pending mutations", () =>
+    withCredentialsHome("observability-v2-migration-", async (root) => {
+      const legacy = {
+        version: 2,
+        axiom: { token: "admin-secret", organizationId: "org-id" },
+        environments: [
+          {
+            project: "livro-caixa",
+            environment: "staging",
+            providers: {
+              type: "axiom",
+              axiom: {
+                tokenId: "token-id",
+                token: "ingest-secret",
+                tracesDataset: "livro-caixa-staging-traces",
+                logsDataset: "livro-caixa-staging-logs",
+                metricsDataset: "livro-caixa-staging-metrics",
+              },
+            },
+          },
+        ],
+        pendingAxiomMutations: [{ project: "livro-caixa", environment: "staging" }],
+      };
+      await Bun.write(`${root}/credentials.json`, `${JSON.stringify(legacy)}\n`);
+      await chmod(`${root}/credentials.json`, 0o600);
+
+      const loaded = await Effect.runPromise(
+        Effect.gen(function* () {
+          const store = yield* CredentialsStore;
+          return yield* store.load();
+        }).pipe(Effect.provide(CredentialsStore.layer), Effect.provide(BunServices.layer)),
+      );
+
+      expect(Option.isSome(loaded)).toBeTrue();
+      if (Option.isSome(loaded)) {
+        expect(loaded.value.version).toBe(3);
+        expect(loaded.value.pendingAxiomMutations).toEqual([
+          { project: "livro-caixa", environment: "staging" },
+        ]);
+        const providers = loaded.value.environments[0]?.providers;
+        if (providers?.type === "axiom") {
+          expect(providers.axiom.token).toBe("ingest-secret");
+          expect(providers.axiom.correlation.type).toBe("verification-required");
+        }
       }
     }),
   );
 
   test.serial("rejects unsupported versions without replacing the file", () =>
     withCredentialsHome("observability-version-", async (root) => {
-      const original = '{"version":3,"environments":[]}\n';
+      const original = '{"version":4,"environments":[]}\n';
       await Bun.write(`${root}/credentials.json`, original);
       await chmod(`${root}/credentials.json`, 0o600);
 
@@ -192,7 +244,7 @@ describe("CredentialsStore", () => {
         Effect.gen(function* () {
           const store = yield* CredentialsStore;
           return yield* Effect.flip(
-            store.save(new CredentialsFile({ version: 2, environments: [] })),
+            store.save(new CredentialsFile({ version: 3, environments: [] })),
           );
         }).pipe(
           Effect.provide(CredentialsStore.layer),
@@ -253,7 +305,7 @@ describe("CredentialsStore", () => {
       const contender = Effect.runPromise(
         Effect.gen(function* () {
           const store = yield* CredentialsStore;
-          yield* store.save(new CredentialsFile({ version: 2, environments: [] }));
+          yield* store.save(new CredentialsFile({ version: 3, environments: [] }));
         }).pipe(Effect.provide(CredentialsStore.layer), Effect.provide(BunServices.layer)),
       ).then(() => {
         contenderFinished = true;
@@ -465,7 +517,7 @@ describe("CredentialsStore", () => {
       await Effect.runPromise(
         Effect.gen(function* () {
           const store = yield* CredentialsStore;
-          yield* store.save(new CredentialsFile({ version: 2, environments: [] }));
+          yield* store.save(new CredentialsFile({ version: 3, environments: [] }));
         }).pipe(Effect.provide(CredentialsStore.layer), Effect.provide(BunServices.layer)),
       );
 
@@ -484,7 +536,7 @@ describe("CredentialsStore", () => {
         Effect.gen(function* () {
           const store = yield* CredentialsStore;
           const fs = yield* FileSystem.FileSystem;
-          yield* store.save(new CredentialsFile({ version: 2, environments: [] }));
+          yield* store.save(new CredentialsFile({ version: 3, environments: [] }));
           yield* fs.chmod(store.path, 0o644);
           return yield* Effect.flip(store.load());
         }).pipe(Effect.provide(CredentialsStore.layer), Effect.provide(BunServices.layer)),

--- a/packages/cli/test/ProviderApis.bun.test.ts
+++ b/packages/cli/test/ProviderApis.bun.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Effect } from "effect";
 import { AxiomCredentials } from "../src/CredentialsStore.ts";
-import { AxiomApi } from "../src/ProviderApis.ts";
+import { AxiomApi, AxiomToken } from "../src/ProviderApis.ts";
 
 const credentials = new AxiomCredentials({ token: "test-token", organizationId: "test-org" });
 
@@ -69,6 +69,242 @@ const startTruncatedResponseServer = (status: number, statusText: string) => {
 };
 
 describe("provider HTTP boundary", () => {
+  test.serial("creates signal datasets with exact kinds and optional configuration", async () => {
+    const requests: Array<{ readonly path: string; readonly body: string }> = [];
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: async (request) => {
+        const url = new URL(request.url);
+        const body = await request.text();
+        requests.push({ path: url.pathname, body });
+        const value = JSON.parse(body);
+        return Response.json(
+          {
+            id: `id-${requests.length}`,
+            name: value.name,
+            description: value.description,
+            kind: value.kind,
+            edgeDeployment: value.edgeDeployment,
+            retentionDays: value.retentionDays,
+            useRetentionPeriod: value.useRetentionPeriod ?? false,
+          },
+          { status: 201 },
+        );
+      },
+    });
+    try {
+      await withAxiomEndpoint(`http://127.0.0.1:${server.port}`, () =>
+        Effect.runPromise(
+          Effect.gen(function* () {
+            const api = yield* AxiomApi;
+            yield* api.createDataset(credentials, "project-traces");
+            yield* api.createDataset(credentials, "project-logs", {
+              kind: "axiom:events:v1",
+            });
+            yield* api.createDataset(credentials, "project-metrics", {
+              kind: "otel:metrics:v1",
+              edgeDeployment: "edge-main",
+              retentionDays: 30,
+            });
+          }).pipe(Effect.provide(AxiomApi.layer)),
+        ),
+      );
+      expect(requests.map((request) => JSON.parse(request.body))).toEqual([
+        {
+          name: "project-traces",
+          description: "OpenTelemetry data for project-traces",
+          kind: "axiom:events:v1",
+        },
+        {
+          name: "project-logs",
+          description: "OpenTelemetry data for project-logs",
+          kind: "axiom:events:v1",
+        },
+        {
+          name: "project-metrics",
+          description: "OpenTelemetry data for project-metrics",
+          kind: "otel:metrics:v1",
+          edgeDeployment: "edge-main",
+          retentionDays: 30,
+          useRetentionPeriod: true,
+        },
+      ]);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test.serial("rereads and reconciles an exact dataset after HTTP 409", async () => {
+    let reads = 0;
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: (request) => {
+        if (request.method === "POST") {
+          return Response.json({ error: "exists" }, { status: 409 });
+        }
+        reads += 1;
+        return Response.json([
+          {
+            id: "metrics-id",
+            name: "project-metrics",
+            description: "metrics",
+            kind: "otel:metrics:v1",
+            edgeDeployment: "edge-main",
+            retentionDays: 30,
+            useRetentionPeriod: true,
+          },
+        ]);
+      },
+    });
+    try {
+      const dataset = await withAxiomEndpoint(`http://127.0.0.1:${server.port}`, () =>
+        Effect.runPromise(
+          Effect.gen(function* () {
+            const api = yield* AxiomApi;
+            return yield* api.createDataset(credentials, "project-metrics", {
+              kind: "otel:metrics:v1",
+              edgeDeployment: "edge-main",
+              retentionDays: 30,
+            });
+          }).pipe(Effect.provide(AxiomApi.layer)),
+        ),
+      );
+      expect(dataset.kind).toBe("otel:metrics:v1");
+      expect(reads).toBe(1);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test.serial("rejects an incompatible dataset after HTTP 409", async () => {
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: (request) =>
+        request.method === "POST"
+          ? Response.json({ error: "exists" }, { status: 409 })
+          : Response.json([
+              {
+                id: "metrics-id",
+                name: "project-metrics",
+                description: "generic create defect",
+                kind: "axiom:events:v1",
+                useRetentionPeriod: false,
+              },
+            ]),
+    });
+    try {
+      const error = await withAxiomEndpoint(`http://127.0.0.1:${server.port}`, () =>
+        Effect.runPromise(
+          Effect.gen(function* () {
+            const api = yield* AxiomApi;
+            return yield* Effect.flip(
+              api.createDataset(credentials, "project-metrics", {
+                kind: "otel:metrics:v1",
+              }),
+            );
+          }).pipe(Effect.provide(AxiomApi.layer)),
+        ),
+      );
+      expect(error.code).toBe("OBS_CLI_AXIOM_DATASET_CONFLICT");
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test.serial("rejects malformed dataset kinds and token capabilities", async () => {
+    let tokenResponse = false;
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: (request) => {
+        if (new URL(request.url).pathname === "/v2/datasets") {
+          return Response.json([
+            {
+              id: "bad-id",
+              name: "bad-dataset",
+              description: "bad",
+              kind: "generic",
+              useRetentionPeriod: false,
+            },
+          ]);
+        }
+        tokenResponse = true;
+        return Response.json([
+          {
+            id: "bad-token",
+            name: "bad-token",
+            description: "bad",
+            datasetCapabilities: { dataset: { ingest: "create" } },
+            orgCapabilities: {},
+          },
+        ]);
+      },
+    });
+    try {
+      const result = await withAxiomEndpoint(`http://127.0.0.1:${server.port}`, () =>
+        Effect.runPromise(
+          Effect.gen(function* () {
+            const api = yield* AxiomApi;
+            const datasetError = yield* Effect.flip(api.datasets(credentials));
+            const tokenError = yield* Effect.flip(api.tokens(credentials));
+            return { datasetError, tokenError };
+          }).pipe(Effect.provide(AxiomApi.layer)),
+        ),
+      );
+      expect(result.datasetError.code).toBe("OBS_CLI_REMOTE_INVALID_RESPONSE");
+      expect(result.tokenError.code).toBe("OBS_CLI_REMOTE_INVALID_RESPONSE");
+      expect(tokenResponse).toBeTrue();
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test.serial("regenerates tokens with the documented exact newToken body", async () => {
+    let body = "";
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: async (request) => {
+        body = await request.text();
+        return Response.json({ id: "token-id", token: "new-secret" });
+      },
+    });
+    const token = new AxiomToken({
+      id: "token-id",
+      name: "project-collector",
+      description: "collector",
+      datasetCapabilities: {},
+      orgCapabilities: {},
+    });
+    try {
+      await withAxiomEndpoint(`http://127.0.0.1:${server.port}`, () =>
+        Effect.runPromise(
+          Effect.gen(function* () {
+            const api = yield* AxiomApi;
+            yield* api.regenerateToken(credentials, token, ["traces", "logs", "metrics"]);
+          }).pipe(Effect.provide(AxiomApi.layer)),
+        ),
+      );
+      expect(JSON.parse(body)).toEqual({
+        newToken: {
+          name: "project-collector",
+          description: "collector",
+          datasetCapabilities: {
+            traces: { ingest: ["create"] },
+            logs: { ingest: ["create"] },
+            metrics: { ingest: ["create"] },
+          },
+          orgCapabilities: {},
+          viewCapabilities: {},
+        },
+      });
+    } finally {
+      await server.stop(true);
+    }
+  });
   test.serial("classifies unauthorized before consuming a body proven unreadable", async () => {
     const server = startTruncatedResponseServer(401, "Unauthorized");
     const url = `http://127.0.0.1:${server.listener.port}`;

--- a/packages/cli/test/ProviderApis.bun.test.ts
+++ b/packages/cli/test/ProviderApis.bun.test.ts
@@ -262,6 +262,42 @@ describe("provider HTTP boundary", () => {
     }
   });
 
+  test.serial("parses complete organization, dataset and view token capabilities", async () => {
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () =>
+        Response.json([
+          {
+            id: "token-id",
+            name: "collector",
+            description: "collector token",
+            expiresAt: "2030-01-01T00:00:00Z",
+            datasetCapabilities: {
+              traces: { ingest: ["create"], query: ["read"] },
+            },
+            orgCapabilities: { datasets: ["read"] },
+            viewCapabilities: { dashboard: ["read"] },
+          },
+        ]),
+    });
+    try {
+      const tokens = await withAxiomEndpoint(`http://127.0.0.1:${server.port}`, () =>
+        Effect.runPromise(
+          Effect.gen(function* () {
+            const api = yield* AxiomApi;
+            return yield* api.tokens(credentials);
+          }).pipe(Effect.provide(AxiomApi.layer)),
+        ),
+      );
+      expect(tokens[0]?.datasetCapabilities.traces?.query).toEqual(["read"]);
+      expect(tokens[0]?.orgCapabilities.datasets).toEqual(["read"]);
+      expect(tokens[0]?.viewCapabilities.dashboard).toEqual(["read"]);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
   test.serial("regenerates tokens with the documented exact newToken body", async () => {
     let body = "";
     const server = Bun.serve({
@@ -278,6 +314,7 @@ describe("provider HTTP boundary", () => {
       description: "collector",
       datasetCapabilities: {},
       orgCapabilities: {},
+      viewCapabilities: {},
     });
     try {
       await withAxiomEndpoint(`http://127.0.0.1:${server.port}`, () =>

--- a/packages/cli/test/ProviderSelection.bun.test.ts
+++ b/packages/cli/test/ProviderSelection.bun.test.ts
@@ -127,6 +127,7 @@ const startProviderServer = (): ProviderServer => {
             description,
             datasetCapabilities,
             orgCapabilities: {},
+            viewCapabilities: {},
           })),
         );
       }
@@ -286,7 +287,7 @@ const provisionArgs = (
     ...providers.flatMap((provider) => ["--provider", provider]),
   ];
   if (providers.includes("axiom") || providers.length === 0) {
-    return [...args, "--axiom-edge-deployment", "edge-main", "--correlation-confirmed"];
+    return [...args, "--axiom-edge-deployment", "edge-main"];
   }
   return args;
 };
@@ -340,6 +341,12 @@ describe("built CLI provider selection", () => {
           axiomTarget,
           server,
         );
+        const axiomConfirmation = await runCli(
+          [...provisionArgs(axiomTarget, "staging", []), "--correlation-confirmed"],
+          axiomRoot,
+          axiomTarget,
+          server,
+        );
         const axiomExport = await runCli(
           ["env", "export", "--name", "livro-caixa", "--environment", "staging"],
           axiomRoot,
@@ -348,6 +355,7 @@ describe("built CLI provider selection", () => {
         );
         expect(axiomFirst.exitCode).toBe(0);
         expect(axiomRepeat.exitCode).toBe(0);
+        expect(axiomConfirmation.exitCode).toBe(0);
         expect(axiomExport.stdout.trim().split("\n")).toEqual([
           'OTEL_SERVICE_NAME="livro-caixa"',
           'OTEL_DEPLOYMENT_ENVIRONMENT="staging"',
@@ -373,6 +381,7 @@ describe("built CLI provider selection", () => {
           "POST /v2/datasets",
           "POST /v2/tokens",
           "GET /v2/datasets",
+          "GET /v2/tokens",
           "GET /v2/datasets",
           "GET /v2/tokens",
           "GET /v2/datasets",
@@ -487,12 +496,19 @@ describe("built CLI provider selection", () => {
         expect(combined.stdout).toContain("providers=axiom,sentry");
         expect(combinedRepeat.stdout).toContain("providers=axiom,sentry");
         assertNoSecretOutput(combinedRepeat);
+        const combinedConfirmation = await runCli(
+          [...provisionArgs(combinedTarget, "canary", []), "--correlation-confirmed"],
+          combinedRoot,
+          combinedTarget,
+          server,
+        );
         const combinedExport = await runCli(
           ["env", "export", "--name", "livro-caixa", "--environment", "canary"],
           combinedRoot,
           combinedTarget,
           server,
         );
+        expect(combinedConfirmation.exitCode).toBe(0);
         expect(combinedExport.exitCode).toBe(0);
         expect(combinedExport.stdout.trim().split("\n")).toEqual([
           'OTEL_SERVICE_NAME="livro-caixa"',
@@ -518,6 +534,9 @@ describe("built CLI provider selection", () => {
           "POST /v2/datasets",
           "POST /v2/tokens",
           "GET /v2/datasets",
+          "GET /v2/tokens",
+          "GET /api/0/projects/maxxi-cash/livro-caixa/",
+          "GET /api/0/projects/maxxi-cash/livro-caixa/keys/",
           "GET /v2/datasets",
           "GET /v2/tokens",
           "GET /api/0/projects/maxxi-cash/livro-caixa/",

--- a/packages/cli/test/ProviderSelection.bun.test.ts
+++ b/packages/cli/test/ProviderSelection.bun.test.ts
@@ -9,7 +9,7 @@ const repository = fileURLToPath(new URL("../../..", import.meta.url));
 const cli = fileURLToPath(new URL("../dist/main.js", import.meta.url));
 
 const PersistedCredentials = Schema.Struct({
-  version: Schema.Literal(2),
+  version: Schema.Literal(3),
   axiom: Schema.Struct({ token: Schema.NonEmptyString }).pipe(Schema.optionalKey),
   sentry: Schema.Struct({ token: Schema.NonEmptyString }).pipe(Schema.optionalKey),
   environments: Schema.Array(
@@ -32,7 +32,13 @@ type ProviderServer = {
   readonly url: string;
   readonly requests: Array<ProviderRequest>;
   readonly datasets: Set<string>;
-  readonly tokens: Array<{ id: string; name: string; token: string }>;
+  readonly tokens: Array<{
+    id: string;
+    name: string;
+    token: string;
+    description: string;
+    datasetCapabilities: { readonly [name: string]: { readonly ingest: ReadonlyArray<string> } };
+  }>;
   failDataset(name: string): void;
   failNextSentryProject(): void;
   failNextTokenResponse(): void;
@@ -53,7 +59,13 @@ const json = (value: ProviderResponsePayload, status = 200): Response =>
 const startProviderServer = (): ProviderServer => {
   const requests: Array<ProviderRequest> = [];
   const datasets = new Set<string>();
-  const tokens: Array<{ id: string; name: string; token: string }> = [];
+  const tokens: Array<{
+    id: string;
+    name: string;
+    token: string;
+    description: string;
+    datasetCapabilities: { readonly [name: string]: { readonly ingest: ReadonlyArray<string> } };
+  }> = [];
   let sentryProject = false;
   let tokenSequence = 0;
   let failSentryProject = false;
@@ -71,30 +83,71 @@ const startProviderServer = (): ProviderServer => {
         return json({ id: "owner", email: "owner@example.com" });
       }
       if (request.method === "GET" && url.pathname === "/v2/datasets") {
-        return json([...datasets].map((name) => ({ name })));
+        return json(
+          [...datasets].map((name, index) => ({
+            id: `dataset-${index + 1}`,
+            name,
+            description: `OpenTelemetry data for ${name}`,
+            kind: name.endsWith("-metrics") ? "otel:metrics:v1" : "axiom:events:v1",
+            edgeDeployment: "edge-main",
+            useRetentionPeriod: false,
+          })),
+        );
       }
       if (request.method === "POST" && url.pathname === "/v2/datasets") {
-        const value = Schema.decodeUnknownSync(Schema.Struct({ name: Schema.NonEmptyString }))(
-          JSON.parse(body),
-        );
+        const value = Schema.decodeUnknownSync(
+          Schema.Struct({
+            name: Schema.NonEmptyString,
+            description: Schema.String,
+            kind: Schema.Literals(["axiom:events:v1", "otel:metrics:v1"]),
+            edgeDeployment: Schema.NonEmptyString.pipe(Schema.optionalKey),
+          }),
+        )(JSON.parse(body));
         if (failedDatasets.has(value.name)) {
           return json({ error: "selected failure" }, 500);
         }
         datasets.add(value.name);
-        return json({ name: value.name }, 201);
+        return json(
+          {
+            id: `dataset-${datasets.size}`,
+            name: value.name,
+            description: value.description,
+            kind: value.kind,
+            edgeDeployment: value.edgeDeployment ?? "edge-main",
+            useRetentionPeriod: false,
+          },
+          201,
+        );
       }
       if (request.method === "GET" && url.pathname === "/v2/tokens") {
-        return json(tokens.map(({ id, name }) => ({ id, name })));
+        return json(
+          tokens.map(({ datasetCapabilities, description, id, name }) => ({
+            id,
+            name,
+            description,
+            datasetCapabilities,
+            orgCapabilities: {},
+          })),
+        );
       }
       if (request.method === "POST" && url.pathname === "/v2/tokens") {
-        const value = Schema.decodeUnknownSync(Schema.Struct({ name: Schema.NonEmptyString }))(
-          JSON.parse(body),
-        );
+        const value = Schema.decodeUnknownSync(
+          Schema.Struct({
+            name: Schema.NonEmptyString,
+            description: Schema.String,
+            datasetCapabilities: Schema.Record(
+              Schema.NonEmptyString,
+              Schema.Struct({ ingest: Schema.Array(Schema.NonEmptyString) }),
+            ),
+          }),
+        )(JSON.parse(body));
         tokenSequence += 1;
         const token = {
           id: `token-${tokenSequence}`,
           name: value.name,
           token: `ingest-secret-${tokenSequence}`,
+          description: value.description,
+          datasetCapabilities: value.datasetCapabilities,
         };
         tokens.push(token);
         if (failTokenResponse) {
@@ -221,16 +274,22 @@ const provisionArgs = (
   target: string,
   environment: string,
   providers: ReadonlyArray<"axiom" | "sentry">,
-): ReadonlyArray<string> => [
-  "provision",
-  "--dir",
-  target,
-  "--name",
-  "livro-caixa",
-  "--environment",
-  environment,
-  ...providers.flatMap((provider) => ["--provider", provider]),
-];
+): ReadonlyArray<string> => {
+  const args = [
+    "provision",
+    "--dir",
+    target,
+    "--name",
+    "livro-caixa",
+    "--environment",
+    environment,
+    ...providers.flatMap((provider) => ["--provider", provider]),
+  ];
+  if (providers.includes("axiom") || providers.length === 0) {
+    return [...args, "--axiom-edge-deployment", "edge-main", "--correlation-confirmed"];
+  }
+  return args;
+};
 
 const assertNoSecretOutput = (result: CliResult): void => {
   for (const secret of [
@@ -314,7 +373,9 @@ describe("built CLI provider selection", () => {
           "POST /v2/datasets",
           "POST /v2/tokens",
           "GET /v2/datasets",
+          "GET /v2/datasets",
           "GET /v2/tokens",
+          "GET /v2/datasets",
         ]);
         expect(
           server.requests
@@ -324,14 +385,20 @@ describe("built CLI provider selection", () => {
           {
             name: "livro-caixa-staging-traces",
             description: "OpenTelemetry data for livro-caixa-staging-traces",
+            kind: "axiom:events:v1",
+            edgeDeployment: "edge-main",
           },
           {
             name: "livro-caixa-staging-logs",
             description: "OpenTelemetry data for livro-caixa-staging-logs",
+            kind: "axiom:events:v1",
+            edgeDeployment: "edge-main",
           },
           {
             name: "livro-caixa-staging-metrics",
             description: "OpenTelemetry data for livro-caixa-staging-metrics",
+            kind: "otel:metrics:v1",
+            edgeDeployment: "edge-main",
           },
         ]);
         const axiomTokenRequest = server.requests.find(
@@ -442,18 +509,20 @@ describe("built CLI provider selection", () => {
             .slice(combinedRequestStart)
             .map((request) => `${request.method} ${request.path}`),
         ).toEqual([
-          "GET /api/0/projects/maxxi-cash/livro-caixa/",
-          "GET /api/0/projects/maxxi-cash/livro-caixa/keys/",
           "GET /v2/datasets",
           "GET /v2/tokens",
+          "GET /api/0/projects/maxxi-cash/livro-caixa/",
+          "GET /api/0/projects/maxxi-cash/livro-caixa/keys/",
           "POST /v2/datasets",
           "POST /v2/datasets",
           "POST /v2/datasets",
           "POST /v2/tokens",
+          "GET /v2/datasets",
+          "GET /v2/datasets",
+          "GET /v2/tokens",
           "GET /api/0/projects/maxxi-cash/livro-caixa/",
           "GET /api/0/projects/maxxi-cash/livro-caixa/keys/",
           "GET /v2/datasets",
-          "GET /v2/tokens",
         ]);
         expect((await readPersisted(combinedRoot)).environments[0]?.providers.type).toBe(
           "combined",
@@ -621,10 +690,12 @@ describe("built CLI provider selection", () => {
           migrationTarget,
           server,
         );
-        expect(migratedExport.exitCode).toBe(0);
-        expect(migratedExport.stdout).toContain('AXIOM_TOKEN="legacy-ingest-secret"');
-        expect(migratedExport.stdout).toContain('SENTRY_DSN="https://legacy@sentry.example/1"');
-        expect((await readPersisted(migrationRoot)).version).toBe(2);
+        expect(migratedExport.exitCode).toBe(1);
+        expect(migratedExport.stderr).toContain("OBS_CLI_CORRELATION_CONFIRMATION_REQUIRED");
+        const migratedContent = await Bun.file(migrationPath).text();
+        expect(migratedContent).toContain("legacy-ingest-secret");
+        expect(migratedContent).toContain("https://legacy@sentry.example/1");
+        expect((await readPersisted(migrationRoot)).version).toBe(3);
         expect((await stat(migrationPath)).mode & 0o777).toBe(0o600);
         const rotated = await runCli(
           [...provisionArgs(migrationTarget, "legacy", ["axiom"]), "--rotate-token"],
@@ -694,7 +765,7 @@ describe("built CLI provider selection", () => {
         expect(sentryFailure.exitCode).toBe(1);
         expect(sentryFailure.stderr).toContain("OBS_CLI_REMOTE_FAILED");
         expect(server.requests.filter((request) => request.path.startsWith("/v2/")).length).toBe(
-          axiomCallsBeforeSentryFailure,
+          axiomCallsBeforeSentryFailure + 2,
         );
         expect((await readPersisted(sentryFailureRoot)).environments).toHaveLength(0);
         assertNoSecretOutput(sentryFailure);

--- a/packages/cli/test/ReleaseWorkflow.bun.test.ts
+++ b/packages/cli/test/ReleaseWorkflow.bun.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+
+const workflowPath = fileURLToPath(
+  new URL("../../../.github/workflows/release.yml", import.meta.url),
+);
+
+const workflow = await Bun.file(workflowPath).text();
+
+describe("release workflow publication gate", () => {
+  test("tag pushes verify but cannot create a release or publish", () => {
+    expect(workflow).toContain('tags:\n      - "v*.*.*"');
+    expect(workflow.match(/if: github\.event_name == 'workflow_dispatch'/g)).toHaveLength(2);
+    expect(workflow).toContain("uses: ./.github/workflows/ci.yml");
+    expect(workflow).not.toContain("if: github.event_name == 'push'");
+  });
+
+  test("dispatch requires an exact tag-bound confirmation", () => {
+    expect(workflow).toContain("confirm_tag:");
+    expect(workflow).toContain('[[ "$CONFIRM_TAG" == "$tag" ]]');
+    expect(workflow).toContain("Publication confirmation must exactly match $tag.");
+    expect(workflow).toContain('[[ "$EVENT_REF" == "refs/tags/$tag" ]]');
+    expect(workflow).toContain("Publication dispatch must run from the exact tag ref");
+    expect(workflow.match(/environment: publication/g)).toHaveLength(2);
+  });
+
+  test("checks out and validates the exact existing tag commit", () => {
+    expect(workflow).toContain(
+      "ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}",
+    );
+    expect(workflow).toContain('git show-ref --verify --quiet "refs/tags/$tag"');
+    expect(workflow).toContain('tag_commit="$(git rev-list -n 1 "$tag")"');
+    expect(workflow).toContain('head_commit="$(git rev-parse HEAD)"');
+    expect(workflow).toContain('[[ "$head_commit" == "$tag_commit" ]]');
+  });
+});

--- a/packages/cli/test/RemoteEnvironment.bun.test.ts
+++ b/packages/cli/test/RemoteEnvironment.bun.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, test } from "bun:test";
 import { Effect, Layer, Option } from "effect";
 import {
   AxiomCredentials,
+  AxiomEnvironment,
   CredentialsAccess,
   CredentialsError,
   CredentialsFile,
   CredentialsStore,
+  ManagedEnvironment,
   PendingAxiomMutation,
   SentryCredentials,
 } from "../src/CredentialsStore.ts";
@@ -136,24 +138,6 @@ const makeRemoteLayer = (options: RemoteOptions = {}) => {
         return dataset;
       });
     },
-    updateDatasetRetention: (_credentials, dataset, retentionDays) =>
-      Effect.sync(() => {
-        const common = {
-          id: dataset.id,
-          name: dataset.name,
-          description: dataset.description,
-          kind: dataset.kind,
-          retentionDays,
-          useRetentionPeriod: true,
-        };
-        const updated =
-          dataset.edgeDeployment === undefined
-            ? new AxiomDataset(common)
-            : new AxiomDataset({ ...common, edgeDeployment: dataset.edgeDeployment });
-        const index = datasets.findIndex((candidate) => candidate.id === dataset.id);
-        datasets[index] = updated;
-        return updated;
-      }),
     tokens: () =>
       Effect.sync(() => {
         axiomTokenLists += 1;
@@ -183,6 +167,7 @@ const makeRemoteLayer = (options: RemoteOptions = {}) => {
               tokenDatasets.map((dataset) => [dataset, { ingest: ["create"] }]),
             ),
             orgCapabilities: {},
+            viewCapabilities: {},
           }),
         );
         return { id, token: `secret-${tokenCreations}` };
@@ -241,6 +226,9 @@ const makeRemoteLayer = (options: RemoteOptions = {}) => {
     },
     failSaveAt: (call: number) => {
       failedSaveCall = Option.some(call);
+    },
+    setCredentials: (next: CredentialsFile) => {
+      credentials = next;
     },
     markPendingAxiomMutation: (project: string, environment: string) => {
       const pendingAxiomMutations = [new PendingAxiomMutation({ project, environment })];
@@ -484,6 +472,7 @@ describe("RemoteEnvironment", () => {
           "livro-caixa-staging-metrics": { ingest: ["create"] },
         },
         orgCapabilities: {},
+        viewCapabilities: {},
       }),
     );
 
@@ -677,6 +666,260 @@ describe("RemoteEnvironment", () => {
         : Option.getOrUndefined(environmentAxiom(result.confirmed[0]))?.correlation.type,
     ).toBe("operator-confirmed");
     expect(result.exported).toContain('AXIOM_TOKEN="secret-1"');
+  });
+
+  test("rejects same-call correlation confirmation before provider reads or mutations", async () => {
+    const remote = makeRemoteLayer({ sentry: false });
+    const error = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        return yield* Effect.flip(
+          service.provision(
+            "livro-caixa",
+            ["staging"],
+            ["axiom"],
+            "node",
+            false,
+            "edge-1",
+            30,
+            true,
+          ),
+        );
+      }).pipe(Effect.provide(remote.layer)),
+    );
+
+    expect(error._tag).toBe("RemoteEnvironmentError");
+    if (error._tag === "RemoteEnvironmentError") {
+      expect(error.code).toBe("OBS_CLI_CORRELATION_CONFIRMATION_REQUIRED");
+    }
+    expect(remote.state().axiomDatasetLists).toBe(0);
+    expect(remote.state().axiomTokenLists).toBe(0);
+    expect(remote.state().datasets).toHaveLength(0);
+    expect(remote.state().tokenCreations).toBe(0);
+  });
+
+  test("rejects lower, higher and disabled explicit retention before any mutation", async () => {
+    for (const retention of [
+      { existing: 30, requested: 14, enabled: true },
+      { existing: 14, requested: 30, enabled: true },
+      { existing: 30, requested: 30, enabled: false },
+    ]) {
+      const remote = makeRemoteLayer({ sentry: false });
+      remote.state().datasets.push(
+        new AxiomDataset({
+          id: `retention-${retention.existing}`,
+          name: "livro-caixa-staging-traces",
+          description: "retention conflict",
+          kind: "axiom:events:v1",
+          edgeDeployment: "edge-1",
+          retentionDays: retention.existing,
+          useRetentionPeriod: retention.enabled,
+        }),
+      );
+      const error = await Effect.runPromise(
+        Effect.gen(function* () {
+          const service = yield* RemoteEnvironment;
+          return yield* Effect.flip(
+            service.provision(
+              "livro-caixa",
+              ["staging"],
+              ["axiom"],
+              "node",
+              false,
+              "edge-1",
+              retention.requested,
+            ),
+          );
+        }).pipe(Effect.provide(remote.layer)),
+      );
+
+      expect(error._tag).toBe("RemoteEnvironmentError");
+      if (error._tag === "RemoteEnvironmentError") {
+        expect(error.code).toBe("OBS_CLI_AXIOM_DATASET_CONFIGURATION_CONFLICT");
+        expect(error.message).toContain("destructive");
+      }
+      expect(remote.state().datasets).toHaveLength(1);
+      expect(remote.state().tokenCreations).toBe(0);
+      expect(remote.state().sentryProjectCalls).toBe(0);
+    }
+  });
+
+  test("rejects extra dataset, organization and view token capabilities", async () => {
+    for (const extra of ["dataset", "organization", "view"]) {
+      const remote = makeRemoteLayer({ sentry: false });
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const service = yield* RemoteEnvironment;
+          yield* service.provision("livro-caixa", ["staging"], ["axiom"], "node", false, "edge-1");
+        }).pipe(Effect.provide(remote.layer)),
+      );
+      const datasetCapabilities = {
+        "livro-caixa-staging-traces": { ingest: ["create"] },
+        "livro-caixa-staging-logs": { ingest: ["create"] },
+        "livro-caixa-staging-metrics": { ingest: ["create"] },
+      };
+      const capabilities =
+        extra === "dataset"
+          ? { ...datasetCapabilities, unexpected: { ingest: ["create"] } }
+          : datasetCapabilities;
+      remote.state().tokens[0] = new AxiomToken({
+        id: "token-1",
+        name: "livro-caixa-staging-collector",
+        description: "Collector token",
+        datasetCapabilities: capabilities,
+        orgCapabilities: extra === "organization" ? { datasets: ["read"] } : {},
+        viewCapabilities: extra === "view" ? { dashboard: ["read"] } : {},
+      });
+
+      const error = await Effect.runPromise(
+        Effect.gen(function* () {
+          const service = yield* RemoteEnvironment;
+          return yield* Effect.flip(
+            service.provision("livro-caixa", ["staging"], ["axiom"], "node", false, "edge-1"),
+          );
+        }).pipe(Effect.provide(remote.layer)),
+      );
+      expect(error._tag).toBe("RemoteEnvironmentError");
+      if (error._tag === "RemoteEnvironmentError") {
+        expect(error.code).toBe("OBS_CLI_AXIOM_TOKEN_CAPABILITIES_MISMATCH");
+      }
+      expect(remote.state().tokenRegenerations).toBe(0);
+    }
+  });
+
+  test("rejects stale manual correlation state before provider reads", async () => {
+    const remote = makeRemoteLayer({ sentry: false });
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        yield* service.provision("livro-caixa", ["staging"], ["axiom"], "node", false, "edge-1");
+      }).pipe(Effect.provide(remote.layer)),
+    );
+    const state = remote.state();
+    const managed = state.credentials.environments[0];
+    const administrative = state.credentials.axiom;
+    if (managed === undefined || administrative === undefined) {
+      throw new Error("Expected persisted Axiom environment");
+    }
+    const existing = environmentAxiom(managed);
+    if (Option.isNone(existing) || existing.value.datasets === undefined) {
+      throw new Error("Expected verified Axiom state");
+    }
+    const staleAxiom = new AxiomEnvironment({
+      tokenId: existing.value.tokenId,
+      token: existing.value.token,
+      tracesDataset: existing.value.tracesDataset,
+      logsDataset: existing.value.logsDataset,
+      metricsDataset: existing.value.metricsDataset,
+      datasets: existing.value.datasets,
+      correlation: {
+        type: "manual-required",
+        groupName: "livro-caixa staging",
+        groupSlug: "stale-slug",
+        tracesDataset: existing.value.tracesDataset,
+        logsDataset: existing.value.logsDataset,
+        metricsDataset: existing.value.metricsDataset,
+      },
+    });
+    remote.setCredentials(
+      new CredentialsFile({
+        version: 3,
+        axiom: administrative,
+        environments: [
+          new ManagedEnvironment({
+            project: "livro-caixa",
+            environment: "staging",
+            providers: { type: "axiom", axiom: staleAxiom },
+          }),
+        ],
+      }),
+    );
+    const reads = remote.state().axiomDatasetLists;
+
+    const error = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        return yield* Effect.flip(
+          service.provision(
+            "livro-caixa",
+            ["staging"],
+            ["axiom"],
+            "node",
+            false,
+            "edge-1",
+            undefined,
+            true,
+          ),
+        );
+      }).pipe(Effect.provide(remote.layer)),
+    );
+    expect(error._tag).toBe("RemoteEnvironmentError");
+    if (error._tag === "RemoteEnvironmentError") {
+      expect(error.code).toBe("OBS_CLI_CORRELATION_CONFIRMATION_REQUIRED");
+    }
+    expect(remote.state().axiomDatasetLists).toBe(reads);
+  });
+
+  test("rejects missing and different edge deployments on every signal", async () => {
+    for (const signal of ["traces", "logs", "metrics"]) {
+      for (const edge of [undefined, "edge-other"]) {
+        const remote = makeRemoteLayer({ sentry: false });
+        await Effect.runPromise(
+          Effect.gen(function* () {
+            const service = yield* RemoteEnvironment;
+            yield* service.provision(
+              "livro-caixa",
+              ["staging"],
+              ["axiom"],
+              "node",
+              false,
+              "edge-1",
+            );
+          }).pipe(Effect.provide(remote.layer)),
+        );
+        const name = `livro-caixa-staging-${signal}`;
+        const index = remote.state().datasets.findIndex((dataset) => dataset.name === name);
+        const dataset = remote.state().datasets[index];
+        if (dataset === undefined) {
+          throw new Error(`Expected ${signal} dataset`);
+        }
+        const common = {
+          id: dataset.id,
+          name: dataset.name,
+          description: dataset.description,
+          kind: dataset.kind,
+          useRetentionPeriod: dataset.useRetentionPeriod,
+        };
+        remote.state().datasets[index] =
+          edge === undefined
+            ? new AxiomDataset(common)
+            : new AxiomDataset({ ...common, edgeDeployment: edge });
+        const mutations = remote.state().tokenCreations;
+
+        const error = await Effect.runPromise(
+          Effect.gen(function* () {
+            const service = yield* RemoteEnvironment;
+            return yield* Effect.flip(
+              service.provision(
+                "livro-caixa",
+                ["staging"],
+                ["axiom"],
+                "node",
+                false,
+                "edge-1",
+                undefined,
+                true,
+              ),
+            );
+          }).pipe(Effect.provide(remote.layer)),
+        );
+        expect(error._tag).toBe("RemoteEnvironmentError");
+        if (error._tag === "RemoteEnvironmentError") {
+          expect(error.code).toBe("OBS_CLI_AXIOM_DATASET_CONFIGURATION_CONFLICT");
+        }
+        expect(remote.state().tokenCreations).toBe(mutations);
+      }
+    }
   });
 
   test("rejects an Events metrics dataset before any mutation", async () => {

--- a/packages/cli/test/RemoteEnvironment.bun.test.ts
+++ b/packages/cli/test/RemoteEnvironment.bun.test.ts
@@ -9,7 +9,13 @@ import {
   PendingAxiomMutation,
   SentryCredentials,
 } from "../src/CredentialsStore.ts";
-import { AxiomApi, RemoteApiError, SentryApi } from "../src/ProviderApis.ts";
+import {
+  AxiomApi,
+  AxiomDataset,
+  AxiomToken,
+  RemoteApiError,
+  SentryApi,
+} from "../src/ProviderApis.ts";
 import {
   environmentAxiom,
   environmentDatasets,
@@ -40,14 +46,14 @@ const makeRemoteLayer = (options: RemoteOptions = {}) => {
     : undefined;
   let credentials =
     axiom !== undefined && sentry !== undefined
-      ? new CredentialsFile({ version: 2, axiom, sentry, environments: [] })
+      ? new CredentialsFile({ version: 3, axiom, sentry, environments: [] })
       : axiom !== undefined
-        ? new CredentialsFile({ version: 2, axiom, environments: [] })
+        ? new CredentialsFile({ version: 3, axiom, environments: [] })
         : sentry !== undefined
-          ? new CredentialsFile({ version: 2, sentry, environments: [] })
-          : new CredentialsFile({ version: 2, environments: [] });
-  const datasets: Array<string> = [];
-  const tokens: Array<{ readonly id: string; readonly name: string }> = [];
+          ? new CredentialsFile({ version: 3, sentry, environments: [] })
+          : new CredentialsFile({ version: 3, environments: [] });
+  const datasets: Array<AxiomDataset> = [];
+  const tokens: Array<AxiomToken> = [];
   let tokenCreations = 0;
   let tokenRegenerations = 0;
   let axiomDatasetLists = 0;
@@ -94,7 +100,7 @@ const makeRemoteLayer = (options: RemoteOptions = {}) => {
         axiomDatasetLists += 1;
         return datasets;
       }),
-    createDataset: (_credentials, name) => {
+    createDataset: (_credentials, name, options = {}) => {
       if (Option.contains(failedDataset, name)) {
         return Effect.fail(
           new RemoteApiError({
@@ -107,15 +113,53 @@ const makeRemoteLayer = (options: RemoteOptions = {}) => {
         );
       }
       return Effect.sync(() => {
-        datasets.push(name);
+        const common = {
+          id: `dataset-${datasets.length + 1}`,
+          name,
+          description: `OpenTelemetry data for ${name}`,
+          kind: options.kind ?? "axiom:events:v1",
+          useRetentionPeriod: options.retentionDays !== undefined,
+        };
+        const dataset =
+          options.edgeDeployment === undefined
+            ? options.retentionDays === undefined
+              ? new AxiomDataset(common)
+              : new AxiomDataset({ ...common, retentionDays: options.retentionDays })
+            : options.retentionDays === undefined
+              ? new AxiomDataset({ ...common, edgeDeployment: options.edgeDeployment })
+              : new AxiomDataset({
+                  ...common,
+                  edgeDeployment: options.edgeDeployment,
+                  retentionDays: options.retentionDays,
+                });
+        datasets.push(dataset);
+        return dataset;
       });
     },
+    updateDatasetRetention: (_credentials, dataset, retentionDays) =>
+      Effect.sync(() => {
+        const common = {
+          id: dataset.id,
+          name: dataset.name,
+          description: dataset.description,
+          kind: dataset.kind,
+          retentionDays,
+          useRetentionPeriod: true,
+        };
+        const updated =
+          dataset.edgeDeployment === undefined
+            ? new AxiomDataset(common)
+            : new AxiomDataset({ ...common, edgeDeployment: dataset.edgeDeployment });
+        const index = datasets.findIndex((candidate) => candidate.id === dataset.id);
+        datasets[index] = updated;
+        return updated;
+      }),
     tokens: () =>
       Effect.sync(() => {
         axiomTokenLists += 1;
         return tokens;
       }),
-    createToken: (_credentials, name) => {
+    createToken: (_credentials, name, tokenDatasets) => {
       if (Option.isSome(failedTokenMutation)) {
         return Effect.fail(
           new RemoteApiError({
@@ -129,15 +173,25 @@ const makeRemoteLayer = (options: RemoteOptions = {}) => {
       }
       return Effect.sync(() => {
         tokenCreations += 1;
-        const token = { id: `token-${tokenCreations}`, name };
-        tokens.push(token);
-        return { id: token.id, token: `secret-${tokenCreations}` };
+        const id = `token-${tokenCreations}`;
+        tokens.push(
+          new AxiomToken({
+            id,
+            name,
+            description: `Collector ingest token for ${name}`,
+            datasetCapabilities: Object.fromEntries(
+              tokenDatasets.map((dataset) => [dataset, { ingest: ["create"] }]),
+            ),
+            orgCapabilities: {},
+          }),
+        );
+        return { id, token: `secret-${tokenCreations}` };
       });
     },
-    regenerateToken: (_credentials, id) =>
+    regenerateToken: (_credentials, token) =>
       Effect.sync(() => {
         tokenRegenerations += 1;
-        return { id, token: `rotated-${tokenRegenerations}` };
+        return { id: token.id, token: `rotated-${tokenRegenerations}` };
       }),
   });
   const sentryApi = SentryApi.of({
@@ -193,7 +247,7 @@ const makeRemoteLayer = (options: RemoteOptions = {}) => {
       credentials =
         credentials.axiom !== undefined && credentials.sentry !== undefined
           ? new CredentialsFile({
-              version: 2,
+              version: 3,
               axiom: credentials.axiom,
               sentry: credentials.sentry,
               environments: credentials.environments,
@@ -201,20 +255,20 @@ const makeRemoteLayer = (options: RemoteOptions = {}) => {
             })
           : credentials.axiom !== undefined
             ? new CredentialsFile({
-                version: 2,
+                version: 3,
                 axiom: credentials.axiom,
                 environments: credentials.environments,
                 pendingAxiomMutations,
               })
             : credentials.sentry !== undefined
               ? new CredentialsFile({
-                  version: 2,
+                  version: 3,
                   sentry: credentials.sentry,
                   environments: credentials.environments,
                   pendingAxiomMutations,
                 })
               : new CredentialsFile({
-                  version: 2,
+                  version: 3,
                   environments: credentials.environments,
                   pendingAxiomMutations,
                 });
@@ -265,8 +319,24 @@ describe("RemoteEnvironment", () => {
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         const service = yield* RemoteEnvironment;
-        const first = yield* service.provision("livro-caixa", ["staging"], [], "node", false);
-        const second = yield* service.provision("livro-caixa", ["staging"], [], "node", false);
+        const first = yield* service.provision(
+          "livro-caixa",
+          ["staging"],
+          [],
+          "node",
+          false,
+          "edge-1",
+        );
+        const second = yield* service.provision(
+          "livro-caixa",
+          ["staging"],
+          [],
+          "node",
+          false,
+          "edge-1",
+          undefined,
+          true,
+        );
         const exported = yield* service.export("livro-caixa", "staging");
         return { first, second, exported };
       }).pipe(Effect.provide(remote.layer)),
@@ -296,8 +366,17 @@ describe("RemoteEnvironment", () => {
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         const service = yield* RemoteEnvironment;
-        yield* service.provision("livro-caixa", ["staging"], ["axiom"], "node", false);
-        const repeated = yield* service.provision("livro-caixa", ["staging"], [], "node", false);
+        yield* service.provision("livro-caixa", ["staging"], ["axiom"], "node", false, "edge-1");
+        const repeated = yield* service.provision(
+          "livro-caixa",
+          ["staging"],
+          [],
+          "node",
+          false,
+          "edge-1",
+          undefined,
+          true,
+        );
         return {
           repeated,
           exported: yield* service.export("livro-caixa", "staging"),
@@ -394,10 +473,19 @@ describe("RemoteEnvironment", () => {
 
   test("requires rotation when the remote token has no local secret", async () => {
     const remote = makeRemoteLayer();
-    remote.state().tokens.push({
-      id: "existing-token",
-      name: "livro-caixa-staging-collector",
-    });
+    remote.state().tokens.push(
+      new AxiomToken({
+        id: "existing-token",
+        name: "livro-caixa-staging-collector",
+        description: "existing token",
+        datasetCapabilities: {
+          "livro-caixa-staging-traces": { ingest: ["create"] },
+          "livro-caixa-staging-logs": { ingest: ["create"] },
+          "livro-caixa-staging-metrics": { ingest: ["create"] },
+        },
+        orgCapabilities: {},
+      }),
+    );
 
     const error = await Effect.runPromise(
       Effect.gen(function* () {
@@ -522,7 +610,132 @@ describe("RemoteEnvironment", () => {
     );
 
     expect(error._tag).toBe("RemoteApiError");
-    expect(remote.state().axiomDatasetLists).toBe(0);
+    expect(remote.state().axiomDatasetLists).toBe(1);
+    expect(remote.state().axiomTokenLists).toBe(1);
+    expect(remote.state().tokenCreations).toBe(0);
+  });
+
+  test("blocks export until a persistent manual correlation action is confirmed", async () => {
+    const remote = makeRemoteLayer({ sentry: false });
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        const initial = yield* service.provision(
+          "livro-caixa",
+          ["staging"],
+          ["axiom"],
+          "node",
+          false,
+          "edge-1",
+          30,
+        );
+        const exportError = yield* Effect.flip(service.export("livro-caixa", "staging"));
+        const mutationCounts = {
+          datasets: remote.state().datasets.length,
+          tokens: remote.state().tokenCreations,
+        };
+        const repeated = yield* service.provision(
+          "livro-caixa",
+          ["staging"],
+          ["axiom"],
+          "node",
+          false,
+          "edge-1",
+          30,
+        );
+        const confirmed = yield* service.provision(
+          "livro-caixa",
+          ["staging"],
+          ["axiom"],
+          "node",
+          false,
+          "edge-1",
+          30,
+          true,
+        );
+        const exported = yield* service.export("livro-caixa", "staging");
+        return { confirmed, exportError, exported, initial, mutationCounts, repeated };
+      }).pipe(Effect.provide(remote.layer)),
+    );
+
+    expect(
+      result.initial[0] === undefined
+        ? undefined
+        : Option.getOrUndefined(environmentAxiom(result.initial[0]))?.correlation.type,
+    ).toBe("manual-required");
+    expect(result.exportError.code).toBe("OBS_CLI_CORRELATION_CONFIRMATION_REQUIRED");
+    expect(
+      result.repeated[0] === undefined
+        ? undefined
+        : Option.getOrUndefined(environmentAxiom(result.repeated[0]))?.correlation.type,
+    ).toBe("manual-required");
+    expect(remote.state().datasets).toHaveLength(result.mutationCounts.datasets);
+    expect(remote.state().tokenCreations).toBe(result.mutationCounts.tokens);
+    expect(
+      result.confirmed[0] === undefined
+        ? undefined
+        : Option.getOrUndefined(environmentAxiom(result.confirmed[0]))?.correlation.type,
+    ).toBe("operator-confirmed");
+    expect(result.exported).toContain('AXIOM_TOKEN="secret-1"');
+  });
+
+  test("rejects an Events metrics dataset before any mutation", async () => {
+    const remote = makeRemoteLayer({ sentry: false });
+    remote.state().datasets.push(
+      new AxiomDataset({
+        id: "wrong-metrics",
+        name: "livro-caixa-staging-metrics",
+        description: "generic create defect",
+        kind: "axiom:events:v1",
+        useRetentionPeriod: false,
+      }),
+    );
+
+    const error = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        return yield* Effect.flip(
+          service.provision("livro-caixa", ["staging"], ["axiom"], "node", false),
+        );
+      }).pipe(Effect.provide(remote.layer)),
+    );
+
+    expect(error._tag).toBe("RemoteEnvironmentError");
+    if (error._tag === "RemoteEnvironmentError") {
+      expect(error.code).toBe("OBS_CLI_AXIOM_METRICS_MIGRATION_REQUIRED");
+      expect(error.message).toContain("replace the dataset manually");
+    }
+    expect(remote.state().datasets).toHaveLength(1);
+    expect(remote.state().tokenCreations).toBe(0);
+  });
+
+  test("rejects duplicate remote dataset names before mutation", async () => {
+    const remote = makeRemoteLayer({ sentry: false });
+    for (const id of ["duplicate-1", "duplicate-2"]) {
+      remote.state().datasets.push(
+        new AxiomDataset({
+          id,
+          name: "livro-caixa-staging-traces",
+          description: "duplicate",
+          kind: "axiom:events:v1",
+          useRetentionPeriod: false,
+        }),
+      );
+    }
+
+    const error = await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        return yield* Effect.flip(
+          service.provision("livro-caixa", ["staging"], ["axiom"], "node", false),
+        );
+      }).pipe(Effect.provide(remote.layer)),
+    );
+
+    expect(error._tag).toBe("RemoteEnvironmentError");
+    if (error._tag === "RemoteEnvironmentError") {
+      expect(error.code).toBe("OBS_CLI_AXIOM_REMOTE_NAME_CONFLICT");
+    }
     expect(remote.state().tokenCreations).toBe(0);
   });
 

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equipe-tech/observability",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Contrato OpenTelemetry da Equipe Tech: configuracao, layer OTLP e wide events sobre Effect",
   "homepage": "https://github.com/equipe-tech/observability#readme",
   "bugs": {


### PR DESCRIPTION
## Summary

- create Axiom traces and logs as Events datasets and metrics as a MetricsDB dataset
- reconcile complete dataset and token contracts without destructive automatic migration
- persist a manual Correlation action, verify operator confirmation, and block unsafe exports
- migrate credentials to version 3 and prepare synchronized package release 0.2.1
- separate tag verification from explicit publication dispatch

## Verification

- exhaustive local provider-boundary and state-migration tests
- full check, build, package smoke, Collector validation, and actionlint
- three deterministic pack sets and provenance dry runs
- exact-head independent review
- no live provider or registry mutation

## Release candidates

- telemetry: `d68f5259fac829bad262537de567f547e7f12aab3a6a3f4bb2af81fd8bc41cf7`
- CLI: `8e6cccfff37da09c60e0e34ec9fe9b395e05c24a237c4531cf699e4fa5b99cff`

Linear: OBS-25
