### PR TITLE
fix(release): query the configured Axiom region correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## observability@0.3.3
+
+Mudanças desde observability@0.3.2.
+
+### Correções
+
+- fix(release): query Axiom edge through the regional APL route
+
 ## observability@0.3.2
 
 Mudanças desde observability@0.3.1.

--- a/bun.lock
+++ b/bun.lock
@@ -124,7 +124,7 @@
     },
     "packages/telemetry": {
       "name": "@equipe-tech/observability",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "devDependencies": {
         "effect": "4.0.0-rc.111",
       },

--- a/docs/migration-0.3.md
+++ b/docs/migration-0.3.md
@@ -151,4 +151,4 @@ Mantenha o ledger no banco de dados da aplicação. Use `commitAuditRecord` ou `
 
 ## Usar releases independentes
 
-Os pacotes mantêm versões independentes. Esta preparação seleciona `0.3.2` para o núcleo e `0.3.0` para os outros cinco pacotes alterados. A tag inicial do núcleo permanece como registro de uma tentativa sem publicação. A CLI avança de `0.2.1` para `0.3.0` pelas mudanças incompatíveis descritas neste guia. Tags usam `<slug>@<semver>`, por exemplo `observability@0.3.0`, `observability-evlog@0.3.0`, `observability-nestjs@0.3.0` e `observability-cli@0.3.0`. Releases futuras alteram somente os pacotes afetados.
+Os pacotes mantêm versões independentes. Esta preparação seleciona `0.3.3` para o núcleo e `0.3.0` para os outros cinco pacotes alterados. A tag inicial do núcleo permanece como registro de uma tentativa sem publicação. A CLI avança de `0.2.1` para `0.3.0` pelas mudanças incompatíveis descritas neste guia. Tags usam `<slug>@<semver>`, por exemplo `observability@0.3.0`, `observability-evlog@0.3.0`, `observability-nestjs@0.3.0` e `observability-cli@0.3.0`. Releases futuras alteram somente os pacotes afetados.

--- a/docs/release-publication-runbook.md
+++ b/docs/release-publication-runbook.md
@@ -48,6 +48,8 @@ A verificação de release executa o canário implantado antes de criar a GitHub
 
 `AXIOM_ORGANIZATION_ID`, `AXIOM_URL`, `AXIOM_DATASET_TRACES`, `AXIOM_DATASET_LOGS` e `AXIOM_DATASET_METRICS` são variables do environment. `AXIOM_URL` aponta para a API regional da organização. Nenhum token administrativo entra no job.
 
+O canário usa `/v1/query/_apl` nos domínios regionais `*.edge.axiom.co` e mantém `/v1/datasets/_apl` na API global. Os domínios regionais não oferecem a rota global. Ambas as consultas APL solicitam o formato `legacy` esperado pelo parser do teste.
+
 O script `scripts/release-canary.ts` resolve o tag para o manifest correspondente e define `OTEL_SERVICE_VERSION` com a versão desse manifest. O step do Collector recebe somente `AXIOM_INGEST_TOKEN`. O step de consulta recebe somente `AXIOM_READ_TOKEN`. O canário consulta traces, logs e métricas usando a versão e os valores de correlação da execução. A ausência de qualquer secret encerra o gate com `OBS_RELEASE_CANARY_CREDENTIALS_MISSING`. CI comum permanece sem credenciais e informa que o gate protegido pertence ao workflow de release.
 
 O orçamento de visibilidade reserva 200 ms para o `flush_timeout` do Collector e 180.000 ms para `axiomQueryVisibilityMilliseconds`. A [documentação pública de ingestão do Axiom](https://axiom.co/docs/send-data/) não publica um limite de latência entre ingestão e consulta. Por isso, os 180 segundos são uma tolerância operacional explícita, não uma garantia do provedor. O teste exige que o intervalo total de polling cubra esses dois campos e informa a margem derivada. Com os valores atuais, o intervalo de 192.000 ms deixa uma margem de 11.800 ms.

--- a/docs/releases/observability-cli@0.3.0.md
+++ b/docs/releases/observability-cli@0.3.0.md
@@ -37,7 +37,8 @@
 
 ### Correções
 
-- fix(release): provision Collector storage and enforce readiness
+- fix(release): query Axiom edge through the regional APL route
+- fix(release): start the protected Collector reliably (#83)
 - fix(release): restore protected canary secret access (#82)
 - fix: resolve stack review findings (#78)
 - fix(cli): accept Axiom default retention payloads (#24)

--- a/docs/releases/observability-cli@0.3.0.sha256
+++ b/docs/releases/observability-cli@0.3.0.sha256
@@ -1,1 +1,1 @@
-af6057bbbc5f37ec74adfde00dba776738c8ec7f619ad65012c8ea19a7b0059a  equipe-tech-observability-cli-0.3.0.tgz
+bcc190676f0e72900beea9ef22adb8acffd708829821f4c8d26099088a8f4028  equipe-tech-observability-cli-0.3.0.tgz

--- a/docs/releases/observability-evlog@0.3.0.md
+++ b/docs/releases/observability-evlog@0.3.0.md
@@ -37,7 +37,8 @@
 
 ### Correções
 
-- fix(release): provision Collector storage and enforce readiness
+- fix(release): query Axiom edge through the regional APL route
+- fix(release): start the protected Collector reliably (#83)
 - fix(release): restore protected canary secret access (#82)
 - fix: resolve stack review findings (#78)
 - fix(cli): accept Axiom default retention payloads (#24)

--- a/docs/releases/observability-evlog@0.3.0.sha256
+++ b/docs/releases/observability-evlog@0.3.0.sha256
@@ -1,1 +1,1 @@
-ea1f3a5769c33588c9108ae18c8e8ac078155787041402632e247b87fc1b701b  equipe-tech-observability-evlog-0.3.0.tgz
+d9a2c8d9c14d76e0343bac05fcf95b2e829c095e6cab6d0bd7b872b815c7f2d8  equipe-tech-observability-evlog-0.3.0.tgz

--- a/docs/releases/observability-nestjs@0.3.0.md
+++ b/docs/releases/observability-nestjs@0.3.0.md
@@ -37,7 +37,8 @@
 
 ### Correções
 
-- fix(release): provision Collector storage and enforce readiness
+- fix(release): query Axiom edge through the regional APL route
+- fix(release): start the protected Collector reliably (#83)
 - fix(release): restore protected canary secret access (#82)
 - fix: resolve stack review findings (#78)
 - fix(cli): accept Axiom default retention payloads (#24)

--- a/docs/releases/observability-nestjs@0.3.0.sha256
+++ b/docs/releases/observability-nestjs@0.3.0.sha256
@@ -1,1 +1,1 @@
-33482401b372c81d98a099945c0af81636fe54fdd0e5425081fd6c9969b51c94  equipe-tech-observability-nestjs-0.3.0.tgz
+9dbf8b42fa4320a2c7d18990a422395bbebca11efe47feef8f5cd23cedbaee64  equipe-tech-observability-nestjs-0.3.0.tgz

--- a/docs/releases/observability-react@0.3.0.md
+++ b/docs/releases/observability-react@0.3.0.md
@@ -37,7 +37,8 @@
 
 ### Correções
 
-- fix(release): provision Collector storage and enforce readiness
+- fix(release): query Axiom edge through the regional APL route
+- fix(release): start the protected Collector reliably (#83)
 - fix(release): restore protected canary secret access (#82)
 - fix: resolve stack review findings (#78)
 - fix(cli): accept Axiom default retention payloads (#24)

--- a/docs/releases/observability-react@0.3.0.sha256
+++ b/docs/releases/observability-react@0.3.0.sha256
@@ -1,1 +1,1 @@
-6f7a41ff413b92721f6b7de47217ba0dc779c88035848f2546225216deac4d2c  equipe-tech-observability-react-0.3.0.tgz
+5fc5e22346c7e253812eb144f5908ccb530095e7792f13a89c6738377afa09f1  equipe-tech-observability-react-0.3.0.tgz

--- a/docs/releases/observability-sentry@0.3.0.md
+++ b/docs/releases/observability-sentry@0.3.0.md
@@ -37,7 +37,8 @@
 
 ### Correções
 
-- fix(release): provision Collector storage and enforce readiness
+- fix(release): query Axiom edge through the regional APL route
+- fix(release): start the protected Collector reliably (#83)
 - fix(release): restore protected canary secret access (#82)
 - fix: resolve stack review findings (#78)
 - fix(cli): accept Axiom default retention payloads (#24)

--- a/docs/releases/observability-sentry@0.3.0.sha256
+++ b/docs/releases/observability-sentry@0.3.0.sha256
@@ -1,1 +1,1 @@
-daa8697eba127b9ca91e4379411dbe809b055c4b878663b7252ed2b9b938f090  equipe-tech-observability-sentry-0.3.0.tgz
+9c9b54d13a2307af8d518647cfcd02e8c539bed5b806cc8a388089e9743f3972  equipe-tech-observability-sentry-0.3.0.tgz

--- a/docs/releases/observability@0.3.3.md
+++ b/docs/releases/observability@0.3.3.md
@@ -1,0 +1,7 @@
+## observability@0.3.3
+
+Mudanças desde observability@0.3.2.
+
+### Correções
+
+- fix(release): query Axiom edge through the regional APL route

--- a/docs/releases/observability@0.3.3.sha256
+++ b/docs/releases/observability@0.3.3.sha256
@@ -1,0 +1,1 @@
+5311b5df1c5575d2e37c88b0f2892b7e703080c52f992f549ce276204364fb16  equipe-tech-observability-0.3.3.tgz

--- a/docs/releases/preparation-0.3.md
+++ b/docs/releases/preparation-0.3.md
@@ -4,7 +4,7 @@ Esta preparação cobre os seis pacotes alterados pelo stack. Cada pacote manté
 
 | Pacote                              | Versão candidata | Motivo                                                                 |
 | ----------------------------------- | ---------------- | ---------------------------------------------------------------------- |
-| `@equipe-tech/observability`        | `0.3.2`          | Contratos tipados, identidade canônica, política, métricas e auditoria |
+| `@equipe-tech/observability`        | `0.3.3`          | Contratos tipados, identidade canônica, política, métricas e auditoria |
 | `@equipe-tech/observability-evlog`  | `0.3.0`          | Primeiro release do adapter oficial de eventos                         |
 | `@equipe-tech/observability-nestjs` | `0.3.0`          | Primeiro release da integração extraída do núcleo                      |
 | `@equipe-tech/observability-sentry` | `0.3.0`          | Primeiro release dos adapters de defeitos Node e browser               |
@@ -23,7 +23,7 @@ Leia [o guia de migração](../migration-0.3.md) antes da atualização. Leia [o
 
 Publique o núcleo antes dos adapters e da CLI, pois os consumidores precisam resolver o peer `@equipe-tech/observability@0.3.x`.
 
-Execute `Release Preflight` para cada pacote na revisão aprovada. Crie somente tags independentes, como `observability@0.3.2`, depois do preflight.
+Execute `Release Preflight` para cada pacote na revisão aprovada. Crie somente tags independentes, como `observability@0.3.3`, depois do preflight.
 
 Mantenha a aprovação humana do environment `publication`. O push da tag solicita somente a verificação protegida. A publicação exige outro `workflow_dispatch`, com `tag` e `confirm_tag` idênticos.
 
@@ -33,7 +33,9 @@ A tag `observability@0.3.0` registra uma tentativa sem publicação no npm. O ca
 
 A tentativa `observability@0.3.1` resolveu os secrets no job direto, mas o Collector encerrou por falta de permissão no diretório da fila. Preserve também essa tag sem publicação.
 
-A recuperação usa `observability@0.3.2`, com armazenamento gravável pelo usuário do Collector e prontidão verificada pelo endpoint de saúde. Os outros cinco pacotes mantêm `0.3.0`, pois suas tags ainda não foram criadas.
+A tentativa `observability@0.3.2` iniciou o Collector, mas a consulta APL usou uma rota global indisponível no endpoint regional.
+
+A recuperação usa `observability@0.3.3`, com armazenamento gravável, prontidão verificada e seleção da rota APL correspondente ao domínio configurado. Os outros cinco pacotes mantêm `0.3.0`, pois suas tags ainda não foram criadas.
 
 Os cadastros dos dois secrets Axiom e das cinco variables existem no environment `publication`. As regras permitem as tags dos seis slugs. O `NPM_TOKEN` existe no escopo do repositório.
 

--- a/observability/compatibility/candidate-versions.json
+++ b/observability/compatibility/candidate-versions.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "packages": [
-    { "name": "@equipe-tech/observability", "version": "0.3.2" },
+    { "name": "@equipe-tech/observability", "version": "0.3.3" },
     { "name": "@equipe-tech/observability-cli", "version": "0.3.0" },
     { "name": "@equipe-tech/observability-evlog", "version": "0.3.0" },
     { "name": "@equipe-tech/observability-nestjs", "version": "0.3.0" },

--- a/observability/compatibility/declared-breaks.json
+++ b/observability/compatibility/declared-breaks.json
@@ -6,7 +6,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_DEPENDENCY_REMOVED",
       "path": "dependencies/effect@4.0.0-rc.111",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -14,7 +14,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_DEPENDENCY_CATEGORY_CHANGED",
       "path": "dependencies/effect",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -22,7 +22,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_EXPORT_CONDITION_REMOVED",
       "path": "exportConditions/./nestjs:import:./dist/nestjs/index.js",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -30,7 +30,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_EXPORT_CONDITION_REMOVED",
       "path": "exportConditions/./nestjs:types:./dist/nestjs/index.d.ts",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -38,7 +38,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_EXPORT_REMOVED",
       "path": "exports/./nestjs",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -46,7 +46,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_PEER_CHANGED",
       "path": "peerDependencies/@nestjs/common@^10.0.0 || ^11.0.0",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -54,7 +54,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_PEER_CHANGED",
       "path": "peerDependencies/@nestjs/core@^10.0.0 || ^11.0.0",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -62,7 +62,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_PEER_CHANGED",
       "path": "peerDependencies/rxjs@^7.2.0",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -70,7 +70,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_PEER_OPTIONALITY_CHANGED",
       "path": "peerDependenciesMeta",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -78,7 +78,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_RUNTIME_ENTRYPOINT_MISSING",
       "path": "runtime/./nestjs",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -86,7 +86,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_ERROR_CODE_REMOVED",
       "path": "publicErrorCodes/OBS_TELEMETRY_INVALID_MODULE_OPTIONS",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -94,7 +94,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_ERROR_CODE_REMOVED",
       "path": "publicErrorCodes/OBS_TELEMETRY_SHUTDOWN_FAILED",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -102,7 +102,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_ERROR_CODE_REMOVED",
       "path": "publicErrorCodes/OBS_TELEMETRY_STARTUP_FAILED",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -110,7 +110,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/.:WideEvent",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -118,7 +118,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:BrowserEventsControllerOptions",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -126,7 +126,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:BrowserEventsRejection",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -134,7 +134,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:createBrowserEventsController",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -142,7 +142,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:createRequestWideEventTraceCorrelation",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -150,7 +150,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:defaultBrowserEventsPath",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -158,7 +158,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:InvalidTelemetryModuleOptions",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -166,7 +166,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:ProxyPolicy",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -174,7 +174,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:RequestReference",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -182,7 +182,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:requestSpan",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -190,7 +190,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:RequestWideEventLogger",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -198,7 +198,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:RequestWideEventLoggerResolver",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -206,7 +206,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:RequestWideEventTraceCorrelation",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -214,7 +214,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:ServerSpanCorrelation",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -222,7 +222,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryInterceptor",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -230,7 +230,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryInterceptorOptions",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -238,7 +238,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryModuleAsyncOptions",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -246,7 +246,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryModule",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -254,7 +254,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryModuleOptions",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -262,7 +262,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:telemetryModuleForTesting",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -270,7 +270,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryModuleTestingOverrides",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -278,7 +278,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryRequestTracker",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -286,7 +286,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryRoutePolicyOptions",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -294,7 +294,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryShutdownError",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -302,7 +302,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryStartupError",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -310,7 +310,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:withRequestSpan",
-      "candidateVersion": "0.3.2",
+      "candidateVersion": "0.3.3",
       "migrationGuide": "docs/migration-0.3.md"
     }
   ]

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equipe-tech/observability",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Nucleo neutro de observabilidade da Equipe Tech para OpenTelemetry, contratos, politicas e ciclo de vida",
   "homepage": "https://github.com/equipe-tech/observability#readme",
   "bugs": {

--- a/packages/telemetry/test/axiomSupport.test.ts
+++ b/packages/telemetry/test/axiomSupport.test.ts
@@ -3,6 +3,7 @@ import { Effect, Option, Schema } from "effect";
 import { readFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import {
+  axiomAplQueryUrl,
   axiomServiceResourceFields,
   decodeAxiomEnvironment,
   findChildSpan,
@@ -139,6 +140,23 @@ const startStubAxiom = (
   });
 
 describe("axiom query support", () => {
+  it("selects the regional APL route while preserving the global API and response format", () => {
+    for (const base of [
+      "https://us-east-1.aws.edge.axiom.co",
+      "https://eu-central-1.aws.edge.axiom.co/",
+    ]) {
+      const url = axiomAplQueryUrl(base);
+      assert.strictEqual(url.origin, new URL(base).origin);
+      assert.strictEqual(url.pathname, "/v1/query/_apl");
+      assert.strictEqual(url.searchParams.get("format"), "legacy");
+    }
+    for (const base of ["https://api.axiom.co", "http://127.0.0.1:4318/"]) {
+      const url = axiomAplQueryUrl(base);
+      assert.strictEqual(url.origin, new URL(base).origin);
+      assert.strictEqual(url.pathname, "/v1/datasets/_apl");
+      assert.strictEqual(url.searchParams.get("format"), "legacy");
+    }
+  });
   it.live("queries root spans with the run id and decodes the projected row", () =>
     Effect.gen(function* () {
       const stub = yield* Effect.promise(() =>

--- a/packages/telemetry/test/support/axiom.ts
+++ b/packages/telemetry/test/support/axiom.ts
@@ -38,6 +38,12 @@ const noopQueryObserver: AxiomQueryObserver = () => Effect.void;
 const defaultQueryTimeoutMilliseconds = 10_000;
 const summarizeResponse = (payload: string): string => payload.slice(0, 500);
 
+export const axiomAplQueryUrl = (baseUrl: string): URL => {
+  const base = new URL(baseUrl);
+  const path = base.hostname.endsWith(".edge.axiom.co") ? "/v1/query/_apl" : "/v1/datasets/_apl";
+  return new URL(`${path}?format=legacy`, base);
+};
+
 const runQuery = (
   env: AxiomEnvironment,
   apl: string,
@@ -45,7 +51,7 @@ const runQuery = (
 ): Effect.Effect<ReadonlyArray<unknown>> =>
   Effect.gen(function* () {
     const response = yield* Effect.promise((signal) =>
-      fetch(`${env.AXIOM_URL}/v1/datasets/_apl?format=legacy`, {
+      fetch(axiomAplQueryUrl(env.AXIOM_URL), {
         method: "POST",
         headers: {
           authorization: `Bearer ${env.AXIOM_READ_TOKEN}`,


### PR DESCRIPTION
## Recovery

The protected 0.3.2 canary reached Axiom and failed with HTTP 404 because regional domains do not serve `/v1/datasets/_apl`.

Select `/v1/query/_apl` for `*.edge.axiom.co`, preserve the global API route and legacy response format, and add routing regression coverage. This matches the documented edge endpoint: https://axiom.co/docs/restapi/endpoints/queryEdge

Preserve failed immutable tags and prepare core 0.3.3. Regenerate candidate metadata, notes, and checksums. Other packages remain 0.3.0.

Checks: full local suite (618 Vitest, 424 Bun), formatting/lint/types, packed consumers, and exact core release compatibility passed. The protected Axiom canary remains mandatory.

Failed run: https://github.com/equipe-tech/observability/actions/runs/34060403447