### PR TITLE
fix(release): restore protected canary secret access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,6 @@ on:
       ref:
         required: false
         type: string
-      release_tag:
-        required: false
-        type: string
-      run_deployed_canary:
-        default: false
-        required: false
-        type: boolean
-    outputs:
-      deployed_canary_result:
-        description: Result of the protected deployed canary gate
-        value: ${{ jobs.canary-gate.outputs.result }}
 
 permissions:
   contents: read
@@ -63,80 +52,7 @@ jobs:
       - if: always()
         run: bun packages/cli/src/main.ts dev down
       - name: Report deployed canary status
-        if: ${{ !inputs.run_deployed_canary }}
-        run: echo "Deployed canary did not run because this CI invocation did not request the protected release gate."
+        run: echo "The protected deployed canary runs directly in the Release workflow after CI succeeds."
       - name: Clean runner observability state
         if: always()
         run: rm -rf "$OBSERVABILITY_HOME" "${RUNNER_TEMP}/collector-recovery"
-
-  deployed-canary:
-    if: ${{ inputs.run_deployed_canary }}
-    needs: verify
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    environment: publication
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref || github.sha }}
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.4.0
-      - run: bun install --frozen-lockfile
-      - name: Resolve release canary identity
-        env:
-          RELEASE_TAG: ${{ inputs.release_tag }}
-        run: bun scripts/release-canary.ts --tag "$RELEASE_TAG" --github-env "$GITHUB_ENV"
-      - name: Start the production collector
-        env:
-          AXIOM_INGEST_TOKEN: ${{ secrets.AXIOM_INGEST_TOKEN }}
-          AXIOM_DATASET_TRACES: ${{ vars.AXIOM_DATASET_TRACES }}
-          AXIOM_DATASET_LOGS: ${{ vars.AXIOM_DATASET_LOGS }}
-          AXIOM_DATASET_METRICS: ${{ vars.AXIOM_DATASET_METRICS }}
-        run: |
-          bun scripts/release-canary.ts --require-credential AXIOM_INGEST_TOKEN
-          export AXIOM_TOKEN="$AXIOM_INGEST_TOKEN"
-          docker run -d --name otel-production \
-            -p 127.0.0.1:24318:4318 \
-            -e AXIOM_TOKEN \
-            -e AXIOM_DATASET_TRACES -e AXIOM_DATASET_LOGS -e AXIOM_DATASET_METRICS \
-            -v "$PWD/packages/cli/src/assets/production.yaml:/etc/otelcol/config.yaml:ro" \
-            otel/opentelemetry-collector-contrib:0.159.0 --config=/etc/otelcol/config.yaml
-          for _ in $(seq 1 30); do
-            if curl -s -o /dev/null http://127.0.0.1:24318; then break; fi
-            sleep 1
-          done
-      - name: Run the deployed release canary
-        env:
-          OBSERVABILITY_E2E_DEPLOYED: "1"
-          OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:24318
-          AXIOM_READ_TOKEN: ${{ secrets.AXIOM_READ_TOKEN }}
-          AXIOM_ORGANIZATION_ID: ${{ vars.AXIOM_ORGANIZATION_ID }}
-          AXIOM_URL: ${{ vars.AXIOM_URL }}
-          AXIOM_DATASET_TRACES: ${{ vars.AXIOM_DATASET_TRACES }}
-          AXIOM_DATASET_LOGS: ${{ vars.AXIOM_DATASET_LOGS }}
-          AXIOM_DATASET_METRICS: ${{ vars.AXIOM_DATASET_METRICS }}
-        run: |
-          bun scripts/release-canary.ts --require-credential AXIOM_READ_TOKEN
-          bun run test:canary:deployed
-      - if: always()
-        run: docker rm -f otel-production 2>/dev/null || true
-
-  canary-gate:
-    if: ${{ !cancelled() }}
-    needs: [verify, deployed-canary]
-    runs-on: ubuntu-latest
-    outputs:
-      result: ${{ steps.result.outputs.result }}
-    steps:
-      - id: result
-        env:
-          CANARY_REQUESTED: ${{ inputs.run_deployed_canary }}
-          CANARY_RESULT: ${{ needs.deployed-canary.result }}
-        run: |
-          if [[ "$CANARY_REQUESTED" == "true" ]]; then
-            [[ "$CANARY_RESULT" == "success" ]] || { echo "The requested deployed canary did not succeed."; exit 1; }
-            echo "result=success" >> "$GITHUB_OUTPUT"
-          else
-            echo "result=not-requested" >> "$GITHUB_OUTPUT"
-          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,15 +64,66 @@ jobs:
     uses: ./.github/workflows/ci.yml
     with:
       ref: ${{ needs.tag-check.outputs.tag }}
-      release_tag: ${{ needs.tag-check.outputs.tag }}
-      run_deployed_canary: true
+
+  deployed-canary:
+    needs: [tag-check, verify]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: publication
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.tag-check.outputs.tag }}
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.4.0
+      - run: bun install --frozen-lockfile
+      - name: Resolve release canary identity
+        env:
+          RELEASE_TAG: ${{ needs.tag-check.outputs.tag }}
+        run: bun scripts/release-canary.ts --tag "$RELEASE_TAG" --github-env "$GITHUB_ENV"
+      - name: Start the production collector
+        env:
+          AXIOM_INGEST_TOKEN: ${{ secrets.AXIOM_INGEST_TOKEN }}
+          AXIOM_DATASET_TRACES: ${{ vars.AXIOM_DATASET_TRACES }}
+          AXIOM_DATASET_LOGS: ${{ vars.AXIOM_DATASET_LOGS }}
+          AXIOM_DATASET_METRICS: ${{ vars.AXIOM_DATASET_METRICS }}
+        run: |
+          bun scripts/release-canary.ts --require-credential AXIOM_INGEST_TOKEN
+          export AXIOM_TOKEN="$AXIOM_INGEST_TOKEN"
+          docker run -d --name otel-production \
+            -p 127.0.0.1:24318:4318 \
+            -e AXIOM_TOKEN \
+            -e AXIOM_DATASET_TRACES -e AXIOM_DATASET_LOGS -e AXIOM_DATASET_METRICS \
+            -v "$PWD/packages/cli/src/assets/production.yaml:/etc/otelcol/config.yaml:ro" \
+            otel/opentelemetry-collector-contrib:0.159.0 --config=/etc/otelcol/config.yaml
+          for _ in $(seq 1 30); do
+            if curl -s -o /dev/null http://127.0.0.1:24318; then break; fi
+            sleep 1
+          done
+      - name: Run the deployed release canary
+        env:
+          OBSERVABILITY_E2E_DEPLOYED: "1"
+          OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:24318
+          AXIOM_READ_TOKEN: ${{ secrets.AXIOM_READ_TOKEN }}
+          AXIOM_ORGANIZATION_ID: ${{ vars.AXIOM_ORGANIZATION_ID }}
+          AXIOM_URL: ${{ vars.AXIOM_URL }}
+          AXIOM_DATASET_TRACES: ${{ vars.AXIOM_DATASET_TRACES }}
+          AXIOM_DATASET_LOGS: ${{ vars.AXIOM_DATASET_LOGS }}
+          AXIOM_DATASET_METRICS: ${{ vars.AXIOM_DATASET_METRICS }}
+        run: |
+          bun scripts/release-canary.ts --require-credential AXIOM_READ_TOKEN
+          bun run test:canary:deployed
+      - if: always()
+        run: docker rm -f otel-production 2>/dev/null || true
 
   canary-gate:
-    needs: verify
+    if: ${{ !cancelled() }}
+    needs: deployed-canary
     runs-on: ubuntu-latest
     steps:
       - env:
-          DEPLOYED_CANARY_RESULT: ${{ needs.verify.outputs.deployed_canary_result }}
+          DEPLOYED_CANARY_RESULT: ${{ needs.deployed-canary.result }}
         run: test "$DEPLOYED_CANARY_RESULT" = "success"
 
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## observability@0.3.1
+
+Mudanças desde observability@0.3.0.
+
+### Correções
+
+- fix(release): resolve protected secrets in native jobs
+
 ## observability@0.3.0
 
 ### Novidades

--- a/bun.lock
+++ b/bun.lock
@@ -124,7 +124,7 @@
     },
     "packages/telemetry": {
       "name": "@equipe-tech/observability",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
         "effect": "4.0.0-rc.111",
       },

--- a/docs/migration-0.3.md
+++ b/docs/migration-0.3.md
@@ -151,4 +151,4 @@ Mantenha o ledger no banco de dados da aplicação. Use `commitAuditRecord` ou `
 
 ## Usar releases independentes
 
-Os pacotes mantêm versões independentes. Esta preparação seleciona `0.3.0` para os seis pacotes alterados. A CLI avança de `0.2.1` para `0.3.0` pelas mudanças incompatíveis descritas neste guia. Tags usam `<slug>@<semver>`, por exemplo `observability@0.3.0`, `observability-evlog@0.3.0`, `observability-nestjs@0.3.0` e `observability-cli@0.3.0`. Releases futuras alteram somente os pacotes afetados.
+Os pacotes mantêm versões independentes. Esta preparação seleciona `0.3.1` para o núcleo e `0.3.0` para os outros cinco pacotes alterados. A tag inicial do núcleo permanece como registro de uma tentativa sem publicação. A CLI avança de `0.2.1` para `0.3.0` pelas mudanças incompatíveis descritas neste guia. Tags usam `<slug>@<semver>`, por exemplo `observability@0.3.0`, `observability-evlog@0.3.0`, `observability-nestjs@0.3.0` e `observability-cli@0.3.0`. Releases futuras alteram somente os pacotes afetados.

--- a/docs/release-publication-runbook.md
+++ b/docs/release-publication-runbook.md
@@ -41,18 +41,18 @@ O dry run não altera manifest, lockfile, commit ou tag. Uma release real altera
 
 ## Gate do canário no provedor
 
-A verificação de release executa o canário implantado antes de criar a GitHub Release. O job reutilizável usa o environment protegido `publication` como a única origem dos secrets. O workflow chamador não repassa secrets. O job exige dois secrets independentes:
+A verificação de release executa o canário implantado antes de criar a GitHub Release. O job `deployed-canary` roda diretamente em `release.yml`, depois da verificação reutilizável de `ci.yml`, e usa o environment protegido `publication` como a única origem dos secrets. Isso evita a falha de resolução de secrets de environment na fronteira de workflows reutilizáveis descrita em [actions/runner#4453](https://github.com/actions/runner/issues/4453). CI continua reutilizável, sem receber secrets ou `NPM_TOKEN`; não use `secrets: inherit`. O gate exige sucesso explícito desse job antes da GitHub Release e da publicação npm. Falha, cancelamento, execução omitida ou resultado ausente não permitem publicação. O job exige dois secrets independentes:
 
 - `AXIOM_INGEST_TOKEN` aceita somente ingestão nos datasets E2E de traces, logs e métricas.
 - `AXIOM_READ_TOKEN` aceita somente consultas nos mesmos datasets E2E.
 
 `AXIOM_ORGANIZATION_ID`, `AXIOM_URL`, `AXIOM_DATASET_TRACES`, `AXIOM_DATASET_LOGS` e `AXIOM_DATASET_METRICS` são variables do environment. `AXIOM_URL` aponta para a API regional da organização. Nenhum token administrativo entra no job.
 
-O script `scripts/release-canary.ts` resolve o tag para o manifest correspondente e define `OTEL_SERVICE_VERSION` com a versão desse manifest. O step do Collector recebe somente `AXIOM_INGEST_TOKEN`. O step de consulta recebe somente `AXIOM_READ_TOKEN`. O canário consulta traces, logs e métricas usando a versão e os valores de correlação da execução. A ausência de qualquer secret encerra o gate com `OBS_RELEASE_CANARY_CREDENTIALS_MISSING`. CI comum permanece sem credenciais e informa que o gate protegido não foi solicitado.
+O script `scripts/release-canary.ts` resolve o tag para o manifest correspondente e define `OTEL_SERVICE_VERSION` com a versão desse manifest. O step do Collector recebe somente `AXIOM_INGEST_TOKEN`. O step de consulta recebe somente `AXIOM_READ_TOKEN`. O canário consulta traces, logs e métricas usando a versão e os valores de correlação da execução. A ausência de qualquer secret encerra o gate com `OBS_RELEASE_CANARY_CREDENTIALS_MISSING`. CI comum permanece sem credenciais e informa que o gate protegido pertence ao workflow de release.
 
 O orçamento de visibilidade reserva 200 ms para o `flush_timeout` do Collector e 180.000 ms para `axiomQueryVisibilityMilliseconds`. A [documentação pública de ingestão do Axiom](https://axiom.co/docs/send-data/) não publica um limite de latência entre ingestão e consulta. Por isso, os 180 segundos são uma tolerância operacional explícita, não uma garantia do provedor. O teste exige que o intervalo total de polling cubra esses dois campos e informa a margem derivada. Com os valores atuais, o intervalo de 192.000 ms deixa uma margem de 11.800 ms.
 
-Se o gate falhar, preserve o tag e os resultados da execução. Corrija a credencial, a variable regional, o dataset ou a entrega de telemetria indicada pelo último resultado de consulta. Execute novamente o mesmo workflow no mesmo tag. Não mova o tag, não use credencial administrativa e não publique manualmente para contornar o gate.
+Se o gate falhar, preserve o tag e os resultados da execução. Corrija a credencial, a variable regional, o dataset ou a entrega de telemetria indicada pelo último resultado de consulta. Para correções de configuração externa, execute novamente o mesmo workflow no mesmo tag. Se a correção exigir mudanças versionadas no workflow ou no código, prepare um novo patch apenas do pacote afetado com um novo tag: a execução no tag anterior continua usando os arquivos antigos. Não mova o tag, não use credencial administrativa e não publique manualmente para contornar o gate.
 
 ## Gate humano
 
@@ -68,6 +68,6 @@ Se a criação da release concluir e o npm falhar, corrija a causa e execute nov
 
 ## Rollback
 
-Nunca remova uma versão publicada do npm e nunca mova um tag publicado. Se a falha ocorrer antes da publicação no npm, mantenha o tag e a release para diagnóstico, corrija o workflow ou as credenciais e execute novamente. Se um pacote incorreto chegar ao npm, descontinue a versão com `npm deprecate`, corrija o código e publique um novo patch apenas para o pacote afetado. Registre na release anterior o link para a versão corrigida.
+Nunca remova uma versão publicada do npm e nunca mova um tag publicado. Se a falha ocorrer antes da publicação no npm, mantenha o tag e a release para diagnóstico. Correções de credenciais permitem executar novamente; correções versionadas de workflow exigem um novo patch e tag do pacote afetado. Se um pacote incorreto chegar ao npm, descontinue a versão com `npm deprecate`, corrija o código e publique um novo patch apenas para o pacote afetado. Registre na release anterior o link para a versão corrigida.
 
 Não publique um pacote irmão para alinhar versões.

--- a/docs/releases/observability-cli@0.3.0.md
+++ b/docs/releases/observability-cli@0.3.0.md
@@ -37,7 +37,7 @@
 
 ### Correções
 
-- fix(deps): isolate fixture manifests and patch YAML parsing
+- fix(release): resolve protected secrets in native jobs
 - fix: resolve stack review findings (#78)
 - fix(cli): accept Axiom default retention payloads (#24)
 - fix(cli): create MetricsDB datasets and correlation gates (#22)
@@ -53,6 +53,7 @@
 
 ### Outras mudanças
 
+- chore: prepare independent 0.3.0 releases (#81)
 - ci(release): restore the scoped provider canary (#74)
 - chore(release): prepare v0.2.0 packages (#18)
 - chore: update pstack model routing

--- a/docs/releases/observability-cli@0.3.0.sha256
+++ b/docs/releases/observability-cli@0.3.0.sha256
@@ -1,1 +1,1 @@
-5e31e15bfb9b26cc6e46a2cbc88dfc723e9381fdfd03219acf283bab7bceb977  equipe-tech-observability-cli-0.3.0.tgz
+2239d81f5546f191a29a835794ec5aeca49be57d428ece93a29b41641f023bc6  equipe-tech-observability-cli-0.3.0.tgz

--- a/docs/releases/observability-evlog@0.3.0.md
+++ b/docs/releases/observability-evlog@0.3.0.md
@@ -37,7 +37,7 @@
 
 ### Correções
 
-- fix(deps): isolate fixture manifests and patch YAML parsing
+- fix(release): resolve protected secrets in native jobs
 - fix: resolve stack review findings (#78)
 - fix(cli): accept Axiom default retention payloads (#24)
 - fix(cli): create MetricsDB datasets and correlation gates (#22)
@@ -53,6 +53,7 @@
 
 ### Outras mudanças
 
+- chore: prepare independent 0.3.0 releases (#81)
 - ci(release): restore the scoped provider canary (#74)
 - chore(release): prepare v0.2.0 packages (#18)
 - chore: update pstack model routing

--- a/docs/releases/observability-evlog@0.3.0.sha256
+++ b/docs/releases/observability-evlog@0.3.0.sha256
@@ -1,1 +1,1 @@
-d6fe34aa2bd086b1600beadfd43ba2dde40bff6693980c10ccbd854cc08965a7  equipe-tech-observability-evlog-0.3.0.tgz
+ba326621f128950996e2c1ee01fa7c005ace92f6a7cb8110ce203119b25027eb  equipe-tech-observability-evlog-0.3.0.tgz

--- a/docs/releases/observability-nestjs@0.3.0.md
+++ b/docs/releases/observability-nestjs@0.3.0.md
@@ -37,7 +37,7 @@
 
 ### Correções
 
-- fix(deps): isolate fixture manifests and patch YAML parsing
+- fix(release): resolve protected secrets in native jobs
 - fix: resolve stack review findings (#78)
 - fix(cli): accept Axiom default retention payloads (#24)
 - fix(cli): create MetricsDB datasets and correlation gates (#22)
@@ -53,6 +53,7 @@
 
 ### Outras mudanças
 
+- chore: prepare independent 0.3.0 releases (#81)
 - ci(release): restore the scoped provider canary (#74)
 - chore(release): prepare v0.2.0 packages (#18)
 - chore: update pstack model routing

--- a/docs/releases/observability-nestjs@0.3.0.sha256
+++ b/docs/releases/observability-nestjs@0.3.0.sha256
@@ -1,1 +1,1 @@
-25b146deea1be04d78f50daf1c73720a1ea17c802c870791ea890cb5044b14c4  equipe-tech-observability-nestjs-0.3.0.tgz
+3e416d65d2e29a152b34dc8c1f465aa13b70f6b4dce00078a93451938fbb1381  equipe-tech-observability-nestjs-0.3.0.tgz

--- a/docs/releases/observability-react@0.3.0.md
+++ b/docs/releases/observability-react@0.3.0.md
@@ -37,7 +37,7 @@
 
 ### Correções
 
-- fix(deps): isolate fixture manifests and patch YAML parsing
+- fix(release): resolve protected secrets in native jobs
 - fix: resolve stack review findings (#78)
 - fix(cli): accept Axiom default retention payloads (#24)
 - fix(cli): create MetricsDB datasets and correlation gates (#22)
@@ -53,6 +53,7 @@
 
 ### Outras mudanças
 
+- chore: prepare independent 0.3.0 releases (#81)
 - ci(release): restore the scoped provider canary (#74)
 - chore(release): prepare v0.2.0 packages (#18)
 - chore: update pstack model routing

--- a/docs/releases/observability-react@0.3.0.sha256
+++ b/docs/releases/observability-react@0.3.0.sha256
@@ -1,1 +1,1 @@
-7ab436bbafac49c12478f8cc1659619fe5d4ad1c3db3630a637f6d2651ef518d  equipe-tech-observability-react-0.3.0.tgz
+e51d523b59f2e8ef1db3cbc621fa38a7d98966311e92d11810982f34c6c85cba  equipe-tech-observability-react-0.3.0.tgz

--- a/docs/releases/observability-sentry@0.3.0.md
+++ b/docs/releases/observability-sentry@0.3.0.md
@@ -37,7 +37,7 @@
 
 ### Correções
 
-- fix(deps): isolate fixture manifests and patch YAML parsing
+- fix(release): resolve protected secrets in native jobs
 - fix: resolve stack review findings (#78)
 - fix(cli): accept Axiom default retention payloads (#24)
 - fix(cli): create MetricsDB datasets and correlation gates (#22)
@@ -53,6 +53,7 @@
 
 ### Outras mudanças
 
+- chore: prepare independent 0.3.0 releases (#81)
 - ci(release): restore the scoped provider canary (#74)
 - chore(release): prepare v0.2.0 packages (#18)
 - chore: update pstack model routing

--- a/docs/releases/observability-sentry@0.3.0.sha256
+++ b/docs/releases/observability-sentry@0.3.0.sha256
@@ -1,1 +1,1 @@
-ab97174894729fb53885d1837e9999379ed25c1c67d3cd73530cc8cf7db75ff4  equipe-tech-observability-sentry-0.3.0.tgz
+970cd131590dbdefcbf27055b7d2452a1412870ad6c8ca317f2cf0044d480a3a  equipe-tech-observability-sentry-0.3.0.tgz

--- a/docs/releases/observability@0.3.1.md
+++ b/docs/releases/observability@0.3.1.md
@@ -1,0 +1,7 @@
+## observability@0.3.1
+
+Mudanças desde observability@0.3.0.
+
+### Correções
+
+- fix(release): resolve protected secrets in native jobs

--- a/docs/releases/observability@0.3.1.sha256
+++ b/docs/releases/observability@0.3.1.sha256
@@ -1,0 +1,1 @@
+b88b41e9f261b50b7f09c0a43a7af10b135462faa318ea8e7aacdbd919d810d2  equipe-tech-observability-0.3.1.tgz

--- a/docs/releases/preparation-0.3.md
+++ b/docs/releases/preparation-0.3.md
@@ -4,7 +4,7 @@ Esta preparação cobre os seis pacotes alterados pelo stack. Cada pacote manté
 
 | Pacote                              | Versão candidata | Motivo                                                                 |
 | ----------------------------------- | ---------------- | ---------------------------------------------------------------------- |
-| `@equipe-tech/observability`        | `0.3.0`          | Contratos tipados, identidade canônica, política, métricas e auditoria |
+| `@equipe-tech/observability`        | `0.3.1`          | Contratos tipados, identidade canônica, política, métricas e auditoria |
 | `@equipe-tech/observability-evlog`  | `0.3.0`          | Primeiro release do adapter oficial de eventos                         |
 | `@equipe-tech/observability-nestjs` | `0.3.0`          | Primeiro release da integração extraída do núcleo                      |
 | `@equipe-tech/observability-sentry` | `0.3.0`          | Primeiro release dos adapters de defeitos Node e browser               |
@@ -23,18 +23,16 @@ Leia [o guia de migração](../migration-0.3.md) antes da atualização. Leia [o
 
 Publique o núcleo antes dos adapters e da CLI, pois os consumidores precisam resolver o peer `@equipe-tech/observability@0.3.x`.
 
-Execute `Release Preflight` para cada pacote na revisão aprovada. Crie somente tags independentes, como `observability@0.3.0`, depois do preflight.
+Execute `Release Preflight` para cada pacote na revisão aprovada. Crie somente tags independentes, como `observability@0.3.1`, depois do preflight.
 
 Mantenha a aprovação humana do environment `publication`. O push da tag solicita somente a verificação protegida. A publicação exige outro `workflow_dispatch`, com `tag` e `confirm_tag` idênticos.
 
-## Pendências externas
+## Recuperação da primeira tentativa
 
-A inspeção do environment `publication` identificou estas pendências:
+A tag `observability@0.3.0` registra uma tentativa sem publicação no npm. O canário protegido falhou ao resolver o secret de ingestão no workflow reutilizável. Preserve essa tag para diagnóstico.
 
-- A política permite somente tags `v*`. Ela não permite as tags independentes `<slug>@<versão>`.
-- Os secrets `AXIOM_INGEST_TOKEN`, `AXIOM_READ_TOKEN` e `NPM_TOKEN` não estão configurados nesse environment.
-- As variables `AXIOM_ORGANIZATION_ID`, `AXIOM_URL`, `AXIOM_DATASET_TRACES`, `AXIOM_DATASET_LOGS` e `AXIOM_DATASET_METRICS` não estão configuradas.
+A recuperação usa `observability@0.3.1` e executa o job protegido diretamente no workflow de release. Os outros cinco pacotes mantêm `0.3.0`, pois suas tags ainda não foram criadas.
 
-Configure credenciais restritas aos datasets E2E. Permita as tags dos seis slugs sem remover a aprovação humana.
+Os cadastros dos dois secrets Axiom e das cinco variables existem no environment `publication`. As regras permitem as tags dos seis slugs. O `NPM_TOKEN` existe no escopo do repositório.
 
-Esta preparação não publica tags, GitHub Releases ou pacotes npm. A aceitação deployed permanece pendente até a configuração e aprovação do environment.
+A existência desses cadastros não comprova autenticação ou entrega de telemetria. A publicação continua condicionada ao canário deployed e à aprovação humana.

--- a/observability/compatibility/candidate-versions.json
+++ b/observability/compatibility/candidate-versions.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "packages": [
-    { "name": "@equipe-tech/observability", "version": "0.3.0" },
+    { "name": "@equipe-tech/observability", "version": "0.3.1" },
     { "name": "@equipe-tech/observability-cli", "version": "0.3.0" },
     { "name": "@equipe-tech/observability-evlog", "version": "0.3.0" },
     { "name": "@equipe-tech/observability-nestjs", "version": "0.3.0" },

--- a/observability/compatibility/declared-breaks.json
+++ b/observability/compatibility/declared-breaks.json
@@ -6,7 +6,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_DEPENDENCY_REMOVED",
       "path": "dependencies/effect@4.0.0-rc.111",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -14,7 +14,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_DEPENDENCY_CATEGORY_CHANGED",
       "path": "dependencies/effect",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -22,7 +22,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_EXPORT_CONDITION_REMOVED",
       "path": "exportConditions/./nestjs:import:./dist/nestjs/index.js",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -30,7 +30,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_EXPORT_CONDITION_REMOVED",
       "path": "exportConditions/./nestjs:types:./dist/nestjs/index.d.ts",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -38,7 +38,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_EXPORT_REMOVED",
       "path": "exports/./nestjs",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -46,7 +46,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_PEER_CHANGED",
       "path": "peerDependencies/@nestjs/common@^10.0.0 || ^11.0.0",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -54,7 +54,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_PEER_CHANGED",
       "path": "peerDependencies/@nestjs/core@^10.0.0 || ^11.0.0",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -62,7 +62,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_PEER_CHANGED",
       "path": "peerDependencies/rxjs@^7.2.0",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -70,7 +70,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_PEER_OPTIONALITY_CHANGED",
       "path": "peerDependenciesMeta",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -78,7 +78,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_RUNTIME_ENTRYPOINT_MISSING",
       "path": "runtime/./nestjs",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -86,7 +86,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_ERROR_CODE_REMOVED",
       "path": "publicErrorCodes/OBS_TELEMETRY_INVALID_MODULE_OPTIONS",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -94,7 +94,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_ERROR_CODE_REMOVED",
       "path": "publicErrorCodes/OBS_TELEMETRY_SHUTDOWN_FAILED",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -102,7 +102,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_ERROR_CODE_REMOVED",
       "path": "publicErrorCodes/OBS_TELEMETRY_STARTUP_FAILED",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -110,7 +110,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/.:WideEvent",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -118,7 +118,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:BrowserEventsControllerOptions",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -126,7 +126,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:BrowserEventsRejection",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -134,7 +134,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:createBrowserEventsController",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -142,7 +142,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:createRequestWideEventTraceCorrelation",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -150,7 +150,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:defaultBrowserEventsPath",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -158,7 +158,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:InvalidTelemetryModuleOptions",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -166,7 +166,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:ProxyPolicy",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -174,7 +174,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:RequestReference",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -182,7 +182,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:requestSpan",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -190,7 +190,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:RequestWideEventLogger",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -198,7 +198,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:RequestWideEventLoggerResolver",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -206,7 +206,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:RequestWideEventTraceCorrelation",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -214,7 +214,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:ServerSpanCorrelation",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -222,7 +222,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryInterceptor",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -230,7 +230,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryInterceptorOptions",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -238,7 +238,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryModuleAsyncOptions",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -246,7 +246,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryModule",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -254,7 +254,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryModuleOptions",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -262,7 +262,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:telemetryModuleForTesting",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -270,7 +270,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryModuleTestingOverrides",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -278,7 +278,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryRequestTracker",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -286,7 +286,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryRoutePolicyOptions",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -294,7 +294,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryShutdownError",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -302,7 +302,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryStartupError",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -310,7 +310,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:withRequestSpan",
-      "candidateVersion": "0.3.0",
+      "candidateVersion": "0.3.1",
       "migrationGuide": "docs/migration-0.3.md"
     }
   ]

--- a/packages/cli/test/ReleaseWorkflow.bun.test.ts
+++ b/packages/cli/test/ReleaseWorkflow.bun.test.ts
@@ -27,8 +27,10 @@ const releaseCanaryScript = await Bun.file(releaseCanaryScriptPath).text();
 
 const WorkflowEnvironment = Schema.Struct({
   OBSERVABILITY_E2E_DEPLOYED: Schema.optionalKey(Schema.String),
-  CANARY_REQUESTED: Schema.optionalKey(Schema.String),
-  CANARY_RESULT: Schema.optionalKey(Schema.String),
+  AXIOM_INGEST_TOKEN: Schema.optionalKey(Schema.String),
+  AXIOM_READ_TOKEN: Schema.optionalKey(Schema.String),
+  NODE_AUTH_TOKEN: Schema.optionalKey(Schema.String),
+  RELEASE_TAG: Schema.optionalKey(Schema.String),
   DEPLOYED_CANARY_RESULT: Schema.optionalKey(Schema.String),
 });
 
@@ -38,7 +40,12 @@ const WorkflowStep = Schema.Struct({
   if: Schema.optionalKey(Schema.String),
   run: Schema.optionalKey(Schema.String),
   uses: Schema.optionalKey(Schema.String),
-  with: Schema.optionalKey(Schema.Struct({ "bun-version": Schema.optionalKey(Schema.String) })),
+  with: Schema.optionalKey(
+    Schema.Struct({
+      "bun-version": Schema.optionalKey(Schema.String),
+      ref: Schema.optionalKey(Schema.String),
+    }),
+  ),
   env: Schema.optionalKey(WorkflowEnvironment),
 });
 
@@ -52,16 +59,11 @@ const WorkflowDocument = Schema.Struct({
 const ConditionalJob = Schema.Struct({
   if: Schema.optionalKey(Schema.String),
   environment: Schema.optionalKey(Schema.String),
+  needs: Schema.optionalKey(Schema.Array(Schema.String)),
+  env: Schema.optionalKey(WorkflowEnvironment),
   "continue-on-error": Schema.optionalKey(Schema.Boolean),
   "timeout-minutes": Schema.optionalKey(Schema.Number),
   steps: Schema.optionalKey(Schema.Array(WorkflowStep)),
-});
-
-const GateJob = Schema.Struct({
-  if: Schema.String,
-  needs: Schema.Array(Schema.String),
-  outputs: Schema.Struct({ result: Schema.String }),
-  steps: Schema.Array(WorkflowStep),
 });
 
 const WorkflowSecrets = Schema.Struct({
@@ -73,15 +75,18 @@ const ReusableWorkflowJob = Schema.Struct({
   uses: Schema.String,
   with: Schema.Struct({
     ref: Schema.String,
-    release_tag: Schema.String,
-    run_deployed_canary: Schema.Boolean,
   }),
   secrets: Schema.optionalKey(WorkflowSecrets),
 });
 
-const DependentJob = Schema.Struct({ needs: Schema.Array(Schema.String) });
+const DependentJob = Schema.Struct({
+  needs: Schema.Array(Schema.String),
+  if: Schema.String,
+  environment: Schema.String,
+});
 
 const ReleaseGateJob = Schema.Struct({
+  if: Schema.String,
   needs: Schema.String,
   steps: Schema.Array(WorkflowStep),
 });
@@ -90,24 +95,20 @@ const CiWorkflow = Schema.Struct({
   on: Schema.Struct({
     workflow_call: Schema.Struct({
       inputs: Schema.Struct({
-        release_tag: Schema.Struct({ required: Schema.Boolean, type: Schema.String }),
-      }),
-      outputs: Schema.Struct({
-        deployed_canary_result: Schema.Struct({ value: Schema.String }),
+        ref: Schema.Struct({ required: Schema.Boolean, type: Schema.String }),
       }),
       secrets: Schema.optionalKey(WorkflowSecrets),
     }),
   }),
   jobs: Schema.Struct({
     verify: ConditionalJob,
-    "deployed-canary": ConditionalJob,
-    "canary-gate": GateJob,
   }),
 });
 
 const ReleaseWorkflow = Schema.Struct({
   jobs: Schema.Struct({
     verify: ReusableWorkflowJob,
+    "deployed-canary": ConditionalJob,
     "canary-gate": ReleaseGateJob,
     release: DependentJob,
     "publish-npm": DependentJob,
@@ -128,28 +129,12 @@ const workflowDocuments = await Array.fromAsync(
     Schema.decodeUnknownSync(WorkflowDocument)(Bun.YAML.parse(await Bun.file(path).text())),
 );
 
-type GateCase = {
-  readonly requested: "true" | "false";
-  readonly result: "success" | "failure" | "skipped" | "cancelled";
-  readonly exitCode: number;
-  readonly output: string;
-};
-
 type ShellResult = {
   readonly exitCode: number;
   readonly output: string;
   readonly stderr: string;
   readonly stdout: string;
 };
-
-const gateCases: ReadonlyArray<GateCase> = [
-  { requested: "false", result: "skipped", exitCode: 0, output: "result=not-requested\n" },
-  { requested: "false", result: "failure", exitCode: 0, output: "result=not-requested\n" },
-  { requested: "true", result: "success", exitCode: 0, output: "result=success\n" },
-  { requested: "true", result: "failure", exitCode: 1, output: "" },
-  { requested: "true", result: "skipped", exitCode: 1, output: "" },
-  { requested: "true", result: "cancelled", exitCode: 1, output: "" },
-];
 
 const executeShell = async (
   script: string,
@@ -209,7 +194,7 @@ describe("release workflow publication gate", () => {
     expect(workflow).toContain('[[ "$CONFIRM_TAG" == "$tag" ]]');
     expect(workflow).toContain("Publication confirmation must exactly match $tag.");
     expect(workflow).toContain('[[ "$EVENT_REF" == "refs/tags/$tag" ]]');
-    expect(workflow.match(/environment: publication/g)).toHaveLength(2);
+    expect(workflow.match(/environment: publication/g)).toHaveLength(3);
   });
 
   test("resolves one package manifest and archive through the release canary script", () => {
@@ -231,36 +216,12 @@ describe("release workflow publication gate", () => {
     expect(workflow).toContain('[[ "$head_commit" == "$tag_commit" ]]');
   });
 
-  test("executes the reusable workflow canary gate script", async () => {
-    const gateStep = parsedCiWorkflow.jobs["canary-gate"].steps.find(
-      (step) => step.id === "result",
-    );
-    expect(gateStep?.run).toBeDefined();
-    if (gateStep?.run === undefined) throw new Error("The reusable canary gate script is missing.");
-    for (const gateCase of gateCases) {
-      const result = await executeShell(gateStep.run, {
-        CANARY_REQUESTED: gateCase.requested,
-        CANARY_RESULT: gateCase.result,
-      });
-      expect(result.exitCode).toBe(gateCase.exitCode);
-      expect(result.output).toBe(gateCase.output);
-      expect(result.stderr).toBe("");
-      if (gateCase.exitCode === 1) {
-        expect(result.stdout).toContain("The requested deployed canary did not succeed.");
-      } else {
-        expect(result.stdout).toBe("");
-      }
-    }
-  });
-
   test("executes the release workflow canary gate script", async () => {
     const gateStep = parsedReleaseWorkflow.jobs["canary-gate"].steps?.[0];
     expect(gateStep?.run).toBeDefined();
     if (gateStep?.run === undefined) throw new Error("The release canary gate script is missing.");
-    for (const canaryResult of ["success", "failure", "skipped", "cancelled"]) {
+    for (const canaryResult of ["success", "failure", "skipped", "cancelled", "", undefined]) {
       const result = await executeShell(gateStep.run, {
-        CANARY_REQUESTED: "true",
-        CANARY_RESULT: canaryResult,
         DEPLOYED_CANARY_RESULT: canaryResult,
       });
       expect(result.exitCode).toBe(canaryResult === "success" ? 0 : 1);
@@ -270,64 +231,74 @@ describe("release workflow publication gate", () => {
     }
   });
 
-  test("wires the reusable gate output into the release gate", () => {
-    expect(parsedCiWorkflow.on.workflow_call.outputs.deployed_canary_result.value).toBe(
-      "${{ jobs.canary-gate.outputs.result }}",
-    );
-    expect(parsedCiWorkflow.jobs["deployed-canary"]["continue-on-error"]).toBeUndefined();
-    expect(parsedCiWorkflow.jobs["canary-gate"].outputs.result).toBe(
-      "${{ steps.result.outputs.result }}",
-    );
-    expect(parsedCiWorkflow.jobs["canary-gate"].steps[0]?.env).toEqual({
-      CANARY_REQUESTED: "${{ inputs.run_deployed_canary }}",
-      CANARY_RESULT: "${{ needs.deployed-canary.result }}",
-    });
-    expect(parsedReleaseWorkflow.jobs["canary-gate"].needs).toBe("verify");
-    expect(parsedReleaseWorkflow.jobs["canary-gate"].steps?.[0]?.env?.DEPLOYED_CANARY_RESULT).toBe(
-      "${{ needs.verify.outputs.deployed_canary_result }}",
+  test("gates publication on the direct protected job result", () => {
+    expect(parsedReleaseWorkflow.jobs["deployed-canary"]["continue-on-error"]).toBeUndefined();
+    expect(parsedReleaseWorkflow.jobs["deployed-canary"].if).toBeUndefined();
+    expect(parsedReleaseWorkflow.jobs["canary-gate"].needs).toBe("deployed-canary");
+    expect(parsedReleaseWorkflow.jobs["canary-gate"].if).toBe("${{ !cancelled() }}");
+    expect(parsedReleaseWorkflow.jobs["canary-gate"].steps[0]?.env?.DEPLOYED_CANARY_RESULT).toBe(
+      "${{ needs.deployed-canary.result }}",
     );
   });
 
   test("keeps the deployed canary job timeout above the suite budget", () => {
-    const timeoutMinutes = parsedCiWorkflow.jobs["deployed-canary"]["timeout-minutes"];
+    const timeoutMinutes = parsedReleaseWorkflow.jobs["deployed-canary"]["timeout-minutes"];
     expect(timeoutMinutes).toBeDefined();
     expect((timeoutMinutes ?? 0) * 60_000).toBeGreaterThanOrEqual(
       deployedCanarySuiteTimeoutMilliseconds + 3 * 60_000,
     );
   });
 
-  test("does not mask a gate bypass when the request variable is unset", async () => {
-    const gateStep = parsedCiWorkflow.jobs["canary-gate"].steps[0];
-    expect(gateStep?.run).toBeDefined();
-    if (gateStep?.run === undefined) throw new Error("The reusable canary gate script is missing.");
-    const result = await executeShell(gateStep.run, {
-      CANARY_REQUESTED: undefined,
-      CANARY_RESULT: "success",
-    });
-    expect(result).toEqual({
-      exitCode: 0,
-      output: "result=not-requested\n",
-      stderr: "",
-      stdout: "",
-    });
-  });
-
   test("builds a release graph that cannot bypass the canary gate", () => {
     expect(parsedReleaseWorkflow.jobs.verify.uses).toBe("./.github/workflows/ci.yml");
-    expect(parsedReleaseWorkflow.jobs.verify.with.run_deployed_canary).toBe(true);
-    expect(parsedCiWorkflow.jobs["canary-gate"].needs).toEqual(["verify", "deployed-canary"]);
-    expect(parsedReleaseWorkflow.jobs.release.needs).toContain("canary-gate");
-    expect(parsedReleaseWorkflow.jobs["publish-npm"].needs).toContain("release");
+    expect(parsedReleaseWorkflow.jobs["deployed-canary"].needs).toEqual(["tag-check", "verify"]);
+    expect(parsedReleaseWorkflow.jobs.release.needs).toEqual([
+      "tag-check",
+      "verify",
+      "canary-gate",
+    ]);
+    expect(parsedReleaseWorkflow.jobs["publish-npm"].needs).toEqual(["tag-check", "release"]);
+    for (const job of [
+      parsedReleaseWorkflow.jobs.release,
+      parsedReleaseWorkflow.jobs["publish-npm"],
+    ]) {
+      expect(job.if).toBe("github.event_name == 'workflow_dispatch'");
+      expect(job.environment).toBe("publication");
+    }
   });
 
   test("uses publication environment secrets without inert caller plumbing", () => {
     expect(parsedCiWorkflow.on.workflow_call.secrets).toBeUndefined();
-    expect(parsedCiWorkflow.jobs["deployed-canary"].environment).toBe("publication");
+    expect(parsedReleaseWorkflow.jobs["deployed-canary"].environment).toBe("publication");
+    expect(workflow).not.toContain("secrets: inherit");
+    expect(ciWorkflow).not.toContain("secrets.");
+    expect(ciWorkflow).not.toContain("NPM_TOKEN");
+    expect(ciWorkflow).not.toContain("environment:");
+    expect(ciWorkflow).not.toContain("deployed-canary:");
     expect(parsedReleaseWorkflow.jobs.verify.secrets).toBeUndefined();
   });
 
-  test("requires and counts an explicitly requested deployed canary test", () => {
-    const canaryStep = parsedCiWorkflow.jobs["deployed-canary"].steps?.find(
+  test("isolates ingest, read and npm credentials to their owning steps", () => {
+    const canary = parsedReleaseWorkflow.jobs["deployed-canary"];
+    expect(canary.env).toBeUndefined();
+    const steps = canary.steps ?? [];
+    const ingestStep = steps.find((step) => step.name === "Start the production collector");
+    const readStep = steps.find((step) => step.name === "Run the deployed release canary");
+    expect(ingestStep?.env?.AXIOM_INGEST_TOKEN).toBe("${{ secrets.AXIOM_INGEST_TOKEN }}");
+    expect(ingestStep?.run).toContain("--require-credential AXIOM_INGEST_TOKEN");
+    expect(readStep?.env?.AXIOM_READ_TOKEN).toBe("${{ secrets.AXIOM_READ_TOKEN }}");
+    expect(readStep?.run).toContain("--require-credential AXIOM_READ_TOKEN");
+    for (const step of steps) {
+      if (step !== ingestStep) expect(step.env?.AXIOM_INGEST_TOKEN).toBeUndefined();
+      if (step !== readStep) expect(step.env?.AXIOM_READ_TOKEN).toBeUndefined();
+      expect(step.env?.NODE_AUTH_TOKEN).toBeUndefined();
+    }
+    expect(workflow.match(/secrets\.NPM_TOKEN/g)).toHaveLength(1);
+    expect(workflow.split("  publish-npm:")[0]).not.toContain("NPM_TOKEN");
+  });
+
+  test("requires and counts the deployed canary test", () => {
+    const canaryStep = parsedReleaseWorkflow.jobs["deployed-canary"].steps?.find(
       (step) => step.name === "Run the deployed release canary",
     );
     expect(canaryStep?.env?.OBSERVABILITY_E2E_DEPLOYED).toBe("1");
@@ -335,35 +306,36 @@ describe("release workflow publication gate", () => {
   });
 
   test("derives the deployed canary service version from its release tag input", () => {
-    expect(parsedCiWorkflow.on.workflow_call.inputs.release_tag).toEqual({
+    expect(parsedCiWorkflow.on.workflow_call.inputs.ref).toEqual({
       required: false,
       type: "string",
     });
-    expect(parsedReleaseWorkflow.jobs.verify.with.release_tag).toBe(
-      "${{ needs.tag-check.outputs.tag }}",
-    );
     expect(parsedReleaseWorkflow.jobs.verify.with.ref).toBe("${{ needs.tag-check.outputs.tag }}");
-    expect(ciWorkflow).toContain("RELEASE_TAG: ${{ inputs.release_tag }}");
-    expect(ciWorkflow).toContain(
+    const steps = parsedReleaseWorkflow.jobs["deployed-canary"].steps ?? [];
+    expect(steps[0]?.with?.ref).toBe("${{ needs.tag-check.outputs.tag }}");
+    expect(
+      steps.find((step) => step.name === "Resolve release canary identity")?.env?.RELEASE_TAG,
+    ).toBe("${{ needs.tag-check.outputs.tag }}");
+    expect(workflow).toContain(
       'bun scripts/release-canary.ts --tag "$RELEASE_TAG" --github-env "$GITHUB_ENV"',
     );
     expect(releaseCanaryScript).toContain("OTEL_SERVICE_VERSION");
-    expect(ciWorkflow).not.toMatch(/serviceVersion: ["']\d+\.\d+\.\d+/);
+    expect(workflow).not.toMatch(/serviceVersion: ["']\d+\.\d+\.\d+/);
   });
 
   test("keeps ordinary CI credential-free and reports the omitted protected gate", () => {
     const reportStep = parsedCiWorkflow.jobs.verify.steps?.find(
       (step) => step.name === "Report deployed canary status",
     );
-    expect(parsedCiWorkflow.jobs["deployed-canary"].if).toBe("${{ inputs.run_deployed_canary }}");
-    expect(reportStep?.if).toBe("${{ !inputs.run_deployed_canary }}");
-    expect(parsedCiWorkflow.jobs["canary-gate"].if).toBe("${{ !cancelled() }}");
+    expect(reportStep?.if).toBeUndefined();
+    expect(reportStep?.run).toContain("runs directly in the Release workflow");
+    expect(Object.keys(parsedCiWorkflow.jobs)).toEqual(["verify"]);
   });
 
   test("keeps the ingest token out of the docker command arguments", () => {
-    expect(ciWorkflow).toContain('export AXIOM_TOKEN="$AXIOM_INGEST_TOKEN"');
-    expect(ciWorkflow).toContain("-e AXIOM_TOKEN \\");
-    expect(ciWorkflow).not.toContain('-e AXIOM_TOKEN="$AXIOM_INGEST_TOKEN"');
+    expect(workflow).toContain('export AXIOM_TOKEN="$AXIOM_INGEST_TOKEN"');
+    expect(workflow).toContain("-e AXIOM_TOKEN \\");
+    expect(workflow).not.toContain('-e AXIOM_TOKEN="$AXIOM_INGEST_TOKEN"');
   });
 
   test("uses release canary identity resolution in preflight", () => {

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equipe-tech/observability",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Nucleo neutro de observabilidade da Equipe Tech para OpenTelemetry, contratos, politicas e ciclo de vida",
   "homepage": "https://github.com/equipe-tech/observability#readme",
   "bugs": {


### PR DESCRIPTION
## Release recovery

The protected run for `observability@0.3.0` failed before Collector startup because the reusable workflow received an empty ingestion secret. The environment contains the secret metadata and required variables. Evidence: https://github.com/equipe-tech/observability/actions/runs/34057980289

- Move the protected deployed canary directly into the Release workflow.
- Keep reusable CI credential-free. Do not introduce `secrets: inherit`.
- Preserve environment approval, separate ingestion/query credentials, exact-tag dispatch confirmation, and fail-closed canary gating before GitHub Release and npm publication.
- Preserve the failed immutable `observability@0.3.0` tag. Prepare only the core at 0.3.1; other package candidates remain 0.3.0.
- Update candidate declarations and regenerate release notes and reproducible archive checksums.

## Checks

- Focused workflow tests passed (18).
- Integrated full suite passed: 617 Vitest tests and 420 Bun tests.
- Formatting, lint, types, packed-consumer smoke, and core 0.3.1 release compatibility passed.
- All candidate archives were regenerated through the repository release scripts.

The real protected canary must pass on the corrected tag before publication. This PR does not remove or bypass that requirement.
