### PR TITLE
fix(release): publish the verified archive as a local file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,6 +261,6 @@ jobs:
           [[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]] || { echo "GitHub OIDC request URL is unavailable."; exit 1; }
           [[ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]] || { echo "GitHub OIDC request token is unavailable."; exit 1; }
           npm whoami --registry https://registry.npmjs.org
-          npm publish "dist-release/$ARCHIVE" --access public --tag "$NPM_TAG" --provenance
+          npm publish "./dist-release/$ARCHIVE" --access public --tag "$NPM_TAG" --provenance
       - if: always()
         run: rm -rf .release-candidate dist-release

--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
     },
     "packages/cli": {
       "name": "@equipe-tech/observability-cli",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "bin": {
         "observability": "./dist/main.js",
       },
@@ -51,7 +51,7 @@
     },
     "packages/evlog": {
       "name": "@equipe-tech/observability-evlog",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "evlog": "2.27.1",
       },
@@ -67,7 +67,7 @@
     },
     "packages/nestjs": {
       "name": "@equipe-tech/observability-nestjs",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
         "@equipe-tech/observability": "workspace:*",
         "@equipe-tech/observability-evlog": "workspace:*",
@@ -90,7 +90,7 @@
     },
     "packages/react": {
       "name": "@equipe-tech/observability-react",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
         "@equipe-tech/observability": "workspace:*",
         "@equipe-tech/observability-sentry": "workspace:*",
@@ -104,7 +104,7 @@
     },
     "packages/sentry": {
       "name": "@equipe-tech/observability-sentry",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
         "@equipe-tech/observability": "workspace:*",
         "@sentry/browser": "10.72.0",
@@ -124,7 +124,7 @@
     },
     "packages/telemetry": {
       "name": "@equipe-tech/observability",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "devDependencies": {
         "effect": "4.0.0-rc.111",
       },

--- a/docs/migration-0.3.md
+++ b/docs/migration-0.3.md
@@ -151,4 +151,4 @@ Mantenha o ledger no banco de dados da aplicação. Use `commitAuditRecord` ou `
 
 ## Usar releases independentes
 
-Os pacotes mantêm versões independentes. Esta preparação seleciona `0.3.4` para o núcleo e `0.3.0` para os outros cinco pacotes alterados. A tag inicial do núcleo permanece como registro de uma tentativa sem publicação. A CLI avança de `0.2.1` para `0.3.0` pelas mudanças incompatíveis descritas neste guia. Tags usam `<slug>@<semver>`, por exemplo `observability@0.3.0`, `observability-evlog@0.3.0`, `observability-nestjs@0.3.0` e `observability-cli@0.3.0`. Releases futuras alteram somente os pacotes afetados.
+Os pacotes mantêm versões independentes. Esta preparação seleciona `0.3.5` para o núcleo e `0.3.1` para os outros cinco pacotes alterados. A tag inicial do núcleo permanece como registro de uma tentativa sem publicação. A CLI avança de `0.2.1` para `0.3.1` pelas mudanças incompatíveis descritas neste guia. Tags usam `<slug>@<semver>`, por exemplo `observability@0.3.0`, `observability-evlog@0.3.0`, `observability-nestjs@0.3.0` e `observability-cli@0.3.0`. Releases futuras alteram somente os pacotes afetados.

--- a/docs/release-publication-runbook.md
+++ b/docs/release-publication-runbook.md
@@ -41,6 +41,8 @@ O dry run não altera manifest, lockfile, commit ou tag. Uma release real altera
 
 `bun run test:package` compila e empacota os seis pacotes. O smoke instala os archives em consumidores Node e Bun, testa NestJS 10 e 11, percorre as declarações, rejeita imports não declarados e confirma os entrypoints públicos.
 
+Use o prefixo `./` ao passar o archive relativo para `npm publish`, como `./dist-release/$ARCHIVE`. Sem esse prefixo, o npm interpreta `dist-release/arquivo.tgz` como uma referência Git. O teste do workflow executa o comando real em dry run offline com transporte Git bloqueado.
+
 `release-candidate.ts` empacota a candidata duas vezes e exige bytes idênticos. O job de publicação reconstrói a candidata a partir do checkout do tag, verifica o checksum gerado e compara os bytes reconstruídos com o asset baixado do GitHub antes de publicar no npm.
 
 ## Gate do canário no provedor

--- a/docs/releases/preparation-0.3.md
+++ b/docs/releases/preparation-0.3.md
@@ -4,14 +4,14 @@ Esta preparação cobre os seis pacotes alterados pelo stack. Cada pacote manté
 
 | Pacote                              | Versão candidata | Motivo                                                                 |
 | ----------------------------------- | ---------------- | ---------------------------------------------------------------------- |
-| `@equipe-tech/observability`        | `0.3.4`          | Contratos tipados, identidade canônica, política, métricas e auditoria |
-| `@equipe-tech/observability-evlog`  | `0.3.0`          | Primeiro release do adapter oficial de eventos                         |
-| `@equipe-tech/observability-nestjs` | `0.3.0`          | Primeiro release da integração extraída do núcleo                      |
-| `@equipe-tech/observability-sentry` | `0.3.0`          | Primeiro release dos adapters de defeitos Node e browser               |
-| `@equipe-tech/observability-react`  | `0.3.0`          | Primeiro release da integração React                                   |
-| `@equipe-tech/observability-cli`    | `0.3.0`          | Setup, manifestos, operações e mudanças incompatíveis documentadas     |
+| `@equipe-tech/observability`        | `0.3.5`          | Contratos tipados, identidade canônica, política, métricas e auditoria |
+| `@equipe-tech/observability-evlog`  | `0.3.1`          | Primeiro release do adapter oficial de eventos                         |
+| `@equipe-tech/observability-nestjs` | `0.3.1`          | Primeiro release da integração extraída do núcleo                      |
+| `@equipe-tech/observability-sentry` | `0.3.1`          | Primeiro release dos adapters de defeitos Node e browser               |
+| `@equipe-tech/observability-react`  | `0.3.1`          | Primeiro release da integração React                                   |
+| `@equipe-tech/observability-cli`    | `0.3.1`          | Setup, manifestos, operações e mudanças incompatíveis documentadas     |
 
-A CLI publicada permanece em `0.2.1`. A candidata exige `0.3.0`, conforme o registro de compatibilidade e o guia de migração.
+A CLI publicada permanece em `0.2.1`. A candidata exige `0.3.1`, conforme o registro de compatibilidade e o guia de migração.
 
 ## Changelog e migração
 
@@ -23,7 +23,7 @@ Leia [o guia de migração](../migration-0.3.md) antes da atualização. Leia [o
 
 Publique o núcleo antes dos adapters e da CLI, pois os consumidores precisam resolver o peer `@equipe-tech/observability@0.3.x`.
 
-Execute `Release Preflight` para cada pacote na revisão aprovada. Crie somente tags independentes, como `observability@0.3.4`, depois do preflight.
+Execute `Release Preflight` para cada pacote na revisão aprovada. Crie somente tags independentes, como `observability@0.3.5`, depois do preflight.
 
 Mantenha a aprovação humana do environment `publication`. O push da tag solicita somente a verificação protegida. A publicação exige outro `workflow_dispatch`, com `tag` e `confirm_tag` idênticos.
 
@@ -37,8 +37,12 @@ A tentativa `observability@0.3.2` iniciou o Collector, mas a consulta APL usou u
 
 A tentativa `observability@0.3.3` alcançou a API regional, mas consultou logs com caminhos de campos exclusivos de traces. O preflight protegido em `master` confirmou os schemas sem criar outra tag.
 
-A recuperação prepara `observability@0.3.4`, com consultas separadas para os schemas reais de traces e logs. O canário preserva as verificações de identidade, correlação e redaction. Crie a tag somente depois do preflight protegido bem-sucedido. Os outros cinco pacotes mantêm `0.3.0`, pois suas tags ainda não foram criadas.
+A tentativa `observability@0.3.4` passou no canário protegido e criou o archive da GitHub Release. A publicação npm falhou porque o caminho relativo do archive não tinha o prefixo `./` e foi interpretado como Git.
 
-Os cadastros dos dois secrets Axiom e das cinco variables existem no environment `publication`. As regras permitem as tags dos seis slugs. O `NPM_TOKEN` existe no escopo do repositório.
+A recuperação prepara o núcleo `0.3.5` e os outros cinco pacotes `0.3.1`. As tags anteriores permanecem imutáveis, inclusive as tags `0.3.0` dos adapters e da CLI. Todos precisam de novos patches porque suas tags anteriores contêm o comando de publicação incorreto. Nenhuma dessas tentativas publicou uma versão no npm.
+
+O comando corrigido recebe `./dist-release/$ARCHIVE`. Um teste executa o parser real do npm em dry run offline, sem credenciais nem acesso Git. Crie cada nova tag somente depois do preflight protegido bem-sucedido.
+
+Os cadastros dos dois secrets Axiom e das cinco variables existem no environment `publication`. As regras permitem `master` e as tags dos seis slugs, sempre com aprovação obrigatória. O `NPM_TOKEN` existe no escopo do repositório.
 
 A existência desses cadastros não comprova autenticação ou entrega de telemetria. A publicação continua condicionada ao canário deployed e à aprovação humana.

--- a/observability/compatibility/candidate-versions.json
+++ b/observability/compatibility/candidate-versions.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "packages": [
-    { "name": "@equipe-tech/observability", "version": "0.3.4" },
-    { "name": "@equipe-tech/observability-cli", "version": "0.3.0" },
-    { "name": "@equipe-tech/observability-evlog", "version": "0.3.0" },
-    { "name": "@equipe-tech/observability-nestjs", "version": "0.3.0" },
-    { "name": "@equipe-tech/observability-react", "version": "0.3.0" },
-    { "name": "@equipe-tech/observability-sentry", "version": "0.3.0" }
+    { "name": "@equipe-tech/observability", "version": "0.3.5" },
+    { "name": "@equipe-tech/observability-cli", "version": "0.3.1" },
+    { "name": "@equipe-tech/observability-evlog", "version": "0.3.1" },
+    { "name": "@equipe-tech/observability-nestjs", "version": "0.3.1" },
+    { "name": "@equipe-tech/observability-react", "version": "0.3.1" },
+    { "name": "@equipe-tech/observability-sentry", "version": "0.3.1" }
   ]
 }

--- a/observability/compatibility/declared-breaks.json
+++ b/observability/compatibility/declared-breaks.json
@@ -6,7 +6,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_DEPENDENCY_REMOVED",
       "path": "dependencies/effect@4.0.0-rc.111",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -14,7 +14,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_DEPENDENCY_CATEGORY_CHANGED",
       "path": "dependencies/effect",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -22,7 +22,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_EXPORT_CONDITION_REMOVED",
       "path": "exportConditions/./nestjs:import:./dist/nestjs/index.js",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -30,7 +30,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_EXPORT_CONDITION_REMOVED",
       "path": "exportConditions/./nestjs:types:./dist/nestjs/index.d.ts",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -38,7 +38,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_EXPORT_REMOVED",
       "path": "exports/./nestjs",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -46,7 +46,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_PEER_CHANGED",
       "path": "peerDependencies/@nestjs/common@^10.0.0 || ^11.0.0",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -54,7 +54,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_PEER_CHANGED",
       "path": "peerDependencies/@nestjs/core@^10.0.0 || ^11.0.0",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -62,7 +62,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_PEER_CHANGED",
       "path": "peerDependencies/rxjs@^7.2.0",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -70,7 +70,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_PEER_OPTIONALITY_CHANGED",
       "path": "peerDependenciesMeta",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -78,7 +78,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_RUNTIME_ENTRYPOINT_MISSING",
       "path": "runtime/./nestjs",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -86,7 +86,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_ERROR_CODE_REMOVED",
       "path": "publicErrorCodes/OBS_TELEMETRY_INVALID_MODULE_OPTIONS",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -94,7 +94,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_ERROR_CODE_REMOVED",
       "path": "publicErrorCodes/OBS_TELEMETRY_SHUTDOWN_FAILED",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -102,7 +102,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_ERROR_CODE_REMOVED",
       "path": "publicErrorCodes/OBS_TELEMETRY_STARTUP_FAILED",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -110,7 +110,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/.:WideEvent",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -118,7 +118,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:BrowserEventsControllerOptions",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -126,7 +126,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:BrowserEventsRejection",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -134,7 +134,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:createBrowserEventsController",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -142,7 +142,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:createRequestWideEventTraceCorrelation",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -150,7 +150,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:defaultBrowserEventsPath",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -158,7 +158,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:InvalidTelemetryModuleOptions",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -166,7 +166,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:ProxyPolicy",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -174,7 +174,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:RequestReference",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -182,7 +182,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:requestSpan",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -190,7 +190,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:RequestWideEventLogger",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -198,7 +198,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:RequestWideEventLoggerResolver",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -206,7 +206,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:RequestWideEventTraceCorrelation",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -214,7 +214,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:ServerSpanCorrelation",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -222,7 +222,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryInterceptor",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -230,7 +230,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryInterceptorOptions",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -238,7 +238,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryModuleAsyncOptions",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -246,7 +246,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryModule",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -254,7 +254,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryModuleOptions",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -262,7 +262,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:telemetryModuleForTesting",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -270,7 +270,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryModuleTestingOverrides",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -278,7 +278,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryRequestTracker",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -286,7 +286,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryRoutePolicyOptions",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -294,7 +294,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryShutdownError",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -302,7 +302,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:TelemetryStartupError",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     },
     {
@@ -310,7 +310,7 @@
       "package": "@equipe-tech/observability",
       "code": "OBS_PACKAGE_SYMBOL_REMOVED",
       "path": "symbols/./nestjs:withRequestSpan",
-      "candidateVersion": "0.3.4",
+      "candidateVersion": "0.3.5",
       "migrationGuide": "docs/migration-0.3.md"
     }
   ]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equipe-tech/observability-cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "CLI da plataforma de observabilidade: ciclo de vida da stack local de desenvolvimento",
   "homepage": "https://github.com/equipe-tech/observability#readme",
   "bugs": {

--- a/packages/cli/test/ReleaseWorkflow.bun.test.ts
+++ b/packages/cli/test/ReleaseWorkflow.bun.test.ts
@@ -1,7 +1,7 @@
 import { deployedCanarySuiteTimeoutMilliseconds } from "@equipe-tech/observability/testing";
 import { describe, expect, test } from "bun:test";
 import { Schema } from "effect";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -227,7 +227,7 @@ describe("release workflow publication gate", () => {
     );
     expect(workflow).not.toContain("for candidate in packages/*/package.json");
     expect(workflow).not.toContain("jq -r .version");
-    expect(workflow).toContain('npm publish "dist-release/$ARCHIVE"');
+    expect(workflow).toContain('npm publish "./dist-release/$ARCHIVE"');
   });
 
   test("checks out and validates the exact existing tag commit", () => {
@@ -606,6 +606,78 @@ describe("release workflow publication gate", () => {
     expect(workflow.match(/bun scripts\/release-candidate\.ts/g)).toHaveLength(2);
     expect(workflow.match(/sha256sum --check/g)).toHaveLength(2);
     expect(workflow).toContain('cmp ".release-candidate/$ARCHIVE" "dist-release/$ARCHIVE"');
+  });
+
+  test("passes the archive to the real npm publish parser without Git interpretation", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "npm-publication-path-"));
+    try {
+      const packageDirectory = join(directory, "package");
+      const archiveDirectory = join(directory, "dist-release");
+      await mkdir(packageDirectory);
+      await mkdir(archiveDirectory);
+      await writeFile(
+        join(packageDirectory, "package.json"),
+        JSON.stringify({
+          name: "release-path-fixture",
+          version: "0.0.0",
+        }),
+      );
+      const archive = "release-path-fixture-0.0.0.tgz";
+      const pack = Bun.spawn(
+        ["tar", "-czf", join(archiveDirectory, archive), "-C", directory, "package"],
+        {
+          stdout: "ignore",
+          stderr: "pipe",
+          timeout: 10_000,
+        },
+      );
+      const [packExit, packError] = await Promise.all([
+        pack.exited,
+        new Response(pack.stderr).text(),
+      ]);
+      expect(packExit).toBe(0);
+      expect(packError).toBe("");
+      const publication = workflow.match(/^\s*npm publish .+$/m)?.[0];
+      if (publication === undefined) throw new Error("The npm publication command is missing.");
+      const userConfig = join(directory, "npmrc");
+      await writeFile(userConfig, "");
+      const child = Bun.spawn(
+        [
+          "bash",
+          "-eu",
+          "-c",
+          `${publication} --dry-run --offline --ignore-scripts --json=false --registry http://127.0.0.1:1 --userconfig "$USER_CONFIG"`,
+        ],
+        {
+          cwd: directory,
+          env: {
+            ...process.env,
+            ARCHIVE: archive,
+            NPM_TAG: "latest",
+            NODE_AUTH_TOKEN: "",
+            USER_CONFIG: userConfig,
+            NPM_CONFIG_CACHE: join(directory, "npm-cache"),
+            GIT_CONFIG_COUNT: "1",
+            GIT_CONFIG_KEY_0: "protocol.allow",
+            GIT_CONFIG_VALUE_0: "never",
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+          timeout: 15_000,
+        },
+      );
+      const [exitCode, stdout, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+      ]);
+      expect(exitCode).toBe(0);
+      expect(stdout.trim()).toBe("+ release-path-fixture@0.0.0");
+      expect(stderr).not.toContain("ls-remote");
+      expect(stderr).not.toContain("npm error");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
   });
 
   test("converges when release and npm publication already exist", () => {

--- a/packages/evlog/package.json
+++ b/packages/evlog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equipe-tech/observability-evlog",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Adapter oficial evlog da plataforma de observabilidade da Equipe Tech",
   "homepage": "https://github.com/equipe-tech/observability#readme",
   "bugs": {

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equipe-tech/observability-nestjs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Integracao NestJS da plataforma de observabilidade da Equipe Tech",
   "homepage": "https://github.com/equipe-tech/observability#readme",
   "bugs": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equipe-tech/observability-react",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Adaptador React para observabilidade de browser da Equipe Tech",
   "homepage": "https://github.com/equipe-tech/observability#readme",
   "bugs": {

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equipe-tech/observability-sentry",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Adaptadores Sentry para defeitos Node e browser da plataforma de observabilidade da Equipe Tech",
   "homepage": "https://github.com/equipe-tech/observability#readme",
   "bugs": {

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equipe-tech/observability",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Nucleo neutro de observabilidade da Equipe Tech para OpenTelemetry, contratos, politicas e ciclo de vida",
   "homepage": "https://github.com/equipe-tech/observability#readme",
   "bugs": {

--- a/tools/compatibility.bun.test.ts
+++ b/tools/compatibility.bun.test.ts
@@ -809,10 +809,7 @@ describe("compatibility gate", () => {
 
   test("accepts exact initial package releases without fetching a predecessor", async () => {
     const baseline = JSON.parse(readFileSync("observability/compatibility/baseline.json", "utf8"));
-    const versions = JSON.parse(
-      readFileSync("observability/compatibility/candidate-versions.json", "utf8"),
-    );
-    const initial = packageSurface("0.3.0", ["."]);
+    const initial = packageSurface("0.3.1", ["."]);
     for (const slug of [
       "observability-evlog",
       "observability-nestjs",
@@ -820,15 +817,24 @@ describe("compatibility gate", () => {
       "observability-sentry",
     ]) {
       const namedInitial = { ...initial, name: `@equipe-tech/${slug}` };
+      const versions: Parameters<typeof releaseIntegrityIssue>[1] = {
+        version: 1,
+        packages: [{ name: namedInitial.name, version: initial.version }],
+      };
       expect(
-        await releaseIntegrityIssue(baseline, versions, [namedInitial], `${slug}@0.3.0`),
+        await releaseIntegrityIssue(
+          baseline,
+          versions,
+          [namedInitial],
+          `${slug}@${initial.version}`,
+        ),
       ).toBeUndefined();
       expect(
         await releaseIntegrityIssue(
           baseline,
           versions,
-          [{ ...namedInitial, version: "0.3.1" }],
-          `${slug}@0.3.0`,
+          [{ ...namedInitial, version: "0.3.2" }],
+          `${slug}@${initial.version}`,
         ),
       ).toBe("release package does not match the exact initial candidate declaration");
     }


### PR DESCRIPTION
## Failure and correction
Publication run 34065488037 passed tag validation, CI, the protected canary, GitHub release creation, and archive verification. npm interpreted dist-release/archive.tgz as a GitHub repository.

Prefix the verified archive with ./ so npm consumes the local tarball. The regression test runs the exact workflow npm command in an offline dry run, with Git transports blocked and no credentials. The old command fails this reproduction; the corrected command succeeds.

## Immutable recovery
Prepare core 0.3.5 and the other five packages 0.3.1. Preserve every previous tag. Their existing tags contain the invalid publication command, so each package needs a new tag without weakening exact-tag or protected-canary gates. Keep all migration declarations scoped identically.

## Verification
- 27 workflow tests pass, including the real npm parser.
- Full suite: Bun 436 passed, 8 skipped; Vitest passed.
- Vite+ check, build, compatibility gate, packed consumer smoke, actionlint, and diff checks pass.
- Run protected preflights before creating the new tags.