### PR TITLE
fix(cli): accept Axiom default retention payloads

### DIFF
--- a/docs/releases/v0.2.1.sha256
+++ b/docs/releases/v0.2.1.sha256
@@ -1,6 +1,6 @@
 d68f5259fac829bad262537de567f547e7f12aab3a6a3f4bb2af81fd8bc41cf7  .release-pack/pack-1/equipe-tech-observability-0.2.1.tgz
-9c880f315de0cbaad853b5c41a35388e2ce3e1b08824b21cdc2fc9aee5868f6c  .release-pack/pack-1/equipe-tech-observability-cli-0.2.1.tgz
+e0ad0382d0f165be6f09e75ea0055ecb7c0159ecba59c6959444677ec39946cf  .release-pack/pack-1/equipe-tech-observability-cli-0.2.1.tgz
 d68f5259fac829bad262537de567f547e7f12aab3a6a3f4bb2af81fd8bc41cf7  .release-pack/pack-2/equipe-tech-observability-0.2.1.tgz
-9c880f315de0cbaad853b5c41a35388e2ce3e1b08824b21cdc2fc9aee5868f6c  .release-pack/pack-2/equipe-tech-observability-cli-0.2.1.tgz
+e0ad0382d0f165be6f09e75ea0055ecb7c0159ecba59c6959444677ec39946cf  .release-pack/pack-2/equipe-tech-observability-cli-0.2.1.tgz
 d68f5259fac829bad262537de567f547e7f12aab3a6a3f4bb2af81fd8bc41cf7  .release-pack/pack-3/equipe-tech-observability-0.2.1.tgz
-9c880f315de0cbaad853b5c41a35388e2ce3e1b08824b21cdc2fc9aee5868f6c  .release-pack/pack-3/equipe-tech-observability-cli-0.2.1.tgz
+e0ad0382d0f165be6f09e75ea0055ecb7c0159ecba59c6959444677ec39946cf  .release-pack/pack-3/equipe-tech-observability-cli-0.2.1.tgz

--- a/docs/releases/v0.2.1.sha256
+++ b/docs/releases/v0.2.1.sha256
@@ -1,6 +1,6 @@
 d68f5259fac829bad262537de567f547e7f12aab3a6a3f4bb2af81fd8bc41cf7  .release-pack/pack-1/equipe-tech-observability-0.2.1.tgz
-8e6cccfff37da09c60e0e34ec9fe9b395e05c24a237c4531cf699e4fa5b99cff  .release-pack/pack-1/equipe-tech-observability-cli-0.2.1.tgz
+9c880f315de0cbaad853b5c41a35388e2ce3e1b08824b21cdc2fc9aee5868f6c  .release-pack/pack-1/equipe-tech-observability-cli-0.2.1.tgz
 d68f5259fac829bad262537de567f547e7f12aab3a6a3f4bb2af81fd8bc41cf7  .release-pack/pack-2/equipe-tech-observability-0.2.1.tgz
-8e6cccfff37da09c60e0e34ec9fe9b395e05c24a237c4531cf699e4fa5b99cff  .release-pack/pack-2/equipe-tech-observability-cli-0.2.1.tgz
+9c880f315de0cbaad853b5c41a35388e2ce3e1b08824b21cdc2fc9aee5868f6c  .release-pack/pack-2/equipe-tech-observability-cli-0.2.1.tgz
 d68f5259fac829bad262537de567f547e7f12aab3a6a3f4bb2af81fd8bc41cf7  .release-pack/pack-3/equipe-tech-observability-0.2.1.tgz
-8e6cccfff37da09c60e0e34ec9fe9b395e05c24a237c4531cf699e4fa5b99cff  .release-pack/pack-3/equipe-tech-observability-cli-0.2.1.tgz
+9c880f315de0cbaad853b5c41a35388e2ce3e1b08824b21cdc2fc9aee5868f6c  .release-pack/pack-3/equipe-tech-observability-cli-0.2.1.tgz

--- a/packages/cli/src/AxiomDatasetRetention.ts
+++ b/packages/cli/src/AxiomDatasetRetention.ts
@@ -1,0 +1,19 @@
+import { Schema } from "effect";
+
+export const AxiomDatasetRetentionDays = Schema.Int.pipe(Schema.optionalKey);
+
+type AxiomDatasetRetention = {
+  readonly retentionDays?: number;
+  readonly useRetentionPeriod: boolean;
+};
+
+export const AxiomDatasetRetentionInvariant = Schema.makeFilter<AxiomDatasetRetention>(
+  (retention) =>
+    retention.useRetentionPeriod
+      ? retention.retentionDays !== undefined && retention.retentionDays > 0
+      : retention.retentionDays === undefined || retention.retentionDays === 0,
+  {
+    expected:
+      "provider-default retention with zero or omitted days, or custom retention with positive days",
+  },
+);

--- a/packages/cli/src/CredentialsStore.ts
+++ b/packages/cli/src/CredentialsStore.ts
@@ -1,5 +1,9 @@
 import { Clock, Context, Effect, FileSystem, Layer, Option, Path, Schema } from "effect";
 import { homedir } from "node:os";
+import {
+  AxiomDatasetRetentionDays,
+  AxiomDatasetRetentionInvariant,
+} from "./AxiomDatasetRetention.ts";
 
 const CredentialsEnvironment = Schema.Struct({
   OBSERVABILITY_HOME: Schema.NonEmptyString.pipe(Schema.optionalKey),
@@ -32,14 +36,16 @@ export const AxiomDatasetKind = Schema.Literals([
 
 export class VerifiedAxiomDataset extends Schema.Class<VerifiedAxiomDataset>(
   "@equipe-tech/observability-cli/VerifiedAxiomDataset",
-)({
-  id: Schema.NonEmptyString,
-  name: Schema.NonEmptyString,
-  kind: AxiomDatasetKind,
-  edgeDeployment: Schema.NonEmptyString.pipe(Schema.optionalKey),
-  retentionDays: Schema.Int.check(Schema.isGreaterThan(0)).pipe(Schema.optionalKey),
-  useRetentionPeriod: Schema.Boolean,
-}) {}
+)(
+  Schema.Struct({
+    id: Schema.NonEmptyString,
+    name: Schema.NonEmptyString,
+    kind: AxiomDatasetKind,
+    edgeDeployment: Schema.NonEmptyString.pipe(Schema.optionalKey),
+    retentionDays: AxiomDatasetRetentionDays,
+    useRetentionPeriod: Schema.Boolean,
+  }).check(AxiomDatasetRetentionInvariant),
+) {}
 
 const VerificationRequired = Schema.Struct({ type: Schema.Literal("verification-required") });
 const ManualCorrelation = Schema.Struct({

--- a/packages/cli/src/ProviderApis.ts
+++ b/packages/cli/src/ProviderApis.ts
@@ -40,14 +40,17 @@ export const AxiomDatasetCapabilities = Schema.Record(
   AxiomDatasetCapability,
 );
 const AxiomOrganizationCapabilities = Schema.Record(Schema.NonEmptyString, AxiomCapabilityActions);
-const AxiomViewCapabilities = Schema.Record(Schema.NonEmptyString, AxiomCapabilityActions);
+const AxiomTokenDescription = Schema.String.pipe(Schema.withDecodingDefaultKey(Effect.succeed("")));
+const AxiomViewCapabilities = Schema.Record(Schema.NonEmptyString, AxiomCapabilityActions).pipe(
+  Schema.withDecodingDefaultKey(Effect.succeed({})),
+);
 
 export class AxiomToken extends Schema.Class<AxiomToken>(
   "@equipe-tech/observability-cli/AxiomToken",
 )({
   id: Schema.NonEmptyString,
   name: Schema.NonEmptyString,
-  description: Schema.String,
+  description: AxiomTokenDescription,
   expiresAt: Schema.String.pipe(Schema.optionalKey),
   datasetCapabilities: AxiomDatasetCapabilities,
   orgCapabilities: AxiomOrganizationCapabilities,

--- a/packages/cli/src/ProviderApis.ts
+++ b/packages/cli/src/ProviderApis.ts
@@ -1,4 +1,8 @@
 import { Context, Effect, Layer, Schema } from "effect";
+import {
+  AxiomDatasetRetentionDays,
+  AxiomDatasetRetentionInvariant,
+} from "./AxiomDatasetRetention.ts";
 import { AxiomCredentials, SentryCredentials } from "./CredentialsStore.ts";
 
 const AxiomUser = Schema.Struct({
@@ -16,15 +20,17 @@ export type AxiomDatasetKind = typeof AxiomDatasetKind.Type;
 
 export class AxiomDataset extends Schema.Class<AxiomDataset>(
   "@equipe-tech/observability-cli/AxiomDataset",
-)({
-  id: Schema.NonEmptyString,
-  name: Schema.NonEmptyString,
-  description: Schema.String,
-  kind: AxiomDatasetKind,
-  edgeDeployment: Schema.NonEmptyString.pipe(Schema.optionalKey),
-  retentionDays: Schema.Int.check(Schema.isGreaterThan(0)).pipe(Schema.optionalKey),
-  useRetentionPeriod: Schema.Boolean,
-}) {}
+)(
+  Schema.Struct({
+    id: Schema.NonEmptyString,
+    name: Schema.NonEmptyString,
+    description: Schema.String,
+    kind: AxiomDatasetKind,
+    edgeDeployment: Schema.NonEmptyString.pipe(Schema.optionalKey),
+    retentionDays: AxiomDatasetRetentionDays,
+    useRetentionPeriod: Schema.Boolean,
+  }).check(AxiomDatasetRetentionInvariant),
+) {}
 
 const AxiomDatasets = Schema.Array(AxiomDataset);
 const AxiomCapabilityActions = Schema.Array(Schema.NonEmptyString);

--- a/packages/cli/test/CredentialsStore.bun.test.ts
+++ b/packages/cli/test/CredentialsStore.bun.test.ts
@@ -8,6 +8,7 @@ import {
   CredentialsFile,
   CredentialsStore,
   SentryCredentials,
+  VerifiedAxiomDataset,
 } from "../src/CredentialsStore.ts";
 
 const PersistedVersion = Schema.Struct({ version: Schema.Number });
@@ -83,6 +84,33 @@ const administrativeCredentials = () => ({
 });
 
 describe("CredentialsStore", () => {
+  test("enforces retention discriminations in verified dataset state", () => {
+    const verifiedDataset = (retention: {
+      readonly retentionDays?: number;
+      readonly useRetentionPeriod: boolean;
+    }) =>
+      new VerifiedAxiomDataset({
+        id: "dataset-id",
+        name: "dataset-name",
+        kind: "axiom:events:v1",
+        ...retention,
+      });
+
+    expect(() => verifiedDataset({ useRetentionPeriod: false })).not.toThrow();
+    expect(() => verifiedDataset({ retentionDays: 0, useRetentionPeriod: false })).not.toThrow();
+    expect(() => verifiedDataset({ retentionDays: 30, useRetentionPeriod: true })).not.toThrow();
+
+    for (const retention of [
+      { retentionDays: -1, useRetentionPeriod: false },
+      { retentionDays: -1, useRetentionPeriod: true },
+      { retentionDays: 0, useRetentionPeriod: true },
+      { useRetentionPeriod: true },
+      { retentionDays: 30, useRetentionPeriod: false },
+    ]) {
+      expect(() => verifiedDataset(retention)).toThrow(/Schema validation failed/);
+    }
+  });
+
   test.serial("writes version 3 credentials durably with owner-only permissions", () =>
     withCredentialsHome("observability-credentials-", async (root) => {
       const credentials = administrativeCredentials();

--- a/packages/cli/test/ProviderApis.bun.test.ts
+++ b/packages/cli/test/ProviderApis.bun.test.ts
@@ -374,6 +374,175 @@ describe("provider HTTP boundary", () => {
     }
   });
 
+  test.serial(
+    "normalizes the exact real token list and explicit-empty optional fields identically",
+    async () => {
+      const omitted = [
+        {
+          id: "unrelated-token-id",
+          name: "unrelated-token",
+          datasetCapabilities: {},
+          orgCapabilities: {},
+        },
+        {
+          id: "hibou-token-id",
+          name: "hibou-production-collector",
+          description: "Collector ingest token for hibou-production-collector",
+          datasetCapabilities: {
+            "hibou-production-traces": { ingest: ["create"] },
+            "hibou-production-logs": { ingest: ["create"] },
+            "hibou-production-metrics": { ingest: ["create"] },
+          },
+          orgCapabilities: {},
+        },
+      ];
+      const explicitEmpty = [
+        {
+          ...omitted[0],
+          description: "",
+          viewCapabilities: {},
+        },
+        {
+          ...omitted[1],
+          viewCapabilities: {},
+        },
+      ];
+      let requestIndex = 0;
+      const requests: Array<{ readonly method: string; readonly path: string }> = [];
+      const server = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        fetch: (request) => {
+          requests.push({ method: request.method, path: new URL(request.url).pathname });
+          return Response.json(requestIndex++ === 0 ? omitted : explicitEmpty);
+        },
+      });
+      try {
+        const result = await withAxiomEndpoint(`http://127.0.0.1:${server.port}`, () =>
+          Effect.runPromise(
+            Effect.gen(function* () {
+              const api = yield* AxiomApi;
+              const normalizedOmitted = yield* api.tokens(credentials);
+              const normalizedExplicitEmpty = yield* api.tokens(credentials);
+              return { normalizedExplicitEmpty, normalizedOmitted };
+            }).pipe(Effect.provide(AxiomApi.layer)),
+          ),
+        );
+        expect(result.normalizedOmitted).toEqual(result.normalizedExplicitEmpty);
+        expect(result.normalizedOmitted[0]?.description).toBe("");
+        expect(result.normalizedOmitted[0]?.viewCapabilities).toEqual({});
+        expect(result.normalizedOmitted[1]?.viewCapabilities).toEqual({});
+        expect(requestIndex).toBe(2);
+        expect(requests).toEqual([
+          { method: "GET", path: "/v2/tokens" },
+          { method: "GET", path: "/v2/tokens" },
+        ]);
+      } finally {
+        await server.stop(true);
+      }
+    },
+  );
+
+  test.serial("rejects every omitted strict token field", async () => {
+    const omissions = [
+      {
+        field: "id",
+        token: {
+          name: "strict-token",
+          datasetCapabilities: {},
+          orgCapabilities: {},
+        },
+      },
+      {
+        field: "name",
+        token: {
+          id: "strict-token-id",
+          datasetCapabilities: {},
+          orgCapabilities: {},
+        },
+      },
+      {
+        field: "datasetCapabilities",
+        token: {
+          id: "strict-token-id",
+          name: "strict-token",
+          orgCapabilities: {},
+        },
+      },
+      {
+        field: "orgCapabilities",
+        token: {
+          id: "strict-token-id",
+          name: "strict-token",
+          datasetCapabilities: {},
+        },
+      },
+    ];
+    let responseIndex = 0;
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () => Response.json([omissions[responseIndex++]?.token]),
+    });
+    try {
+      const errors = await withAxiomEndpoint(`http://127.0.0.1:${server.port}`, () =>
+        Effect.runPromise(
+          Effect.gen(function* () {
+            const api = yield* AxiomApi;
+            const results = [];
+            for (const _ of omissions) {
+              results.push(yield* Effect.flip(api.tokens(credentials)));
+            }
+            return results;
+          }).pipe(Effect.provide(AxiomApi.layer)),
+        ),
+      );
+      expect(errors.map((error) => error.code)).toEqual(
+        omissions.map(() => "OBS_CLI_REMOTE_INVALID_RESPONSE"),
+      );
+      expect(omissions.map(({ field }) => field)).toEqual([
+        "id",
+        "name",
+        "datasetCapabilities",
+        "orgCapabilities",
+      ]);
+      expect(responseIndex).toBe(omissions.length);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test.serial("rejects malformed optional token view capabilities", async () => {
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () =>
+        Response.json([
+          {
+            id: "malformed-view-token",
+            name: "malformed-view-token",
+            description: "",
+            datasetCapabilities: {},
+            orgCapabilities: {},
+            viewCapabilities: { dashboard: "read" },
+          },
+        ]),
+    });
+    try {
+      const error = await withAxiomEndpoint(`http://127.0.0.1:${server.port}`, () =>
+        Effect.runPromise(
+          Effect.gen(function* () {
+            const api = yield* AxiomApi;
+            return yield* Effect.flip(api.tokens(credentials));
+          }).pipe(Effect.provide(AxiomApi.layer)),
+        ),
+      );
+      expect(error.code).toBe("OBS_CLI_REMOTE_INVALID_RESPONSE");
+    } finally {
+      await server.stop(true);
+    }
+  });
+
   test.serial("parses complete organization, dataset and view token capabilities", async () => {
     const server = Bun.serve({
       hostname: "127.0.0.1",

--- a/packages/cli/test/ProviderApis.bun.test.ts
+++ b/packages/cli/test/ProviderApis.bun.test.ts
@@ -135,6 +135,118 @@ describe("provider HTTP boundary", () => {
     }
   });
 
+  test.serial(
+    "accepts an unrelated provider-default zero retention dataset before mutation",
+    async () => {
+      const requests: Array<{ readonly method: string; readonly path: string }> = [];
+      const server = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        fetch: (request) => {
+          requests.push({ method: request.method, path: new URL(request.url).pathname });
+          return Response.json([
+            {
+              id: "unrelated-id",
+              name: "unrelated-production-traces",
+              description: "Unrelated provider-default dataset",
+              kind: "axiom:events:v1",
+              retentionDays: 0,
+              useRetentionPeriod: false,
+            },
+          ]);
+        },
+      });
+      try {
+        const datasets = await withAxiomEndpoint(`http://127.0.0.1:${server.port}`, () =>
+          Effect.runPromise(
+            Effect.gen(function* () {
+              const api = yield* AxiomApi;
+              return yield* api.datasets(credentials);
+            }).pipe(Effect.provide(AxiomApi.layer)),
+          ),
+        );
+        expect(datasets).toHaveLength(1);
+        expect(datasets[0]?.retentionDays).toBe(0);
+        expect(datasets[0]?.useRetentionPeriod).toBeFalse();
+        expect(
+          datasets.some((dataset) => dataset.name.startsWith("hibou-production-")),
+        ).toBeFalse();
+        expect(requests).toEqual([{ method: "GET", path: "/v2/datasets" }]);
+      } finally {
+        await server.stop(true);
+      }
+    },
+  );
+
+  test.serial("rejects invalid dataset retention discriminations", async () => {
+    const invalidDatasets = [
+      {
+        id: "negative-default",
+        name: "negative-default",
+        description: "negative provider default",
+        kind: "axiom:events:v1",
+        retentionDays: -1,
+        useRetentionPeriod: false,
+      },
+      {
+        id: "negative-custom",
+        name: "negative-custom",
+        description: "negative custom retention",
+        kind: "axiom:events:v1",
+        retentionDays: -1,
+        useRetentionPeriod: true,
+      },
+      {
+        id: "zero-custom",
+        name: "zero-custom",
+        description: "zero custom retention",
+        kind: "axiom:events:v1",
+        retentionDays: 0,
+        useRetentionPeriod: true,
+      },
+      {
+        id: "missing-custom",
+        name: "missing-custom",
+        description: "missing custom retention",
+        kind: "axiom:events:v1",
+        useRetentionPeriod: true,
+      },
+      {
+        id: "positive-default",
+        name: "positive-default",
+        description: "positive provider default",
+        kind: "axiom:events:v1",
+        retentionDays: 30,
+        useRetentionPeriod: false,
+      },
+    ];
+    let responseIndex = 0;
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () => Response.json([invalidDatasets[responseIndex++]]),
+    });
+    try {
+      const errors = await withAxiomEndpoint(`http://127.0.0.1:${server.port}`, () =>
+        Effect.runPromise(
+          Effect.gen(function* () {
+            const api = yield* AxiomApi;
+            const results = [];
+            for (const _ of invalidDatasets) {
+              results.push(yield* Effect.flip(api.datasets(credentials)));
+            }
+            return results;
+          }).pipe(Effect.provide(AxiomApi.layer)),
+        ),
+      );
+      expect(errors.map((error) => error.code)).toEqual(
+        invalidDatasets.map(() => "OBS_CLI_REMOTE_INVALID_RESPONSE"),
+      );
+    } finally {
+      await server.stop(true);
+    }
+  });
+
   test.serial("rereads and reconciles an exact dataset after HTTP 409", async () => {
     let reads = 0;
     const server = Bun.serve({

--- a/packages/cli/test/RemoteEnvironment.bun.test.ts
+++ b/packages/cli/test/RemoteEnvironment.bun.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { Effect, Layer, Option } from "effect";
+import { Effect, Layer, Option, Schema } from "effect";
 import {
   AxiomCredentials,
   AxiomEnvironment,
@@ -743,6 +743,55 @@ describe("RemoteEnvironment", () => {
     }
   });
 
+  test("reconciles the exact normalized production token list without mutation", async () => {
+    const remote = makeRemoteLayer({ sentry: false });
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        yield* service.provision("hibou", ["production"], ["axiom"], "node", false);
+      }).pipe(Effect.provide(remote.layer)),
+    );
+    const state = remote.state();
+    state.tokens.splice(
+      0,
+      state.tokens.length,
+      Schema.decodeUnknownSync(AxiomToken)({
+        id: "unrelated-token-id",
+        name: "unrelated-token",
+        datasetCapabilities: {},
+        orgCapabilities: {},
+      }),
+      Schema.decodeUnknownSync(AxiomToken)({
+        id: "token-1",
+        name: "hibou-production-collector",
+        description: "Collector ingest token for hibou-production-collector",
+        datasetCapabilities: {
+          "hibou-production-traces": { ingest: ["create"] },
+          "hibou-production-logs": { ingest: ["create"] },
+          "hibou-production-metrics": { ingest: ["create"] },
+        },
+        orgCapabilities: {},
+      }),
+    );
+    const mutationCounts = {
+      creations: state.tokenCreations,
+      regenerations: state.tokenRegenerations,
+    };
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* RemoteEnvironment;
+        yield* service.provision("hibou", ["production"], ["axiom"], "node", false);
+      }).pipe(Effect.provide(remote.layer)),
+    );
+
+    expect(state.tokens[0]?.description).toBe("");
+    expect(state.tokens[0]?.viewCapabilities).toEqual({});
+    expect(state.tokens[1]?.viewCapabilities).toEqual({});
+    expect(remote.state().tokenCreations - mutationCounts.creations).toBe(0);
+    expect(remote.state().tokenRegenerations - mutationCounts.regenerations).toBe(0);
+  });
+
   test("rejects extra dataset, organization and view token capabilities", async () => {
     for (const extra of ["dataset", "organization", "view"]) {
       const remote = makeRemoteLayer({ sentry: false });
@@ -761,14 +810,25 @@ describe("RemoteEnvironment", () => {
         extra === "dataset"
           ? { ...datasetCapabilities, unexpected: { ingest: ["create"] } }
           : datasetCapabilities;
-      remote.state().tokens[0] = new AxiomToken({
-        id: "token-1",
-        name: "livro-caixa-staging-collector",
-        description: "Collector token",
-        datasetCapabilities: capabilities,
-        orgCapabilities: extra === "organization" ? { datasets: ["read"] } : {},
-        viewCapabilities: extra === "view" ? { dashboard: ["read"] } : {},
-      });
+      remote.state().tokens[0] =
+        extra === "view"
+          ? Schema.decodeUnknownSync(AxiomToken)({
+              id: "token-1",
+              name: "livro-caixa-staging-collector",
+              datasetCapabilities: capabilities,
+              orgCapabilities: {},
+              viewCapabilities: { dashboard: ["read"] },
+            })
+          : Schema.decodeUnknownSync(AxiomToken)({
+              id: "token-1",
+              name: "livro-caixa-staging-collector",
+              datasetCapabilities: capabilities,
+              orgCapabilities: extra === "organization" ? { datasets: ["read"] } : {},
+            });
+      const mutationCounts = {
+        creations: remote.state().tokenCreations,
+        regenerations: remote.state().tokenRegenerations,
+      };
 
       const error = await Effect.runPromise(
         Effect.gen(function* () {
@@ -782,7 +842,8 @@ describe("RemoteEnvironment", () => {
       if (error._tag === "RemoteEnvironmentError") {
         expect(error.code).toBe("OBS_CLI_AXIOM_TOKEN_CAPABILITIES_MISMATCH");
       }
-      expect(remote.state().tokenRegenerations).toBe(0);
+      expect(remote.state().tokenCreations).toBe(mutationCounts.creations);
+      expect(remote.state().tokenRegenerations).toBe(mutationCounts.regenerations);
     }
   });
 

--- a/packages/cli/test/RemoteEnvironment.bun.test.ts
+++ b/packages/cli/test/RemoteEnvironment.bun.test.ts
@@ -698,11 +698,10 @@ describe("RemoteEnvironment", () => {
     expect(remote.state().tokenCreations).toBe(0);
   });
 
-  test("rejects lower, higher and disabled explicit retention before any mutation", async () => {
+  test("rejects lower and higher explicit retention before any mutation", async () => {
     for (const retention of [
       { existing: 30, requested: 14, enabled: true },
       { existing: 14, requested: 30, enabled: true },
-      { existing: 30, requested: 30, enabled: false },
     ]) {
       const remote = makeRemoteLayer({ sentry: false });
       remote.state().datasets.push(


### PR DESCRIPTION
## Summary

- accept Axiom provider-default retention represented as zero days with custom retention disabled
- normalize omitted optional token description and view capabilities without weakening strict identity or capabilities
- reproduce both production payload failures through local HTTP boundary tests
- update deterministic 0.2.1 CLI package checksums

## Production E2E

The corrected exact head provisioned all three Hibou datasets after a clean deletion:

- traces: `axiom:events:v1`
- logs: `axiom:events:v1`
- metrics: `otel:metrics:v1`
- retention: 30 days
- edge: `cloud.us-east-1.aws`
- token: exact ingest-only capability for the three datasets

The CLI emitted the required manual Correlation action. No automatic dataset deletion path exists.

## Verification

- full checks, builds, tests, package smoke, triple-pack, and release dry-runs
- two independent reviewer gates
- production provisioning and exact read-back

Linear: OBS-26
