### PR TITLE
fix(release): start the protected Collector reliably

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,18 +89,29 @@ jobs:
           AXIOM_DATASET_LOGS: ${{ vars.AXIOM_DATASET_LOGS }}
           AXIOM_DATASET_METRICS: ${{ vars.AXIOM_DATASET_METRICS }}
         run: |
+          set -euo pipefail
           bun scripts/release-canary.ts --require-credential AXIOM_INGEST_TOKEN
+          trap 'status=$?; if [[ "$status" != 0 ]]; then docker inspect --format "{{json .State}}" otel-production || true; docker logs --tail 100 otel-production || true; fi' EXIT
+          queue_directory="${RUNNER_TEMP:?}/release-canary-queue"
+          sudo install -d -m 0700 -o 10001 -g 10001 "$queue_directory"
           export AXIOM_TOKEN="$AXIOM_INGEST_TOKEN"
           docker run -d --name otel-production \
-            -p 127.0.0.1:24318:4318 \
+            -p 127.0.0.1:24318:4318 -p 127.0.0.1:24319:13133 \
+            -v "$queue_directory:/var/lib/otelcol/queue" \
             -e AXIOM_TOKEN \
             -e AXIOM_DATASET_TRACES -e AXIOM_DATASET_LOGS -e AXIOM_DATASET_METRICS \
             -v "$PWD/packages/cli/src/assets/production.yaml:/etc/otelcol/config.yaml:ro" \
             otel/opentelemetry-collector-contrib:0.159.0 --config=/etc/otelcol/config.yaml
           for _ in $(seq 1 30); do
-            if curl -s -o /dev/null http://127.0.0.1:24318; then break; fi
+            if [[ "$(docker inspect --format '{{.State.Running}}' otel-production)" != "true" ]]; then
+              echo "The production Collector exited before becoming healthy. Review the startup diagnostics."
+              exit 1
+            fi
+            if curl --fail --silent --show-error --connect-timeout 1 --max-time 2 -o /dev/null http://127.0.0.1:24319/health; then exit 0; fi
             sleep 1
           done
+          echo "The production Collector did not become healthy after 30 attempts. Review the startup diagnostics."
+          exit 1
       - name: Run the deployed release canary
         env:
           OBSERVABILITY_E2E_DEPLOYED: "1"
@@ -114,8 +125,14 @@ jobs:
         run: |
           bun scripts/release-canary.ts --require-credential AXIOM_READ_TOKEN
           bun run test:canary:deployed
-      - if: always()
-        run: docker rm -f otel-production 2>/dev/null || true
+      - name: Report failed canary Collector logs
+        if: failure()
+        run: docker logs --tail 100 otel-production 2>&1 || true
+      - name: Clean the production collector
+        if: always()
+        run: |
+          docker rm -f otel-production 2>/dev/null || true
+          sudo rm -rf -- "${RUNNER_TEMP:?}/release-canary-queue"
 
   canary-gate:
     if: ${{ !cancelled() }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## observability@0.3.2
+
+Mudanças desde observability@0.3.1.
+
+### Correções
+
+- fix(release): provision Collector storage and enforce readiness
+
 ## observability@0.3.1
 
 Mudanças desde observability@0.3.0.

--- a/bun.lock
+++ b/bun.lock
@@ -124,7 +124,7 @@
     },
     "packages/telemetry": {
       "name": "@equipe-tech/observability",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "devDependencies": {
         "effect": "4.0.0-rc.111",
       },

--- a/docs/migration-0.3.md
+++ b/docs/migration-0.3.md
@@ -151,4 +151,4 @@ Mantenha o ledger no banco de dados da aplicação. Use `commitAuditRecord` ou `
 
 ## Usar releases independentes
 
-Os pacotes mantêm versões independentes. Esta preparação seleciona `0.3.1` para o núcleo e `0.3.0` para os outros cinco pacotes alterados. A tag inicial do núcleo permanece como registro de uma tentativa sem publicação. A CLI avança de `0.2.1` para `0.3.0` pelas mudanças incompatíveis descritas neste guia. Tags usam `<slug>@<semver>`, por exemplo `observability@0.3.0`, `observability-evlog@0.3.0`, `observability-nestjs@0.3.0` e `observability-cli@0.3.0`. Releases futuras alteram somente os pacotes afetados.
+Os pacotes mantêm versões independentes. Esta preparação seleciona `0.3.2` para o núcleo e `0.3.0` para os outros cinco pacotes alterados. A tag inicial do núcleo permanece como registro de uma tentativa sem publicação. A CLI avança de `0.2.1` para `0.3.0` pelas mudanças incompatíveis descritas neste guia. Tags usam `<slug>@<semver>`, por exemplo `observability@0.3.0`, `observability-evlog@0.3.0`, `observability-nestjs@0.3.0` e `observability-cli@0.3.0`. Releases futuras alteram somente os pacotes afetados.

--- a/docs/releases/observability-cli@0.3.0.md
+++ b/docs/releases/observability-cli@0.3.0.md
@@ -37,7 +37,8 @@
 
 ### Correções
 
-- fix(release): resolve protected secrets in native jobs
+- fix(release): provision Collector storage and enforce readiness
+- fix(release): restore protected canary secret access (#82)
 - fix: resolve stack review findings (#78)
 - fix(cli): accept Axiom default retention payloads (#24)
 - fix(cli): create MetricsDB datasets and correlation gates (#22)

--- a/docs/releases/observability-cli@0.3.0.sha256
+++ b/docs/releases/observability-cli@0.3.0.sha256
@@ -1,1 +1,1 @@
-2239d81f5546f191a29a835794ec5aeca49be57d428ece93a29b41641f023bc6  equipe-tech-observability-cli-0.3.0.tgz
+af6057bbbc5f37ec74adfde00dba776738c8ec7f619ad65012c8ea19a7b0059a  equipe-tech-observability-cli-0.3.0.tgz

--- a/docs/releases/observability-evlog@0.3.0.md
+++ b/docs/releases/observability-evlog@0.3.0.md
@@ -37,7 +37,8 @@
 
 ### Correções
 
-- fix(release): resolve protected secrets in native jobs
+- fix(release): provision Collector storage and enforce readiness
+- fix(release): restore protected canary secret access (#82)
 - fix: resolve stack review findings (#78)
 - fix(cli): accept Axiom default retention payloads (#24)
 - fix(cli): create MetricsDB datasets and correlation gates (#22)

--- a/docs/releases/observability-evlog@0.3.0.sha256
+++ b/docs/releases/observability-evlog@0.3.0.sha256
@@ -1,1 +1,1 @@
-ba326621f128950996e2c1ee01fa7c005ace92f6a7cb8110ce203119b25027eb  equipe-tech-observability-evlog-0.3.0.tgz
+ea1f3a5769c33588c9108ae18c8e8ac078155787041402632e247b87fc1b701b  equipe-tech-observability-evlog-0.3.0.tgz

--- a/docs/releases/observability-nestjs@0.3.0.md
+++ b/docs/releases/observability-nestjs@0.3.0.md
@@ -37,7 +37,8 @@
 
 ### Correções
 
-- fix(release): resolve protected secrets in native jobs
+- fix(release): provision Collector storage and enforce readiness
+- fix(release): restore protected canary secret access (#82)
 - fix: resolve stack review findings (#78)
 - fix(cli): accept Axiom default retention payloads (#24)
 - fix(cli): create MetricsDB datasets and correlation gates (#22)

--- a/docs/releases/observability-nestjs@0.3.0.sha256
+++ b/docs/releases/observability-nestjs@0.3.0.sha256
@@ -1,1 +1,1 @@
-3e416d65d2e29a152b34dc8c1f465aa13b70f6b4dce00078a93451938fbb1381  equipe-tech-observability-nestjs-0.3.0.tgz
+33482401b372c81d98a099945c0af81636fe54fdd0e5425081fd6c9969b51c94  equipe-tech-observability-nestjs-0.3.0.tgz

--- a/docs/releases/observability-react@0.3.0.md
+++ b/docs/releases/observability-react@0.3.0.md
@@ -37,7 +37,8 @@
 
 ### Correções
 
-- fix(release): resolve protected secrets in native jobs
+- fix(release): provision Collector storage and enforce readiness
+- fix(release): restore protected canary secret access (#82)
 - fix: resolve stack review findings (#78)
 - fix(cli): accept Axiom default retention payloads (#24)
 - fix(cli): create MetricsDB datasets and correlation gates (#22)

--- a/docs/releases/observability-react@0.3.0.sha256
+++ b/docs/releases/observability-react@0.3.0.sha256
@@ -1,1 +1,1 @@
-e51d523b59f2e8ef1db3cbc621fa38a7d98966311e92d11810982f34c6c85cba  equipe-tech-observability-react-0.3.0.tgz
+6f7a41ff413b92721f6b7de47217ba0dc779c88035848f2546225216deac4d2c  equipe-tech-observability-react-0.3.0.tgz

--- a/docs/releases/observability-sentry@0.3.0.md
+++ b/docs/releases/observability-sentry@0.3.0.md
@@ -37,7 +37,8 @@
 
 ### Correções
 
-- fix(release): resolve protected secrets in native jobs
+- fix(release): provision Collector storage and enforce readiness
+- fix(release): restore protected canary secret access (#82)
 - fix: resolve stack review findings (#78)
 - fix(cli): accept Axiom default retention payloads (#24)
 - fix(cli): create MetricsDB datasets and correlation gates (#22)

--- a/docs/releases/observability-sentry@0.3.0.sha256
+++ b/docs/releases/observability-sentry@0.3.0.sha256
@@ -1,1 +1,1 @@
-970cd131590dbdefcbf27055b7d2452a1412870ad6c8ca317f2cf0044d480a3a  equipe-tech-observability-sentry-0.3.0.tgz
+daa8697eba127b9ca91e4379411dbe809b055c4b878663b7252ed2b9b938f090  equipe-tech-observability-sentry-0.3.0.tgz

--- a/docs/releases/observability@0.3.2.md
+++ b/docs/releases/observability@0.3.2.md
@@ -1,0 +1,7 @@
+## observability@0.3.2
+
+Mudanças desde observability@0.3.1.
+
+### Correções
+
+- fix(release): provision Collector storage and enforce readiness

--- a/docs/releases/observability@0.3.2.sha256
+++ b/docs/releases/observability@0.3.2.sha256
@@ -1,0 +1,1 @@
+64414575af822f31f1908b7c2274dce1ab735fa81e8927f007cea3211d46884c  equipe-tech-observability-0.3.2.tgz

--- a/docs/releases/preparation-0.3.md
+++ b/docs/releases/preparation-0.3.md
@@ -4,7 +4,7 @@ Esta preparação cobre os seis pacotes alterados pelo stack. Cada pacote manté
 
 | Pacote                              | Versão candidata | Motivo                                                                 |
 | ----------------------------------- | ---------------- | ---------------------------------------------------------------------- |
-| `@equipe-tech/observability`        | `0.3.1`          | Contratos tipados, identidade canônica, política, métricas e auditoria |
+| `@equipe-tech/observability`        | `0.3.2`          | Contratos tipados, identidade canônica, política, métricas e auditoria |
 | `@equipe-tech/observability-evlog`  | `0.3.0`          | Primeiro release do adapter oficial de eventos                         |
 | `@equipe-tech/observability-nestjs` | `0.3.0`          | Primeiro release da integração extraída do núcleo                      |
 | `@equipe-tech/observability-sentry` | `0.3.0`          | Primeiro release dos adapters de defeitos Node e browser               |
@@ -23,7 +23,7 @@ Leia [o guia de migração](../migration-0.3.md) antes da atualização. Leia [o
 
 Publique o núcleo antes dos adapters e da CLI, pois os consumidores precisam resolver o peer `@equipe-tech/observability@0.3.x`.
 
-Execute `Release Preflight` para cada pacote na revisão aprovada. Crie somente tags independentes, como `observability@0.3.1`, depois do preflight.
+Execute `Release Preflight` para cada pacote na revisão aprovada. Crie somente tags independentes, como `observability@0.3.2`, depois do preflight.
 
 Mantenha a aprovação humana do environment `publication`. O push da tag solicita somente a verificação protegida. A publicação exige outro `workflow_dispatch`, com `tag` e `confirm_tag` idênticos.
 
@@ -31,7 +31,9 @@ Mantenha a aprovação humana do environment `publication`. O push da tag solici
 
 A tag `observability@0.3.0` registra uma tentativa sem publicação no npm. O canário protegido falhou ao resolver o secret de ingestão no workflow reutilizável. Preserve essa tag para diagnóstico.
 
-A recuperação usa `observability@0.3.1` e executa o job protegido diretamente no workflow de release. Os outros cinco pacotes mantêm `0.3.0`, pois suas tags ainda não foram criadas.
+A tentativa `observability@0.3.1` resolveu os secrets no job direto, mas o Collector encerrou por falta de permissão no diretório da fila. Preserve também essa tag sem publicação.
+
+A recuperação usa `observability@0.3.2`, com armazenamento gravável pelo usuário do Collector e prontidão verificada pelo endpoint de saúde. Os outros cinco pacotes mantêm `0.3.0`, pois suas tags ainda não foram criadas.
 
 Os cadastros dos dois secrets Axiom e das cinco variables existem no environment `publication`. As regras permitem as tags dos seis slugs. O `NPM_TOKEN` existe no escopo do repositório.
 

--- a/observability/compatibility/candidate-versions.json
+++ b/observability/compatibility/candidate-versions.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "packages": [
-    { "name": "@equipe-tech/observability", "version": "0.3.1" },
+    { "name": "@equipe-tech/observability", "version": "0.3.2" },
     { "name": "@equipe-tech/observability-cli", "version": "0.3.0" },
     { "name": "@equipe-tech/observability-evlog", "version": "0.3.0" },
     { "name": "@equipe-tech/observability-nestjs", "version": "0.3.0" },

--- a/observability/compatibility/declared-breaks.json
+++ b/observability/compatibility/declared-breaks.json
@@ -6,7 +6,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_DEPENDENCY_REMOVED",
       "path": "dependencies/effect@4.0.0-rc.111",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -14,7 +14,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_DEPENDENCY_CATEGORY_CHANGED",
       "path": "dependencies/effect",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -22,7 +22,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_EXPORT_CONDITION_REMOVED",
       "path": "exportConditions/./nestjs:import:./dist/nestjs/index.js",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -30,7 +30,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_EXPORT_CONDITION_REMOVED",
       "path": "exportConditions/./nestjs:types:./dist/nestjs/index.d.ts",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -38,7 +38,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_EXPORT_REMOVED",
       "path": "exports/./nestjs",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -46,7 +46,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_PEER_CHANGED",
       "path": "peerDependencies/@nestjs/common@^10.0.0 || ^11.0.0",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -54,7 +54,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_PEER_CHANGED",
       "path": "peerDependencies/@nestjs/core@^10.0.0 || ^11.0.0",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -62,7 +62,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_PEER_CHANGED",
       "path": "peerDependencies/rxjs@^7.2.0",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -70,7 +70,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_PEER_OPTIONALITY_CHANGED",
       "path": "peerDependenciesMeta",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -78,7 +78,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_RUNTIME_ENTRYPOINT_MISSING",
       "path": "runtime/./nestjs",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -86,7 +86,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_ERROR_CODE_REMOVED",
       "path": "publicErrorCodes/OBS_TELEMETRY_INVALID_MODULE_OPTIONS",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -94,7 +94,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_ERROR_CODE_REMOVED",
       "path": "publicErrorCodes/OBS_TELEMETRY_SHUTDOWN_FAILED",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -102,7 +102,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_ERROR_CODE_REMOVED",
       "path": "publicErrorCodes/OBS_TELEMETRY_STARTUP_FAILED",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -110,7 +110,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/.:WideEvent",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -118,7 +118,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:BrowserEventsControllerOptions",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -126,7 +126,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:BrowserEventsRejection",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -134,7 +134,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:createBrowserEventsController",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -142,7 +142,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:createRequestWideEventTraceCorrelation",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -150,7 +150,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:defaultBrowserEventsPath",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -158,7 +158,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:InvalidTelemetryModuleOptions",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -166,7 +166,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:ProxyPolicy",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -174,7 +174,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:RequestReference",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -182,7 +182,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:requestSpan",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -190,7 +190,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:RequestWideEventLogger",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -198,7 +198,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:RequestWideEventLoggerResolver",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -206,7 +206,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:RequestWideEventTraceCorrelation",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -214,7 +214,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:ServerSpanCorrelation",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -222,7 +222,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryInterceptor",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -230,7 +230,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryInterceptorOptions",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -238,7 +238,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryModuleAsyncOptions",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -246,7 +246,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryModule",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -254,7 +254,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryModuleOptions",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -262,7 +262,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:telemetryModuleForTesting",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -270,7 +270,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryModuleTestingOverrides",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -278,7 +278,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryRequestTracker",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -286,7 +286,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryRoutePolicyOptions",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -294,7 +294,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryShutdownError",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -302,7 +302,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryStartupError",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -310,7 +310,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:withRequestSpan",
-      "candidateVersion": "0.3.1",
+      "candidateVersion": "0.3.2",
       "migrationGuide": "docs/migration-0.3.md"
     }
   ]

--- a/packages/cli/test/ReleaseWorkflow.bun.test.ts
+++ b/packages/cli/test/ReleaseWorkflow.bun.test.ts
@@ -332,6 +332,113 @@ describe("release workflow publication gate", () => {
     expect(Object.keys(parsedCiWorkflow.jobs)).toEqual(["verify"]);
   });
 
+  test("mounts a private writable queue without running the Collector as root", () => {
+    const start = parsedReleaseWorkflow.jobs["deployed-canary"].steps?.find(
+      (step) => step.name === "Start the production collector",
+    )?.run;
+    expect(start).toContain('queue_directory="${RUNNER_TEMP:?}/release-canary-queue"');
+    expect(start).toContain('sudo install -d -m 0700 -o 10001 -g 10001 "$queue_directory"');
+    expect(start).toContain('-v "$queue_directory:/var/lib/otelcol/queue"');
+    expect(start).toContain("-p 127.0.0.1:24319:13133");
+    expect(start).not.toContain("--user");
+    expect(start).not.toContain("sudo docker");
+    expect(start).not.toContain("--privileged");
+  });
+
+  test("requires health success and diagnoses exited or unready Collectors", async () => {
+    const start = parsedReleaseWorkflow.jobs["deployed-canary"].steps?.find(
+      (step) => step.name === "Start the production collector",
+    )?.run;
+    if (start === undefined) throw new Error("The Collector startup script is missing.");
+    const commands = `
+      bun() { return 0; }
+      sudo() { printf '%s\\n' "sudo $*" >&2; }
+      sleep() { return 0; }
+      docker() {
+        printf '%s\\n' "docker $*" >&2
+        case "$1" in
+          run) [[ "$STARTUP_CASE" != "run-failed" ]] ;;
+          inspect)
+            if [[ "$3" == '{{.State.Running}}' ]]; then
+              [[ "$STARTUP_CASE" != "exited" ]] && echo true || echo false
+            else
+              echo 'startup state'
+            fi ;;
+          logs) echo 'startup logs' ;;
+        esac
+      }
+      curl() {
+        printf '%s\\n' "curl $*" >&2
+        [[ "$*" == '--fail --silent --show-error --connect-timeout 1 --max-time 2 -o /dev/null http://127.0.0.1:24319/health' ]] || return 2
+        [[ "$STARTUP_CASE" == "healthy" ]]
+      }
+    `;
+    for (const scenario of ["healthy", "exited", "timeout", "run-failed"]) {
+      const result = await executeShell(`${commands}\n${start}`, {
+        STARTUP_CASE: scenario,
+        RUNNER_TEMP: "/runner temp",
+        AXIOM_INGEST_TOKEN: "ingest-test",
+      });
+      expect(result.exitCode).toBe(scenario === "healthy" ? 0 : 1);
+      expect(result.stderr).toContain(
+        "sudo install -d -m 0700 -o 10001 -g 10001 /runner temp/release-canary-queue",
+      );
+      expect(result.stderr).toContain(
+        "-v /runner temp/release-canary-queue:/var/lib/otelcol/queue",
+      );
+      const attempts = result.stderr.match(/curl --fail/g) ?? [];
+      expect(attempts).toHaveLength(scenario === "healthy" ? 1 : scenario === "timeout" ? 30 : 0);
+      if (scenario === "healthy") {
+        expect(result.stderr).not.toContain("docker logs");
+      } else {
+        expect(result.stderr).toContain("docker inspect --format {{json .State}} otel-production");
+        expect(result.stderr).toContain("docker logs --tail 100 otel-production");
+        expect(result.stdout).toContain("startup logs");
+      }
+      if (scenario === "exited") expect(result.stdout).toContain("exited before becoming healthy");
+      if (scenario === "timeout") expect(result.stdout).toContain("after 30 attempts");
+      expect(result.stderr).not.toContain("ingest-test");
+    }
+  });
+
+  test("preserves Collector diagnostics before cleaning a failed canary", () => {
+    const steps = parsedReleaseWorkflow.jobs["deployed-canary"].steps ?? [];
+    const canaryIndex = steps.findIndex((step) => step.name === "Run the deployed release canary");
+    const logsIndex = steps.findIndex(
+      (step) => step.name === "Report failed canary Collector logs",
+    );
+    const cleanupIndex = steps.findIndex((step) => step.name === "Clean the production collector");
+    expect(logsIndex).toBeGreaterThan(canaryIndex);
+    expect(cleanupIndex).toBeGreaterThan(logsIndex);
+    expect(steps[logsIndex]?.if).toBe("failure()");
+    expect(steps[logsIndex]?.run).toBe("docker logs --tail 100 otel-production 2>&1 || true");
+    expect(steps[logsIndex]?.env).toBeUndefined();
+  });
+
+  test("always cleans only its Collector and queue even if container removal fails", async () => {
+    const cleanup = parsedReleaseWorkflow.jobs["deployed-canary"].steps?.find(
+      (step) => step.name === "Clean the production collector",
+    );
+    expect(cleanup?.if).toBe("always()");
+    if (cleanup?.run === undefined) throw new Error("The Collector cleanup script is missing.");
+    const commands = `
+      docker() { printf '%s\\n' "docker $*"; return 1; }
+      sudo() { printf '%s\\n' "sudo $*"; }
+    `;
+    const result = await executeShell(`${commands}\n${cleanup.run}`, {
+      RUNNER_TEMP: "/runner temp",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe(
+      "docker rm -f otel-production\nsudo rm -rf -- /runner temp/release-canary-queue\n",
+    );
+    const missingTemp = await executeShell(`${commands}\n${cleanup.run}`, {
+      RUNNER_TEMP: undefined,
+    });
+    expect(missingTemp.exitCode).not.toBe(0);
+    expect(missingTemp.stdout).not.toContain("sudo rm");
+  });
+
   test("keeps the ingest token out of the docker command arguments", () => {
     expect(workflow).toContain('export AXIOM_TOKEN="$AXIOM_INGEST_TOKEN"');
     expect(workflow).toContain("-e AXIOM_TOKEN \\");

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equipe-tech/observability",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Nucleo neutro de observabilidade da Equipe Tech para OpenTelemetry, contratos, politicas e ciclo de vida",
   "homepage": "https://github.com/equipe-tech/observability#readme",
   "bugs": {


### PR DESCRIPTION
## Release recovery

The protected `observability@0.3.1` run resolved both Axiom secrets, then failed because the Collector could not create its file-storage queue. Local Docker reproduced `mkdir /var: permission denied` with the exact production asset and non-root image.

- Provide an isolated queue directory owned by the pinned Collector user (10001:10001).
- Keep the Collector non-root and mount its queue read-write.
- Require HTTP 200 from `/health`, bound readiness attempts, and fail immediately if the container exits.
- Retain bounded diagnostics before cleanup and remove only owned resources.
- Preserve immutable failed tags. Prepare core 0.3.2 and regenerate all release candidate notes/checksums.

## Verification

- Real Docker before/after proof: startup failure before; non-root Collector running and health HTTP 200 after. Dummy token only, no telemetry emitted.
- 22 focused workflow tests passed.
- Full suite: 617 Vitest tests and 424 Bun tests passed.
- Formatting, lint, types, packed consumers, and core release compatibility passed.

The real Axiom canary remains mandatory before publishing any package. Failed run evidence: https://github.com/equipe-tech/observability/actions/runs/34059272429
