### PR TITLE
fix(release): match canary queries to observed Axiom schemas

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -124,7 +124,7 @@
     },
     "packages/telemetry": {
       "name": "@equipe-tech/observability",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "devDependencies": {
         "effect": "4.0.0-rc.111",
       },

--- a/docs/migration-0.3.md
+++ b/docs/migration-0.3.md
@@ -151,4 +151,4 @@ Mantenha o ledger no banco de dados da aplicação. Use `commitAuditRecord` ou `
 
 ## Usar releases independentes
 
-Os pacotes mantêm versões independentes. Esta preparação seleciona `0.3.3` para o núcleo e `0.3.0` para os outros cinco pacotes alterados. A tag inicial do núcleo permanece como registro de uma tentativa sem publicação. A CLI avança de `0.2.1` para `0.3.0` pelas mudanças incompatíveis descritas neste guia. Tags usam `<slug>@<semver>`, por exemplo `observability@0.3.0`, `observability-evlog@0.3.0`, `observability-nestjs@0.3.0` e `observability-cli@0.3.0`. Releases futuras alteram somente os pacotes afetados.
+Os pacotes mantêm versões independentes. Esta preparação seleciona `0.3.4` para o núcleo e `0.3.0` para os outros cinco pacotes alterados. A tag inicial do núcleo permanece como registro de uma tentativa sem publicação. A CLI avança de `0.2.1` para `0.3.0` pelas mudanças incompatíveis descritas neste guia. Tags usam `<slug>@<semver>`, por exemplo `observability@0.3.0`, `observability-evlog@0.3.0`, `observability-nestjs@0.3.0` e `observability-cli@0.3.0`. Releases futuras alteram somente os pacotes afetados.

--- a/docs/release-publication-runbook.md
+++ b/docs/release-publication-runbook.md
@@ -54,6 +54,10 @@ A verificação de release executa o canário implantado antes de criar a GitHub
 
 O canário usa `/v1/query/_apl` nos domínios regionais `*.edge.axiom.co` e mantém `/v1/datasets/_apl` na API global. Os domínios regionais não oferecem a rota global. Ambas as consultas APL solicitam o formato `legacy` esperado pelo parser do teste.
 
+O [preflight protegido de 6 de setembro de 2026](https://github.com/equipe-tech/observability/actions/runs/34063620778) confirmou schemas distintos. Logs expõem atributos como `attributes.canary.run_id`; traces usam o mapa `attributes.custom`. Ambos expõem `service.namespace` e `resource.deployment.environment.name`. O alias legado do ambiente permanece em `resource.custom` nos traces e em `resource.deployment.environment` nos logs. A fixture `packages/telemetry/test/fixtures/axiom-canary-schema.json` preserva somente nomes e tipos das colunas observadas.
+
+O identificador opcional de instância pode não existir no schema de logs. A consulta usa `column_ifexists` sem substituir campos obrigatórios. O decoder trata o resultado vazio de `tostring(null)` como ausência. Um identificador não vazio continua visível e reprova a política do canário.
+
 O script `scripts/release-canary.ts` resolve o tag para o manifest correspondente e define `OTEL_SERVICE_VERSION` com a versão desse manifest. O step do Collector recebe somente `AXIOM_INGEST_TOKEN`. O step de consulta recebe somente `AXIOM_READ_TOKEN`. O canário consulta traces, logs e métricas usando a versão e os valores de correlação da execução. A ausência de qualquer secret encerra o gate com `OBS_RELEASE_CANARY_CREDENTIALS_MISSING`. CI comum permanece sem credenciais e informa que o gate protegido pertence ao workflow de release.
 
 Quando o canário falha, `scripts/axiom-schema.ts` consulta `getschema` nos datasets E2E de traces e logs. O diagnóstico imprime somente nomes e tipos de colunas validados, nunca eventos, credenciais ou corpos de erro do provedor. Cada consulta tem timeout de dez segundos. Respostas malformadas ou com mais de 512 colunas falham explicitamente. O diagnóstico não converte a falha do canário em sucesso.

--- a/docs/releases/preparation-0.3.md
+++ b/docs/releases/preparation-0.3.md
@@ -4,7 +4,7 @@ Esta preparação cobre os seis pacotes alterados pelo stack. Cada pacote manté
 
 | Pacote                              | Versão candidata | Motivo                                                                 |
 | ----------------------------------- | ---------------- | ---------------------------------------------------------------------- |
-| `@equipe-tech/observability`        | `0.3.3`          | Contratos tipados, identidade canônica, política, métricas e auditoria |
+| `@equipe-tech/observability`        | `0.3.4`          | Contratos tipados, identidade canônica, política, métricas e auditoria |
 | `@equipe-tech/observability-evlog`  | `0.3.0`          | Primeiro release do adapter oficial de eventos                         |
 | `@equipe-tech/observability-nestjs` | `0.3.0`          | Primeiro release da integração extraída do núcleo                      |
 | `@equipe-tech/observability-sentry` | `0.3.0`          | Primeiro release dos adapters de defeitos Node e browser               |
@@ -23,7 +23,7 @@ Leia [o guia de migração](../migration-0.3.md) antes da atualização. Leia [o
 
 Publique o núcleo antes dos adapters e da CLI, pois os consumidores precisam resolver o peer `@equipe-tech/observability@0.3.x`.
 
-Execute `Release Preflight` para cada pacote na revisão aprovada. Crie somente tags independentes, como `observability@0.3.3`, depois do preflight.
+Execute `Release Preflight` para cada pacote na revisão aprovada. Crie somente tags independentes, como `observability@0.3.4`, depois do preflight.
 
 Mantenha a aprovação humana do environment `publication`. O push da tag solicita somente a verificação protegida. A publicação exige outro `workflow_dispatch`, com `tag` e `confirm_tag` idênticos.
 
@@ -35,7 +35,9 @@ A tentativa `observability@0.3.1` resolveu os secrets no job direto, mas o Colle
 
 A tentativa `observability@0.3.2` iniciou o Collector, mas a consulta APL usou uma rota global indisponível no endpoint regional.
 
-A recuperação usa `observability@0.3.3`, com armazenamento gravável, prontidão verificada e seleção da rota APL correspondente ao domínio configurado. Os outros cinco pacotes mantêm `0.3.0`, pois suas tags ainda não foram criadas.
+A tentativa `observability@0.3.3` alcançou a API regional, mas consultou logs com caminhos de campos exclusivos de traces. O preflight protegido em `master` confirmou os schemas sem criar outra tag.
+
+A recuperação prepara `observability@0.3.4`, com consultas separadas para os schemas reais de traces e logs. O canário preserva as verificações de identidade, correlação e redaction. Crie a tag somente depois do preflight protegido bem-sucedido. Os outros cinco pacotes mantêm `0.3.0`, pois suas tags ainda não foram criadas.
 
 Os cadastros dos dois secrets Axiom e das cinco variables existem no environment `publication`. As regras permitem as tags dos seis slugs. O `NPM_TOKEN` existe no escopo do repositório.
 

--- a/observability/compatibility/candidate-versions.json
+++ b/observability/compatibility/candidate-versions.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "packages": [
-    { "name": "@equipe-tech/observability", "version": "0.3.3" },
+    { "name": "@equipe-tech/observability", "version": "0.3.4" },
     { "name": "@equipe-tech/observability-cli", "version": "0.3.0" },
     { "name": "@equipe-tech/observability-evlog", "version": "0.3.0" },
     { "name": "@equipe-tech/observability-nestjs", "version": "0.3.0" },

--- a/observability/compatibility/declared-breaks.json
+++ b/observability/compatibility/declared-breaks.json
@@ -6,7 +6,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_DEPENDENCY_REMOVED",
       "path": "dependencies/effect@4.0.0-rc.111",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -14,7 +14,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_DEPENDENCY_CATEGORY_CHANGED",
       "path": "dependencies/effect",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -22,7 +22,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_EXPORT_CONDITION_REMOVED",
       "path": "exportConditions/./nestjs:import:./dist/nestjs/index.js",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -30,7 +30,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_EXPORT_CONDITION_REMOVED",
       "path": "exportConditions/./nestjs:types:./dist/nestjs/index.d.ts",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -38,7 +38,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_EXPORT_REMOVED",
       "path": "exports/./nestjs",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -46,7 +46,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_PEER_CHANGED",
       "path": "peerDependencies/@nestjs/common@^10.0.0 || ^11.0.0",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -54,7 +54,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_PEER_CHANGED",
       "path": "peerDependencies/@nestjs/core@^10.0.0 || ^11.0.0",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -62,7 +62,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_PEER_CHANGED",
       "path": "peerDependencies/rxjs@^7.2.0",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -70,7 +70,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_PEER_OPTIONALITY_CHANGED",
       "path": "peerDependenciesMeta",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -78,7 +78,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_RUNTIME_ENTRYPOINT_MISSING",
       "path": "runtime/./nestjs",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -86,7 +86,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_ERROR_CODE_REMOVED",
       "path": "publicErrorCodes/OBS_TELEMETRY_INVALID_MODULE_OPTIONS",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -94,7 +94,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_ERROR_CODE_REMOVED",
       "path": "publicErrorCodes/OBS_TELEMETRY_SHUTDOWN_FAILED",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -102,7 +102,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_ERROR_CODE_REMOVED",
       "path": "publicErrorCodes/OBS_TELEMETRY_STARTUP_FAILED",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -110,7 +110,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/.:WideEvent",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -118,7 +118,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:BrowserEventsControllerOptions",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -126,7 +126,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:BrowserEventsRejection",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -134,7 +134,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:createBrowserEventsController",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -142,7 +142,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:createRequestWideEventTraceCorrelation",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -150,7 +150,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:defaultBrowserEventsPath",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -158,7 +158,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:InvalidTelemetryModuleOptions",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -166,7 +166,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:ProxyPolicy",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -174,7 +174,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:RequestReference",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -182,7 +182,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:requestSpan",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -190,7 +190,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:RequestWideEventLogger",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -198,7 +198,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:RequestWideEventLoggerResolver",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -206,7 +206,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:RequestWideEventTraceCorrelation",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -214,7 +214,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:ServerSpanCorrelation",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -222,7 +222,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryInterceptor",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -230,7 +230,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryInterceptorOptions",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -238,7 +238,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryModuleAsyncOptions",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -246,7 +246,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryModule",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -254,7 +254,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryModuleOptions",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -262,7 +262,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:telemetryModuleForTesting",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -270,7 +270,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryModuleTestingOverrides",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -278,7 +278,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryRequestTracker",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -286,7 +286,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryRoutePolicyOptions",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -294,7 +294,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryShutdownError",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -302,7 +302,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryStartupError",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -310,7 +310,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:withRequestSpan",
-      "candidateVersion": "0.3.3",
+      "candidateVersion": "0.3.4",
       "migrationGuide": "docs/migration-0.3.md"
     }
   ]

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equipe-tech/observability",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Nucleo neutro de observabilidade da Equipe Tech para OpenTelemetry, contratos, politicas e ciclo de vida",
   "homepage": "https://github.com/equipe-tech/observability#readme",
   "bugs": {

--- a/packages/telemetry/test/axiomSupport.test.ts
+++ b/packages/telemetry/test/axiomSupport.test.ts
@@ -38,6 +38,19 @@ const MplQueryBody = Schema.Struct({
 });
 const decodeAplQueryBody = Schema.decodeUnknownOption(AplQueryBody);
 const decodeMplQueryBody = Schema.decodeUnknownOption(MplQueryBody);
+const CapturedDatasetSchema = Schema.Array(
+  Schema.Struct({
+    signal: Schema.Literals(["traces", "logs"]),
+    fields: Schema.Array(Schema.Struct({ name: Schema.String, type: Schema.String })),
+  }),
+);
+const decodeCapturedDatasetSchema = Schema.decodeUnknownSync(CapturedDatasetSchema);
+const capturedDatasetSchema = decodeCapturedDatasetSchema(
+  JSON.parse(
+    await readFile(new URL("./fixtures/axiom-canary-schema.json", import.meta.url), "utf8"),
+  ),
+);
+
 const productionCollectorConfig = await readFile(
   new URL("../../cli/src/assets/production.yaml", import.meta.url),
   "utf8",
@@ -157,6 +170,29 @@ describe("axiom query support", () => {
       assert.strictEqual(url.searchParams.get("format"), "legacy");
     }
   });
+  it.live("references only columns observed in the deployed Axiom schemas", () =>
+    Effect.gen(function* () {
+      for (const schema of capturedDatasetSchema) {
+        const stub = yield* Effect.promise(() => startStubAxiom([]));
+        const lookup =
+          schema.signal === "traces"
+            ? findRootSpan(stub.env, "test-run-1", "0.1.0").pipe(Effect.asVoid)
+            : findLogs(stub.env, "test-run-1", "0.1.0").pipe(Effect.asVoid);
+        yield* lookup.pipe(Effect.ensuring(Effect.sync(() => stub.server.close())));
+        const query = stub.queries[0];
+        assert.isDefined(query);
+        const references = [...query.query.matchAll(/(?<!\])\['([^']+)'\]/g)].slice(1);
+        assert.isAbove(references.length, 0);
+        for (const reference of references) {
+          assert.include(
+            schema.fields.map((field) => field.name),
+            reference[1],
+          );
+        }
+      }
+    }),
+  );
+
   it.live("queries root spans with the run id and decodes the projected row", () =>
     Effect.gen(function* () {
       const stub = yield* Effect.promise(() =>
@@ -199,9 +235,10 @@ describe("axiom query support", () => {
       assert.include(query.query, "name == 'canary.operation'");
       assert.include(query.query, "service_name = tostring(['service.name'])");
       assert.include(query.query, "service_version = tostring(['service.version'])");
+      assert.include(query.query, "service_namespace = tostring(['service.namespace'])");
       assert.include(
         query.query,
-        "environment_name = tostring(['resource.custom']['deployment.environment.name'])",
+        "environment_name = tostring(['resource.deployment.environment.name'])",
       );
       assert.include(
         query.query,
@@ -274,7 +311,7 @@ describe("axiom query support", () => {
       assert.isDefined(query);
       assert.include(query.query, "['e2e-logs']");
       assert.deepStrictEqual(axiomServiceResourceFields, {
-        namespace: "['resource.custom']['service.namespace']",
+        namespace: "['service.namespace']",
         name: "['service.name']",
         version: "['service.version']",
       });
@@ -287,14 +324,59 @@ describe("axiom query support", () => {
       assert.include(query.query, `${axiomServiceResourceFields.version} == '0.1.0'`);
       assert.include(productionCollectorConfig, "otlphttp/logs:");
       assert.include(productionCollectorConfig, "X-Axiom-Dataset: ${env:AXIOM_DATASET_LOGS}");
+      assert.include(query.query, "['attributes.canary.run_id'] == 'test-run-1'");
+      assert.include(query.query, "event_name = tostring(['attributes.event.name'])");
+      assert.include(query.query, "event_kind = tostring(['attributes.event.kind'])");
+      assert.include(query.query, "event_source = tostring(['attributes.event.source'])");
+      assert.include(query.query, "authorization = tostring(['attributes.http.authorization'])");
+      assert.include(query.query, "password = tostring(['attributes.user.password'])");
+      assert.include(query.query, "access_token = tostring(['attributes.auth.access_token'])");
+      assert.include(query.query, "user_password = tostring(['attributes.profile.password'])");
+      assert.include(query.query, "phone_number = tostring(['attributes.contact.phone'])");
+      assert.include(query.query, "tokenizer = tostring(['attributes.tool.tokenizer'])");
+      assert.include(query.query, "documentation = tostring(['attributes.docs.documentation'])");
+      assert.include(query.query, "safe_message = tostring(['attributes.safe.message'])");
+      assert.include(query.query, "column_ifexists('service.instance.id', '')");
+      assert.include(query.query, "column_ifexists('resource.service.instance.id', '')");
+      assert.notInclude(query.query, "['attributes.custom']");
+      assert.notInclude(query.query, "['resource.custom']");
       assert.include(
         query.query,
-        "environment_name = tostring(['resource.custom']['deployment.environment.name'])",
+        "environment_name = tostring(['resource.deployment.environment.name'])",
       );
       assert.include(
         query.query,
-        "environment_alias = tostring(['resource.custom']['deployment.environment'])",
+        "environment_alias = tostring(['resource.deployment.environment'])",
       );
+    }),
+  );
+
+  it.live("normalizes missing instance IDs without hiding an unexpected instance", () =>
+    Effect.gen(function* () {
+      for (const instanceId of [null, "", "unexpected-instance"]) {
+        const stub = yield* Effect.promise(() =>
+          startStubAxiom([
+            {
+              data: {
+                trace_id: "trace-1",
+                span_id: "span-1",
+                name: "canary.operation",
+                event_name: "canary.completed",
+                service_instance_id: instanceId,
+              },
+            },
+          ]),
+        );
+        const results = yield* Effect.all([
+          findRootSpan(stub.env, "test-run-1", "0.1.0"),
+          findLogs(stub.env, "test-run-1", "0.1.0"),
+        ]).pipe(Effect.ensuring(Effect.sync(() => stub.server.close())));
+        const expected =
+          instanceId === "unexpected-instance" ? Option.some(instanceId) : Option.none();
+        assert.deepStrictEqual(Option.getOrThrow(results[0]).serviceInstanceId, expected);
+        assert.isDefined(results[1][0]);
+        assert.deepStrictEqual(results[1][0].serviceInstanceId, expected);
+      }
     }),
   );
 

--- a/packages/telemetry/test/fixtures/axiom-canary-schema.json
+++ b/packages/telemetry/test/fixtures/axiom-canary-schema.json
@@ -1,0 +1,292 @@
+[
+  {
+    "signal": "traces",
+    "fields": [
+      {
+        "name": "_sysTime",
+        "type": "datetime"
+      },
+      {
+        "name": "_time",
+        "type": "datetime"
+      },
+      {
+        "name": "attributes.custom",
+        "type": "dynamic"
+      },
+      {
+        "name": "duration",
+        "type": "timespan"
+      },
+      {
+        "name": "events",
+        "type": "dynamic"
+      },
+      {
+        "name": "kind",
+        "type": "string"
+      },
+      {
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "name": "parent_span_id",
+        "type": "string"
+      },
+      {
+        "name": "resource.custom",
+        "type": "dynamic"
+      },
+      {
+        "name": "resource.deployment.environment.name",
+        "type": "string"
+      },
+      {
+        "name": "scope.name",
+        "type": "string"
+      },
+      {
+        "name": "service.name",
+        "type": "string"
+      },
+      {
+        "name": "service.namespace",
+        "type": "string"
+      },
+      {
+        "name": "service.version",
+        "type": "string"
+      },
+      {
+        "name": "span_id",
+        "type": "string"
+      },
+      {
+        "name": "status.code",
+        "type": "string"
+      },
+      {
+        "name": "trace_id",
+        "type": "string"
+      }
+    ]
+  },
+  {
+    "signal": "logs",
+    "fields": [
+      {
+        "name": "_sysTime",
+        "type": "datetime"
+      },
+      {
+        "name": "_time",
+        "type": "datetime"
+      },
+      {
+        "name": "attributes.auth.access_token",
+        "type": "string"
+      },
+      {
+        "name": "attributes.browser.event.id",
+        "type": "string"
+      },
+      {
+        "name": "attributes.browser.event.occurred_at",
+        "type": "int"
+      },
+      {
+        "name": "attributes.canary.run_id",
+        "type": "string"
+      },
+      {
+        "name": "attributes.contact.phone",
+        "type": "string"
+      },
+      {
+        "name": "attributes.docs.documentation",
+        "type": "string"
+      },
+      {
+        "name": "attributes.effect.fiber.id",
+        "type": "int"
+      },
+      {
+        "name": "attributes.event.kind",
+        "type": "string"
+      },
+      {
+        "name": "attributes.event.name",
+        "type": "string"
+      },
+      {
+        "name": "attributes.event.outcome",
+        "type": "string"
+      },
+      {
+        "name": "attributes.event.policy_dropped_attributes",
+        "type": "int"
+      },
+      {
+        "name": "attributes.event.source",
+        "type": "string"
+      },
+      {
+        "name": "attributes.http.authorization",
+        "type": "string"
+      },
+      {
+        "name": "attributes.profile.password",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.message",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.nested_0",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.nested_1",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.nested_10",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.nested_11",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.nested_12",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.nested_13",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.nested_14",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.nested_15",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.nested_16",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.nested_17",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.nested_18",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.nested_19",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.nested_2",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.nested_3",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.nested_4",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.nested_5",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.nested_6",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.nested_7",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.nested_8",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.nested_9",
+        "type": "string"
+      },
+      {
+        "name": "attributes.safe.raw_header",
+        "type": "string"
+      },
+      {
+        "name": "attributes.tool.tokenizer",
+        "type": "string"
+      },
+      {
+        "name": "attributes.user.password",
+        "type": "string"
+      },
+      {
+        "name": "body",
+        "type": "string"
+      },
+      {
+        "name": "observed_time",
+        "type": "datetime"
+      },
+      {
+        "name": "resource.deployment.environment",
+        "type": "string"
+      },
+      {
+        "name": "resource.deployment.environment.name",
+        "type": "string"
+      },
+      {
+        "name": "scope.name",
+        "type": "string"
+      },
+      {
+        "name": "service.name",
+        "type": "string"
+      },
+      {
+        "name": "service.namespace",
+        "type": "string"
+      },
+      {
+        "name": "service.version",
+        "type": "string"
+      },
+      {
+        "name": "severity",
+        "type": "string"
+      },
+      {
+        "name": "severity_number",
+        "type": "int"
+      },
+      {
+        "name": "severity_text",
+        "type": "string"
+      },
+      {
+        "name": "span_id",
+        "type": "string"
+      },
+      {
+        "name": "trace_id",
+        "type": "string"
+      }
+    ]
+  }
+]

--- a/packages/telemetry/test/support/axiom.ts
+++ b/packages/telemetry/test/support/axiom.ts
@@ -150,6 +150,9 @@ const toAxiomRedactionAttributes = (row: AxiomRedactionRow): AxiomRedactionAttri
 const redactionProjection =
   "authorization = tostring(['attributes.custom']['http.authorization']), password = tostring(['attributes.custom']['user.password']), access_token = tostring(['attributes.custom']['auth.access_token']), user_password = tostring(['attributes.custom']['profile.password']), phone_number = tostring(['attributes.custom']['contact.phone']), tokenizer = tostring(['attributes.custom']['tool.tokenizer']), documentation = tostring(['attributes.custom']['docs.documentation']), safe_message = tostring(['attributes.custom']['safe.message'])";
 
+const logRedactionProjection =
+  "authorization = tostring(['attributes.http.authorization']), password = tostring(['attributes.user.password']), access_token = tostring(['attributes.auth.access_token']), user_password = tostring(['attributes.profile.password']), phone_number = tostring(['attributes.contact.phone']), tokenizer = tostring(['attributes.tool.tokenizer']), documentation = tostring(['attributes.docs.documentation']), safe_message = tostring(['attributes.safe.message'])";
+
 const AxiomSpanRow = Schema.Struct({
   trace_id: Schema.NonEmptyString,
   span_id: Schema.NonEmptyString,
@@ -192,7 +195,9 @@ const toAxiomSpan = (row: typeof AxiomSpanRow.Type): AxiomSpan => ({
   serviceNamespace: Option.fromNullishOr(row.service_namespace),
   serviceName: Option.fromNullishOr(row.service_name),
   serviceVersion: Option.fromNullishOr(row.service_version),
-  serviceInstanceId: Option.fromNullishOr(row.service_instance_id),
+  serviceInstanceId: Option.fromNullishOr(row.service_instance_id).pipe(
+    Option.filter((value) => value !== ""),
+  ),
   environmentName: Option.fromNullishOr(row.environment_name),
   environmentAlias: Option.fromNullishOr(row.environment_alias),
   events: Option.fromNullishOr(row.events),
@@ -200,7 +205,7 @@ const toAxiomSpan = (row: typeof AxiomSpanRow.Type): AxiomSpan => ({
 });
 
 export const axiomServiceResourceFields = Object.freeze({
-  namespace: "['resource.custom']['service.namespace']",
+  namespace: "['service.namespace']",
   name: "['service.name']",
   version: "['service.version']",
 });
@@ -209,7 +214,7 @@ const serviceNamespacePath = axiomServiceResourceFields.namespace;
 const serviceNamePath = axiomServiceResourceFields.name;
 const serviceVersionPath = axiomServiceResourceFields.version;
 
-const spanProjection = `project trace_id, span_id, parent_span_id, name, service_namespace = tostring(${serviceNamespacePath}), service_name = tostring(${serviceNamePath}), service_version = tostring(${serviceVersionPath}), service_instance_id = tostring(['resource.custom']['service.instance.id']), environment_name = tostring(['resource.custom']['deployment.environment.name']), environment_alias = tostring(['resource.custom']['deployment.environment']), events = tostring(events), ${redactionProjection}`;
+const spanProjection = `project trace_id, span_id, parent_span_id, name, service_namespace = tostring(${serviceNamespacePath}), service_name = tostring(${serviceNamePath}), service_version = tostring(${serviceVersionPath}), service_instance_id = tostring(['resource.custom']['service.instance.id']), environment_name = tostring(['resource.deployment.environment.name']), environment_alias = tostring(['resource.custom']['deployment.environment']), events = tostring(events), ${redactionProjection}`;
 
 export const findRootSpan = (
   env: AxiomEnvironment,
@@ -288,7 +293,9 @@ const toAxiomLog = (row: typeof AxiomLogRow.Type): AxiomLog => ({
   serviceNamespace: Option.fromNullishOr(row.service_namespace),
   serviceName: Option.fromNullishOr(row.service_name),
   serviceVersion: Option.fromNullishOr(row.service_version),
-  serviceInstanceId: Option.fromNullishOr(row.service_instance_id),
+  serviceInstanceId: Option.fromNullishOr(row.service_instance_id).pipe(
+    Option.filter((value) => value !== ""),
+  ),
   environmentName: Option.fromNullishOr(row.environment_name),
   environmentAlias: Option.fromNullishOr(row.environment_alias),
   body: Option.fromNullishOr(row.body),
@@ -303,7 +310,7 @@ export const findLogs = (
 ): Effect.Effect<ReadonlyArray<AxiomLog>> =>
   runQuery(
     env,
-    `['${env.AXIOM_DATASET_LOGS}'] | where ['attributes.custom']['canary.run_id'] == '${runId}' and ${serviceVersionPath} == '${serviceVersion}' | project trace_id, event_name = tostring(['attributes.custom']['event.name']), event_kind = tostring(['attributes.custom']['event.kind']), event_source = tostring(['attributes.custom']['event.source']), service_namespace = tostring(${serviceNamespacePath}), service_name = tostring(${serviceNamePath}), service_version = tostring(${serviceVersionPath}), service_instance_id = tostring(['resource.custom']['service.instance.id']), environment_name = tostring(['resource.custom']['deployment.environment.name']), environment_alias = tostring(['resource.custom']['deployment.environment']), body = tostring(body), ${redactionProjection}`,
+    `['${env.AXIOM_DATASET_LOGS}'] | where ['attributes.canary.run_id'] == '${runId}' and ${serviceVersionPath} == '${serviceVersion}' | project trace_id, event_name = tostring(['attributes.event.name']), event_kind = tostring(['attributes.event.kind']), event_source = tostring(['attributes.event.source']), service_namespace = tostring(${serviceNamespacePath}), service_name = tostring(${serviceNamePath}), service_version = tostring(${serviceVersionPath}), service_instance_id = tostring(coalesce(column_ifexists('service.instance.id', ''), column_ifexists('resource.service.instance.id', ''))), environment_name = tostring(['resource.deployment.environment.name']), environment_alias = tostring(['resource.deployment.environment']), body = tostring(body), ${logRedactionProjection}`,
     options,
   ).pipe(
     Effect.map((rows) =>


### PR DESCRIPTION
## Changes
- Match log attribute paths to the schema returned by protected preflight run 34063620778.
- Correct promoted namespace and environment fields for traces and logs.
- Preserve mandatory identity, correlation, redaction, and metric assertions.
- Decode missing instance IDs without hiding a nonempty unexpected ID.
- Retain a metadata-only schema fixture and reproduce the former invalid-field failure against it.
- Prepare core 0.3.4 without creating or moving a tag; preserve the exact scope of all existing migration declarations.

## Verification
- 10 focused Axiom query tests pass.
- Full suite, Vite+ check, build, compatibility gate, and packed Node/Bun consumer smoke pass.
- Protected canary must pass from master before any new release tag is created.