### PR TITLE
fix(release): validate protected canary before tagging

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -23,8 +23,13 @@ jobs:
   readiness:
     runs-on: ubuntu-latest
     steps:
+      - name: Require the default branch
+        env:
+          EVENT_REF: ${{ github.ref }}
+        run: test "$EVENT_REF" = "refs/heads/master"
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.sha }}
           fetch-depth: 0
       - uses: oven-sh/setup-bun@v2
         with:
@@ -51,3 +56,94 @@ jobs:
           (cd "$output" && sha256sum --check "$SLUG@$VERSION.sha256")
           bun run test:package
           bun scripts/npm-publication-state.ts "$RELEASE_PACKAGE_NAME" "$VERSION"
+
+  deployed-canary:
+    if: github.ref == 'refs/heads/master'
+    needs: [readiness]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: publication
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.4.0
+      - run: bun install --frozen-lockfile
+      - name: Resolve release canary identity
+        env:
+          RELEASE_TAG: ${{ format('{0}@{1}', inputs.package, inputs.version) }}
+        run: bun scripts/release-canary.ts --tag "$RELEASE_TAG" --github-env "$GITHUB_ENV"
+      - name: Start the production collector
+        env:
+          AXIOM_INGEST_TOKEN: ${{ secrets.AXIOM_INGEST_TOKEN }}
+          AXIOM_DATASET_TRACES: ${{ vars.AXIOM_DATASET_TRACES }}
+          AXIOM_DATASET_LOGS: ${{ vars.AXIOM_DATASET_LOGS }}
+          AXIOM_DATASET_METRICS: ${{ vars.AXIOM_DATASET_METRICS }}
+        run: |
+          set -euo pipefail
+          bun scripts/release-canary.ts --require-credential AXIOM_INGEST_TOKEN
+          trap 'status=$?; if [[ "$status" != 0 ]]; then docker inspect --format "{{json .State}}" otel-production || true; docker logs --tail 100 otel-production || true; fi' EXIT
+          queue_directory="${RUNNER_TEMP:?}/release-canary-queue"
+          sudo install -d -m 0700 -o 10001 -g 10001 "$queue_directory"
+          export AXIOM_TOKEN="$AXIOM_INGEST_TOKEN"
+          docker run -d --name otel-production \
+            -p 127.0.0.1:24318:4318 -p 127.0.0.1:24319:13133 \
+            -v "$queue_directory:/var/lib/otelcol/queue" \
+            -e AXIOM_TOKEN \
+            -e AXIOM_DATASET_TRACES -e AXIOM_DATASET_LOGS -e AXIOM_DATASET_METRICS \
+            -v "$PWD/packages/cli/src/assets/production.yaml:/etc/otelcol/config.yaml:ro" \
+            otel/opentelemetry-collector-contrib:0.159.0 --config=/etc/otelcol/config.yaml
+          for _ in $(seq 1 30); do
+            if [[ "$(docker inspect --format '{{.State.Running}}' otel-production)" != "true" ]]; then
+              echo "The production Collector exited before becoming healthy. Review the startup diagnostics."
+              exit 1
+            fi
+            if curl --fail --silent --show-error --connect-timeout 1 --max-time 2 -o /dev/null http://127.0.0.1:24319/health; then exit 0; fi
+            sleep 1
+          done
+          echo "The production Collector did not become healthy after 30 attempts. Review the startup diagnostics."
+          exit 1
+      - name: Run the deployed release canary
+        id: canary
+        env:
+          OBSERVABILITY_E2E_DEPLOYED: "1"
+          OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:24318
+          AXIOM_READ_TOKEN: ${{ secrets.AXIOM_READ_TOKEN }}
+          AXIOM_ORGANIZATION_ID: ${{ vars.AXIOM_ORGANIZATION_ID }}
+          AXIOM_URL: ${{ vars.AXIOM_URL }}
+          AXIOM_DATASET_TRACES: ${{ vars.AXIOM_DATASET_TRACES }}
+          AXIOM_DATASET_LOGS: ${{ vars.AXIOM_DATASET_LOGS }}
+          AXIOM_DATASET_METRICS: ${{ vars.AXIOM_DATASET_METRICS }}
+        run: |
+          bun scripts/release-canary.ts --require-credential AXIOM_READ_TOKEN
+          bun run test:canary:deployed
+      - name: Report failed canary dataset schemas
+        if: failure() && steps.canary.outcome == 'failure'
+        timeout-minutes: 2
+        env:
+          AXIOM_READ_TOKEN: ${{ secrets.AXIOM_READ_TOKEN }}
+          AXIOM_ORGANIZATION_ID: ${{ vars.AXIOM_ORGANIZATION_ID }}
+          AXIOM_URL: ${{ vars.AXIOM_URL }}
+          AXIOM_DATASET_TRACES: ${{ vars.AXIOM_DATASET_TRACES }}
+          AXIOM_DATASET_LOGS: ${{ vars.AXIOM_DATASET_LOGS }}
+          AXIOM_DATASET_METRICS: ${{ vars.AXIOM_DATASET_METRICS }}
+        run: bun scripts/axiom-schema.ts
+      - name: Report failed canary Collector logs
+        if: failure()
+        run: docker logs --tail 100 otel-production 2>&1 || true
+      - name: Clean the production collector
+        if: always()
+        run: |
+          docker rm -f otel-production 2>/dev/null || true
+          sudo rm -rf -- "${RUNNER_TEMP:?}/release-canary-queue"
+
+  canary-gate:
+    if: ${{ !cancelled() }}
+    needs: deployed-canary
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          DEPLOYED_CANARY_RESULT: ${{ needs.deployed-canary.result }}
+        run: test "$DEPLOYED_CANARY_RESULT" = "success"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,7 @@ jobs:
           echo "The production Collector did not become healthy after 30 attempts. Review the startup diagnostics."
           exit 1
       - name: Run the deployed release canary
+        id: canary
         env:
           OBSERVABILITY_E2E_DEPLOYED: "1"
           OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:24318
@@ -125,6 +126,17 @@ jobs:
         run: |
           bun scripts/release-canary.ts --require-credential AXIOM_READ_TOKEN
           bun run test:canary:deployed
+      - name: Report failed canary dataset schemas
+        if: failure() && steps.canary.outcome == 'failure'
+        timeout-minutes: 2
+        env:
+          AXIOM_READ_TOKEN: ${{ secrets.AXIOM_READ_TOKEN }}
+          AXIOM_ORGANIZATION_ID: ${{ vars.AXIOM_ORGANIZATION_ID }}
+          AXIOM_URL: ${{ vars.AXIOM_URL }}
+          AXIOM_DATASET_TRACES: ${{ vars.AXIOM_DATASET_TRACES }}
+          AXIOM_DATASET_LOGS: ${{ vars.AXIOM_DATASET_LOGS }}
+          AXIOM_DATASET_METRICS: ${{ vars.AXIOM_DATASET_METRICS }}
+        run: bun scripts/axiom-schema.ts
       - name: Report failed canary Collector logs
         if: failure()
         run: docker logs --tail 100 otel-production 2>&1 || true

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -47,6 +47,14 @@ Não sugira repetir quando a operação pode ter completado parcialmente, ou qua
 
 - `OBS_CLI_AUTH_TOKEN_INPUT_INVALID` indica que `--token-env` não nomeia uma variável segura ou que a variável selecionada está ausente, vazia ou contém caracteres de controle. Corrija a variável e tente novamente. A falha ocorre antes de acesso ao provider ou gravação de credenciais e inclui `request_id` e `retryable: true`.
 
+## Diagnóstico de schema Axiom
+
+- `OBS_AXIOM_SCHEMA_INPUT_INVALID` indica ambiente de leitura ausente ou URL inválida. Corrija a configuração antes de repetir.
+- `OBS_AXIOM_SCHEMA_REQUEST_FAILED` indica falha de transporte, timeout ou resposta HTTP malsucedida. Verifique conectividade, permissões de leitura e datasets antes de repetir.
+- `OBS_AXIOM_SCHEMA_RESPONSE_INVALID` indica JSON inválido ou metadados incompatíveis com o contrato de schema. Verifique a compatibilidade do provedor antes de repetir.
+
+O diagnóstico inclui um identificador de correlação local. A saída não expõe causas internas, credenciais ou corpos de resposta.
+
 ## Release Sentry
 
 - `OBS_SENTRY_RELEASE_INPUT_INVALID` indica identidade ou plano de release Sentry inválido. Corrija serviço, versão, ambiente e argumentos antes de executar a release.

--- a/docs/release-publication-runbook.md
+++ b/docs/release-publication-runbook.md
@@ -17,7 +17,11 @@ Execute o workflow `Release Preflight` com o slug e a versão exata antes de cri
 
 O preflight executa `bun run compat --release <slug>@<versão>` depois do build. O comando usa o baseline exato de `v0.2.1`, gerado das declarações dos tarballs npm publicados, e valida a versão candidata, as quebras declaradas e o guia de migração antes de criar o archive. Para pacotes já publicados, o gate consulta o packument diretamente, valida a integridade do tarball anterior, rejeita caminhos inseguros e links e compara sua superfície canônica com o digest congelado no baseline.
 
-O preflight não depende de arquivos existentes em `docs/releases`. Para reproduzi-lo localmente:
+Execute o preflight no branch `master`. Depois da validação local, aprove o job direto `deployed-canary` no environment `publication`. O job usa o commit imutável da execução, não um tag existente. O gate exige sucesso explícito antes de considerar o preflight aprovado. O preflight nunca publica pacotes.
+
+Permita `master` e os padrões de tags de pacote na política de branches do environment. Mantenha a aprovação obrigatória. Os jobs protegidos permanecem diretos nos dois workflows para preservar a resolução dos secrets de environment.
+
+O preflight não depende de arquivos existentes em `docs/releases`. Para reproduzir a parte local:
 
 ```sh
 bun scripts/release.ts 0.3.0 --package observability --dry-run
@@ -52,9 +56,11 @@ O canário usa `/v1/query/_apl` nos domínios regionais `*.edge.axiom.co` e mant
 
 O script `scripts/release-canary.ts` resolve o tag para o manifest correspondente e define `OTEL_SERVICE_VERSION` com a versão desse manifest. O step do Collector recebe somente `AXIOM_INGEST_TOKEN`. O step de consulta recebe somente `AXIOM_READ_TOKEN`. O canário consulta traces, logs e métricas usando a versão e os valores de correlação da execução. A ausência de qualquer secret encerra o gate com `OBS_RELEASE_CANARY_CREDENTIALS_MISSING`. CI comum permanece sem credenciais e informa que o gate protegido pertence ao workflow de release.
 
+Quando o canário falha, `scripts/axiom-schema.ts` consulta `getschema` nos datasets E2E de traces e logs. O diagnóstico imprime somente nomes e tipos de colunas validados, nunca eventos, credenciais ou corpos de erro do provedor. Cada consulta tem timeout de dez segundos. Respostas malformadas ou com mais de 512 colunas falham explicitamente. O diagnóstico não converte a falha do canário em sucesso.
+
 O orçamento de visibilidade reserva 200 ms para o `flush_timeout` do Collector e 180.000 ms para `axiomQueryVisibilityMilliseconds`. A [documentação pública de ingestão do Axiom](https://axiom.co/docs/send-data/) não publica um limite de latência entre ingestão e consulta. Por isso, os 180 segundos são uma tolerância operacional explícita, não uma garantia do provedor. O teste exige que o intervalo total de polling cubra esses dois campos e informa a margem derivada. Com os valores atuais, o intervalo de 192.000 ms deixa uma margem de 11.800 ms.
 
-Se o gate falhar, preserve o tag e os resultados da execução. Corrija a credencial, a variable regional, o dataset ou a entrega de telemetria indicada pelo último resultado de consulta. Para correções de configuração externa, execute novamente o mesmo workflow no mesmo tag. Se a correção exigir mudanças versionadas no workflow ou no código, prepare um novo patch apenas do pacote afetado com um novo tag: a execução no tag anterior continua usando os arquivos antigos. Não mova o tag, não use credencial administrativa e não publique manualmente para contornar o gate.
+Se o gate falhar, preserve o tag e os resultados da execução. Corrija a credencial, a variable regional, o dataset ou a entrega de telemetria indicada pelo último resultado de consulta. Para correções de configuração externa, execute novamente o mesmo workflow no mesmo tag. Se a correção exigir mudanças versionadas, valide primeiro o candidato com o preflight protegido em `master`. Depois do sucesso, prepare um novo patch apenas do pacote afetado com um novo tag. A execução no tag anterior continua usando os arquivos antigos. Não mova o tag, não use credencial administrativa e não publique manualmente para contornar o gate.
 
 ## Gate humano
 

--- a/packages/cli/test/AxiomSchema.bun.test.ts
+++ b/packages/cli/test/AxiomSchema.bun.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Schema } from "effect";
+import { fileURLToPath } from "node:url";
+import { inspectAxiomSchema } from "../../../scripts/axiom-schema.ts";
+
+const script = fileURLToPath(new URL("../../../scripts/axiom-schema.ts", import.meta.url));
+const QueryRequest = Schema.Struct({ apl: Schema.String });
+const decodeQueryRequest = Schema.decodeUnknownSync(QueryRequest);
+const environment = (url: string): NodeJS.ProcessEnv => ({
+  AXIOM_URL: url,
+  AXIOM_READ_TOKEN: "read-only-secret",
+  AXIOM_ORGANIZATION_ID: "test-organization",
+  AXIOM_DATASET_TRACES: "test-traces",
+  AXIOM_DATASET_LOGS: "test-logs",
+  AXIOM_DATASET_METRICS: "test-metrics",
+});
+const fieldResponse = () =>
+  Response.json({
+    matches: [
+      { data: { ColumnName: "_time", ColumnType: "datetime", event: "private-event-value" } },
+    ],
+    private: "private-response-value",
+  });
+
+const runScript = async (env: NodeJS.ProcessEnv) => {
+  const child = Bun.spawn([process.execPath, script], { env, stdout: "pipe", stderr: "pipe" });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  return { exitCode, stdout, stderr };
+};
+
+describe("protected Axiom schema diagnostics", () => {
+  test("queries only trace and log schemas and prints only parsed metadata", async () => {
+    const queries: Array<string> = [];
+    const credentials: Array<string | null> = [];
+    const paths: Array<string> = [];
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        queries.push(decodeQueryRequest(await request.json()).apl);
+        credentials.push(request.headers.get("authorization"));
+        expect(request.headers.get("x-axiom-org-id")).toBe("test-organization");
+        const url = new URL(request.url);
+        paths.push(`${url.pathname}${url.search}`);
+        return fieldResponse();
+      },
+    });
+    try {
+      const result = await runScript(environment(server.url.toString()));
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toBe(
+        `${JSON.stringify([
+          { signal: "traces", fields: [{ name: "_time", type: "datetime" }] },
+          { signal: "logs", fields: [{ name: "_time", type: "datetime" }] },
+        ])}\n`,
+      );
+      expect(queries).toEqual(['["test-traces"] | getschema', '["test-logs"] | getschema']);
+      expect(credentials).toEqual(["Bearer read-only-secret", "Bearer read-only-secret"]);
+      expect(paths).toEqual(["/v1/datasets/_apl?format=legacy", "/v1/datasets/_apl?format=legacy"]);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("escapes dataset names rather than interpolating APL syntax", async () => {
+    const queries: Array<string> = [];
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        queries.push(decodeQueryRequest(await request.json()).apl);
+        return Response.json({ matches: [] });
+      },
+    });
+    try {
+      const env = environment(server.url.toString());
+      env.AXIOM_DATASET_LOGS = 'logs"] | take 1 | ["other';
+      const result = await Effect.runPromise(inspectAxiomSchema(env));
+      expect(queries[1]).toBe(`[${JSON.stringify(env.AXIOM_DATASET_LOGS)}] | getschema`);
+      expect(result).toEqual([
+        { signal: "traces", fields: [] },
+        { signal: "logs", fields: [] },
+      ]);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("rejects absent credentials and malformed URLs without exposing environment values", async () => {
+    for (const env of [
+      { ...environment("http://127.0.0.1:1"), AXIOM_READ_TOKEN: undefined },
+      environment("private-invalid-url"),
+    ]) {
+      const result = await runScript(env);
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain("OBS_AXIOM_SCHEMA_INPUT_INVALID");
+      expect(result.stderr).toContain("Correlation ID:");
+      expect(result.stderr).not.toContain("read-only-secret");
+      expect(result.stderr).not.toContain("private-invalid-url");
+    }
+  });
+
+  test("fails closed on HTTP errors without printing response bodies", async () => {
+    for (const status of [400, 401, 403, 404, 429, 500]) {
+      const server = Bun.serve({
+        port: 0,
+        fetch: () => new Response("private-provider-error", { status }),
+      });
+      try {
+        const result = await runScript(environment(server.url.toString()));
+        expect(result.exitCode).toBe(1);
+        expect(result.stdout).toBe("");
+        expect(result.stderr).toContain("OBS_AXIOM_SCHEMA_REQUEST_FAILED");
+        expect(result.stderr).toContain(`HTTP ${status}`);
+        expect(result.stderr).not.toContain("private-provider-error");
+        expect(result.stderr).not.toContain("read-only-secret");
+      } finally {
+        await server.stop(true);
+      }
+    }
+  });
+
+  test("rejects invalid JSON, missing schema columns and oversized schema responses", async () => {
+    const responses = [
+      "private-invalid-json",
+      JSON.stringify({ matches: [{ data: { ColumnName: "private-missing-type" } }] }),
+      JSON.stringify({ matches: null }),
+      JSON.stringify({
+        matches: Array.from({ length: 513 }, () => ({
+          data: { ColumnName: "field", ColumnType: "string" },
+        })),
+      }),
+    ];
+    for (const response of responses) {
+      const server = Bun.serve({ port: 0, fetch: () => new Response(response) });
+      try {
+        const result = await runScript(environment(server.url.toString()));
+        expect(result.exitCode).toBe(1);
+        expect(result.stdout).toBe("");
+        expect(result.stderr).toContain("OBS_AXIOM_SCHEMA_RESPONSE_INVALID");
+        expect(result.stderr).not.toContain("private-");
+      } finally {
+        await server.stop(true);
+      }
+    }
+  });
+
+  test("bounds schema requests that never return", async () => {
+    const server = Bun.serve({ port: 0, fetch: () => new Promise<Response>(() => {}) });
+    try {
+      const result = await runScript(environment(server.url.toString()));
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain("OBS_AXIOM_SCHEMA_REQUEST_FAILED");
+    } finally {
+      await server.stop(true);
+    }
+  }, 15_000);
+
+  test("reports transport failures without disclosing the configured URL", async () => {
+    const server = Bun.serve({ port: 0, fetch: fieldResponse });
+    const url = server.url.toString();
+    await server.stop(true);
+    const result = await runScript(environment(url));
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("OBS_AXIOM_SCHEMA_REQUEST_FAILED");
+    expect(result.stderr).not.toContain(url);
+  });
+});

--- a/packages/cli/test/ReleaseWorkflow.bun.test.ts
+++ b/packages/cli/test/ReleaseWorkflow.bun.test.ts
@@ -29,6 +29,13 @@ const WorkflowEnvironment = Schema.Struct({
   OBSERVABILITY_E2E_DEPLOYED: Schema.optionalKey(Schema.String),
   AXIOM_INGEST_TOKEN: Schema.optionalKey(Schema.String),
   AXIOM_READ_TOKEN: Schema.optionalKey(Schema.String),
+  AXIOM_ORGANIZATION_ID: Schema.optionalKey(Schema.String),
+  AXIOM_URL: Schema.optionalKey(Schema.String),
+  AXIOM_DATASET_TRACES: Schema.optionalKey(Schema.String),
+  AXIOM_DATASET_LOGS: Schema.optionalKey(Schema.String),
+  AXIOM_DATASET_METRICS: Schema.optionalKey(Schema.String),
+  OTEL_EXPORTER_OTLP_ENDPOINT: Schema.optionalKey(Schema.String),
+  EVENT_REF: Schema.optionalKey(Schema.String),
   NODE_AUTH_TOKEN: Schema.optionalKey(Schema.String),
   RELEASE_TAG: Schema.optionalKey(Schema.String),
   DEPLOYED_CANARY_RESULT: Schema.optionalKey(Schema.String),
@@ -40,6 +47,8 @@ const WorkflowStep = Schema.Struct({
   if: Schema.optionalKey(Schema.String),
   run: Schema.optionalKey(Schema.String),
   uses: Schema.optionalKey(Schema.String),
+  "continue-on-error": Schema.optionalKey(Schema.Boolean),
+  "timeout-minutes": Schema.optionalKey(Schema.Number),
   with: Schema.optionalKey(
     Schema.Struct({
       "bun-version": Schema.optionalKey(Schema.String),
@@ -50,6 +59,8 @@ const WorkflowStep = Schema.Struct({
 });
 
 const WorkflowDocument = Schema.Struct({
+  permissions: Schema.Record(Schema.String, Schema.String),
+  env: Schema.optionalKey(WorkflowEnvironment),
   jobs: Schema.Record(
     Schema.String,
     Schema.Struct({ steps: Schema.optionalKey(Schema.Array(WorkflowStep)) }),
@@ -57,6 +68,9 @@ const WorkflowDocument = Schema.Struct({
 });
 
 const ConditionalJob = Schema.Struct({
+  uses: Schema.optionalKey(Schema.String),
+  "runs-on": Schema.optionalKey(Schema.String),
+  permissions: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
   if: Schema.optionalKey(Schema.String),
   environment: Schema.optionalKey(Schema.String),
   needs: Schema.optionalKey(Schema.Array(Schema.String)),
@@ -115,11 +129,21 @@ const ReleaseWorkflow = Schema.Struct({
   }),
 });
 
+const ReleasePreflightWorkflow = Schema.Struct({
+  jobs: Schema.Struct({
+    readiness: ConditionalJob,
+    "deployed-canary": ConditionalJob,
+    "canary-gate": ReleaseGateJob,
+  }),
+});
+
 const parsedCiWorkflow = Schema.decodeUnknownSync(CiWorkflow)(Bun.YAML.parse(ciWorkflow));
-const parsedReleaseWorkflow = Schema.decodeUnknownSync(ReleaseWorkflow)(Bun.YAML.parse(workflow));
-const parsedReleasePreflightWorkflow = Schema.decodeUnknownSync(WorkflowDocument)(
-  Bun.YAML.parse(releasePreflightWorkflow),
-);
+const parsedReleaseWorkflow = Schema.decodeUnknownSync(ReleaseWorkflow, {
+  onExcessProperty: "preserve",
+})(Bun.YAML.parse(workflow));
+const parsedReleasePreflightWorkflow = Schema.decodeUnknownSync(ReleasePreflightWorkflow, {
+  onExcessProperty: "preserve",
+})(Bun.YAML.parse(releasePreflightWorkflow));
 const workflowDocuments = await Array.fromAsync(
   new Bun.Glob(".github/workflows/*.yml").scan({
     cwd: fileURLToPath(new URL("../../..", import.meta.url)),
@@ -216,37 +240,43 @@ describe("release workflow publication gate", () => {
     expect(workflow).toContain('[[ "$head_commit" == "$tag_commit" ]]');
   });
 
-  test("executes the release workflow canary gate script", async () => {
-    const gateStep = parsedReleaseWorkflow.jobs["canary-gate"].steps?.[0];
-    expect(gateStep?.run).toBeDefined();
-    if (gateStep?.run === undefined) throw new Error("The release canary gate script is missing.");
-    for (const canaryResult of ["success", "failure", "skipped", "cancelled", "", undefined]) {
-      const result = await executeShell(gateStep.run, {
-        DEPLOYED_CANARY_RESULT: canaryResult,
-      });
-      expect(result.exitCode).toBe(canaryResult === "success" ? 0 : 1);
-      expect(result.output).toBe("");
-      expect(result.stderr).toBe("");
-      expect(result.stdout).toBe("");
+  test("executes both canary gates and rejects every result except success", async () => {
+    for (const document of [parsedReleaseWorkflow, parsedReleasePreflightWorkflow]) {
+      const gateStep = document.jobs["canary-gate"].steps[0];
+      expect(gateStep?.run).toBeDefined();
+      if (gateStep?.run === undefined) throw new Error("The canary gate script is missing.");
+      for (const canaryResult of ["success", "failure", "skipped", "cancelled", "", undefined]) {
+        const result = await executeShell(gateStep.run, {
+          DEPLOYED_CANARY_RESULT: canaryResult,
+        });
+        expect(result.exitCode).toBe(canaryResult === "success" ? 0 : 1);
+        expect(result.output).toBe("");
+        expect(result.stderr).toBe("");
+        expect(result.stdout).toBe("");
+      }
     }
   });
 
   test("gates publication on the direct protected job result", () => {
-    expect(parsedReleaseWorkflow.jobs["deployed-canary"]["continue-on-error"]).toBeUndefined();
     expect(parsedReleaseWorkflow.jobs["deployed-canary"].if).toBeUndefined();
-    expect(parsedReleaseWorkflow.jobs["canary-gate"].needs).toBe("deployed-canary");
-    expect(parsedReleaseWorkflow.jobs["canary-gate"].if).toBe("${{ !cancelled() }}");
-    expect(parsedReleaseWorkflow.jobs["canary-gate"].steps[0]?.env?.DEPLOYED_CANARY_RESULT).toBe(
-      "${{ needs.deployed-canary.result }}",
-    );
+    for (const document of [parsedReleaseWorkflow, parsedReleasePreflightWorkflow]) {
+      expect(document.jobs["deployed-canary"]["continue-on-error"]).toBeUndefined();
+      expect(document.jobs["canary-gate"].needs).toBe("deployed-canary");
+      expect(document.jobs["canary-gate"].if).toBe("${{ !cancelled() }}");
+      expect(document.jobs["canary-gate"].steps[0]?.env?.DEPLOYED_CANARY_RESULT).toBe(
+        "${{ needs.deployed-canary.result }}",
+      );
+    }
   });
 
   test("keeps the deployed canary job timeout above the suite budget", () => {
-    const timeoutMinutes = parsedReleaseWorkflow.jobs["deployed-canary"]["timeout-minutes"];
-    expect(timeoutMinutes).toBeDefined();
-    expect((timeoutMinutes ?? 0) * 60_000).toBeGreaterThanOrEqual(
-      deployedCanarySuiteTimeoutMilliseconds + 3 * 60_000,
-    );
+    for (const document of [parsedReleaseWorkflow, parsedReleasePreflightWorkflow]) {
+      const timeoutMinutes = document.jobs["deployed-canary"]["timeout-minutes"];
+      expect(timeoutMinutes).toBeDefined();
+      expect((timeoutMinutes ?? 0) * 60_000).toBeGreaterThanOrEqual(
+        deployedCanarySuiteTimeoutMilliseconds + 3 * 60_000,
+      );
+    }
   });
 
   test("builds a release graph that cannot bypass the canary gate", () => {
@@ -269,8 +299,21 @@ describe("release workflow publication gate", () => {
 
   test("uses publication environment secrets without inert caller plumbing", () => {
     expect(parsedCiWorkflow.on.workflow_call.secrets).toBeUndefined();
-    expect(parsedReleaseWorkflow.jobs["deployed-canary"].environment).toBe("publication");
+    for (const document of [parsedReleaseWorkflow, parsedReleasePreflightWorkflow]) {
+      const canary = document.jobs["deployed-canary"];
+      expect(canary.environment).toBe("publication");
+      expect(canary["runs-on"]).toBe("ubuntu-latest");
+      expect(canary.uses).toBeUndefined();
+      expect(canary.env).toBeUndefined();
+      expect(canary.permissions).toBeUndefined();
+    }
+    for (const document of workflowDocuments) {
+      expect(document.permissions).toEqual({ contents: "read" });
+      expect(document.env).toBeUndefined();
+    }
     expect(workflow).not.toContain("secrets: inherit");
+    expect(releasePreflightWorkflow).not.toContain("secrets: inherit");
+    expect(releasePreflightWorkflow).not.toContain("NPM_TOKEN");
     expect(ciWorkflow).not.toContain("secrets.");
     expect(ciWorkflow).not.toContain("NPM_TOKEN");
     expect(ciWorkflow).not.toContain("environment:");
@@ -284,13 +327,16 @@ describe("release workflow publication gate", () => {
     const steps = canary.steps ?? [];
     const ingestStep = steps.find((step) => step.name === "Start the production collector");
     const readStep = steps.find((step) => step.name === "Run the deployed release canary");
+    const schemaStep = steps.find((step) => step.name === "Report failed canary dataset schemas");
     expect(ingestStep?.env?.AXIOM_INGEST_TOKEN).toBe("${{ secrets.AXIOM_INGEST_TOKEN }}");
     expect(ingestStep?.run).toContain("--require-credential AXIOM_INGEST_TOKEN");
     expect(readStep?.env?.AXIOM_READ_TOKEN).toBe("${{ secrets.AXIOM_READ_TOKEN }}");
     expect(readStep?.run).toContain("--require-credential AXIOM_READ_TOKEN");
     for (const step of steps) {
       if (step !== ingestStep) expect(step.env?.AXIOM_INGEST_TOKEN).toBeUndefined();
-      if (step !== readStep) expect(step.env?.AXIOM_READ_TOKEN).toBeUndefined();
+      if (step !== readStep && step !== schemaStep) {
+        expect(step.env?.AXIOM_READ_TOKEN).toBeUndefined();
+      }
       expect(step.env?.NODE_AUTH_TOKEN).toBeUndefined();
     }
     expect(workflow.match(/secrets\.NPM_TOKEN/g)).toHaveLength(1);
@@ -443,6 +489,96 @@ describe("release workflow publication gate", () => {
     expect(workflow).toContain('export AXIOM_TOKEN="$AXIOM_INGEST_TOKEN"');
     expect(workflow).toContain("-e AXIOM_TOKEN \\");
     expect(workflow).not.toContain('-e AXIOM_TOKEN="$AXIOM_INGEST_TOKEN"');
+  });
+
+  test("keeps direct protected canary steps identical except checkout and candidate identity", () => {
+    const releaseSteps = parsedReleaseWorkflow.jobs["deployed-canary"].steps ?? [];
+    const preflightSteps = parsedReleasePreflightWorkflow.jobs["deployed-canary"].steps ?? [];
+    expect(releaseSteps.length).toBeGreaterThan(0);
+    expect(preflightSteps).toHaveLength(releaseSteps.length);
+    for (const [index, step] of releaseSteps.entries()) {
+      if (step.uses === "actions/checkout@v4") {
+        expect(preflightSteps[index]).toEqual({
+          ...step,
+          with: { ref: "${{ github.sha }}" },
+        });
+      } else if (step.name === "Resolve release canary identity") {
+        expect(preflightSteps[index]).toEqual({
+          ...step,
+          env: { RELEASE_TAG: "${{ format('{0}@{1}', inputs.package, inputs.version) }}" },
+        });
+      } else {
+        expect(preflightSteps[index]).toEqual(step);
+      }
+    }
+  });
+
+  test("runs preflight canary only after readiness on the immutable master dispatch commit", () => {
+    const { readiness, "deployed-canary": canary } = parsedReleasePreflightWorkflow.jobs;
+    expect(canary.needs).toEqual(["readiness"]);
+    expect(canary.if).toBe("github.ref == 'refs/heads/master'");
+    expect(readiness["continue-on-error"]).toBeUndefined();
+    expect(readiness.steps?.find((step) => step.uses === "actions/checkout@v4")?.with?.ref).toBe(
+      "${{ github.sha }}",
+    );
+    expect(Object.keys(parsedReleasePreflightWorkflow.jobs)).toEqual([
+      "readiness",
+      "deployed-canary",
+      "canary-gate",
+    ]);
+    expect(releasePreflightWorkflow).not.toContain("refs/tags/");
+    expect(releasePreflightWorkflow).not.toContain("git show-ref");
+    expect(releasePreflightWorkflow).not.toContain("gh release");
+    expect(releasePreflightWorkflow).not.toContain("npm publish");
+    expect(releasePreflightWorkflow).not.toMatch(/git (?:tag|push)/);
+  });
+
+  test("rejects preflight dispatch outside master before readiness", async () => {
+    const requireBranch = parsedReleasePreflightWorkflow.jobs.readiness.steps?.[0];
+    expect(requireBranch?.name).toBe("Require the default branch");
+    expect(requireBranch?.env?.EVENT_REF).toBe("${{ github.ref }}");
+    if (requireBranch?.run === undefined) throw new Error("The preflight branch check is missing.");
+    for (const ref of [
+      "refs/heads/master",
+      "refs/heads/feature",
+      "refs/tags/observability@0.3.0",
+      "",
+      undefined,
+    ]) {
+      const result = await executeShell(requireBranch.run, { EVENT_REF: ref });
+      expect(result.exitCode).toBe(ref === "refs/heads/master" ? 0 : 1);
+    }
+  });
+
+  test("diagnoses only failed canaries with bounded read-only dataset schema access", () => {
+    for (const document of [parsedReleaseWorkflow, parsedReleasePreflightWorkflow]) {
+      const steps = document.jobs["deployed-canary"].steps ?? [];
+      const canaryIndex = steps.findIndex(
+        (step) => step.name === "Run the deployed release canary",
+      );
+      const schemaIndex = steps.findIndex(
+        (step) => step.name === "Report failed canary dataset schemas",
+      );
+      const cleanupIndex = steps.findIndex(
+        (step) => step.name === "Clean the production collector",
+      );
+      const schemaStep = steps[schemaIndex];
+      expect(steps[canaryIndex]?.id).toBe("canary");
+      expect(schemaIndex).toBeGreaterThan(canaryIndex);
+      expect(cleanupIndex).toBeGreaterThan(schemaIndex);
+      expect(schemaStep?.if).toBe("failure() && steps.canary.outcome == 'failure'");
+      expect(schemaStep?.["timeout-minutes"]).toBe(2);
+      expect(schemaStep?.run).toBe("bun scripts/axiom-schema.ts");
+      expect(schemaStep?.env).toEqual({
+        AXIOM_READ_TOKEN: "${{ secrets.AXIOM_READ_TOKEN }}",
+        AXIOM_ORGANIZATION_ID: "${{ vars.AXIOM_ORGANIZATION_ID }}",
+        AXIOM_URL: "${{ vars.AXIOM_URL }}",
+        AXIOM_DATASET_TRACES: "${{ vars.AXIOM_DATASET_TRACES }}",
+        AXIOM_DATASET_LOGS: "${{ vars.AXIOM_DATASET_LOGS }}",
+        AXIOM_DATASET_METRICS: "${{ vars.AXIOM_DATASET_METRICS }}",
+      });
+      for (const step of steps) expect(step["continue-on-error"]).toBeUndefined();
+    }
   });
 
   test("uses release canary identity resolution in preflight", () => {

--- a/scripts/axiom-schema.ts
+++ b/scripts/axiom-schema.ts
@@ -1,0 +1,137 @@
+import { Effect, Schema } from "effect";
+import {
+  axiomAplQueryUrl,
+  decodeAxiomEnvironment,
+} from "../packages/telemetry/test/support/axiom.ts";
+
+const AxiomSchemaErrorCode = Schema.Literals([
+  "OBS_AXIOM_SCHEMA_INPUT_INVALID",
+  "OBS_AXIOM_SCHEMA_REQUEST_FAILED",
+  "OBS_AXIOM_SCHEMA_RESPONSE_INVALID",
+]);
+
+export class AxiomSchemaError extends Schema.TaggedError<AxiomSchemaError>()("AxiomSchemaError", {
+  code: AxiomSchemaErrorCode,
+  message: Schema.String,
+  correlationId: Schema.NonEmptyString,
+  cause: Schema.Defect(),
+}) {}
+
+const DatasetSchemaResponse = Schema.Struct({
+  matches: Schema.Array(
+    Schema.Struct({
+      data: Schema.Struct({
+        ColumnName: Schema.NonEmptyString,
+        ColumnType: Schema.NonEmptyString,
+      }),
+    }),
+  ).check(Schema.isMaxLength(512)),
+});
+
+const decodeDatasetSchemaResponse = Schema.decodeUnknownEffect(DatasetSchemaResponse);
+
+type DatasetSchema = {
+  readonly signal: string;
+  readonly fields: ReadonlyArray<{ readonly name: string; readonly type: string }>;
+};
+
+export const inspectAxiomSchema = Effect.fn("inspectAxiomSchema")(function* (
+  environment: NodeJS.ProcessEnv,
+) {
+  const correlationId = crypto.randomUUID();
+  const failure = (
+    code: typeof AxiomSchemaErrorCode.Type,
+    message: string,
+    cause: unknown,
+  ): AxiomSchemaError => new AxiomSchemaError({ code, message, correlationId, cause });
+  const env = yield* decodeAxiomEnvironment(environment).pipe(
+    Effect.mapError((cause) =>
+      failure(
+        "OBS_AXIOM_SCHEMA_INPUT_INVALID",
+        "Configure the Axiom read environment before retrying.",
+        cause,
+      ),
+    ),
+  );
+  const url = yield* Effect.try({
+    try: () => axiomAplQueryUrl(env.AXIOM_URL),
+    catch: (cause) =>
+      failure(
+        "OBS_AXIOM_SCHEMA_INPUT_INVALID",
+        "Configure a valid Axiom URL before retrying.",
+        cause,
+      ),
+  });
+  const results: Array<DatasetSchema> = [];
+  for (const dataset of [
+    { signal: "traces", name: env.AXIOM_DATASET_TRACES },
+    { signal: "logs", name: env.AXIOM_DATASET_LOGS },
+  ]) {
+    const response = yield* Effect.tryPromise({
+      try: (signal) =>
+        fetch(url, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${env.AXIOM_READ_TOKEN}`,
+            "content-type": "application/json",
+            "x-axiom-org-id": env.AXIOM_ORGANIZATION_ID,
+          },
+          body: JSON.stringify({ apl: `[${JSON.stringify(dataset.name)}] | getschema` }),
+          signal: AbortSignal.any([signal, AbortSignal.timeout(10_000)]),
+        }),
+      catch: (cause) =>
+        failure(
+          "OBS_AXIOM_SCHEMA_REQUEST_FAILED",
+          "The Axiom schema request failed. Check connectivity before retrying.",
+          cause,
+        ),
+    });
+    if (!response.ok) {
+      yield* Effect.promise(() => response.body?.cancel() ?? Promise.resolve());
+      return yield* failure(
+        "OBS_AXIOM_SCHEMA_REQUEST_FAILED",
+        `Axiom schema lookup returned HTTP ${response.status}. Check read access and the dataset configuration before retrying.`,
+        response.status,
+      );
+    }
+    const payload = yield* Effect.tryPromise({
+      try: () => response.json(),
+      catch: (cause) =>
+        failure(
+          "OBS_AXIOM_SCHEMA_RESPONSE_INVALID",
+          "Axiom returned invalid schema JSON. Check provider compatibility before retrying.",
+          cause,
+        ),
+    });
+    const schema = yield* decodeDatasetSchemaResponse(payload).pipe(
+      Effect.mapError((cause) =>
+        failure(
+          "OBS_AXIOM_SCHEMA_RESPONSE_INVALID",
+          "Axiom returned unsupported schema metadata. Check provider compatibility before retrying.",
+          cause,
+        ),
+      ),
+    );
+    results.push({
+      signal: dataset.signal,
+      fields: schema.matches.map(({ data }) => ({ name: data.ColumnName, type: data.ColumnType })),
+    });
+  }
+  return results;
+});
+
+if (import.meta.main) {
+  Effect.runPromise(inspectAxiomSchema(process.env)).then(
+    (schemas) => console.log(JSON.stringify(schemas)),
+    (cause) => {
+      if (cause instanceof AxiomSchemaError) {
+        console.error(`${cause.code}: ${cause.message} Correlation ID: ${cause.correlationId}.`);
+      } else {
+        console.error(
+          "Axiom schema inspection failed unexpectedly. Review the diagnostic implementation before retrying.",
+        );
+      }
+      process.exitCode = 1;
+    },
+  );
+}

--- a/scripts/package-smoke.ts
+++ b/scripts/package-smoke.ts
@@ -188,9 +188,9 @@ const allocateTemporaryDirectory = async (): Promise<string> => {
   return mkdtemp(join(tmpdir(), "observability-package-"));
 };
 
-allocationPromise = allocateTemporaryDirectory();
 process.on("SIGINT", onSigint);
 process.on("SIGTERM", onSigterm);
+allocationPromise = allocateTemporaryDirectory();
 
 try {
   temporaryDirectory = await allocationPromise;


### PR DESCRIPTION
## Changes
- Run the protected canary from immutable master commits before creating release tags.
- Keep direct environment-bound jobs, separate read/ingest credentials, and fail-closed gates.
- Report validated Axiom schema metadata after failures without exposing events or provider error bodies.
- Preserve all existing release tags and package versions.

## Verification
- 26 workflow regression tests and 7 diagnostic HTTP/CLI tests pass.
- Full local suite: Vitest 618 passed, 3 skipped; Bun 431 passed, 8 skipped before the four additional workflow tests.
- Vite+ check, actionlint, formatting and diff checks pass.
- Protected master execution follows merge. The release remains blocked until the real canary passes.

## Environment
The user explicitly approved adding master to publication while retaining its required reviewer. No secrets were copied or exposed.